### PR TITLE
Allow pipes to determine whether they will allow gas transfer based on the tile before

### DIFF
--- a/src/minecraft/mekanism/api/GasTransmission.java
+++ b/src/minecraft/mekanism/api/GasTransmission.java
@@ -25,7 +25,7 @@ public class GasTransmission
     	{
 			TileEntity tube = VectorHelper.getTileEntityFromSide(tileEntity.worldObj, new Vector3(tileEntity.xCoord, tileEntity.yCoord, tileEntity.zCoord), orientation);
 			
-			if(tube instanceof IPressurizedTube && ((IPressurizedTube)tube).canTransferGas())
+			if(tube instanceof IPressurizedTube && ((IPressurizedTube)tube).canTransferGas(tileEntity))
 			{
 				tubes[orientation.ordinal()] = tube;
 			}

--- a/src/minecraft/mekanism/api/IPressurizedTube.java
+++ b/src/minecraft/mekanism/api/IPressurizedTube.java
@@ -1,10 +1,12 @@
 package mekanism.api;
 
+import net.minecraft.tileentity.TileEntity;
+
 public interface IPressurizedTube 
 {
 	/**
 	 * Whether or not this tube can transfer gas.
 	 * @return if the tube can transfer gas
 	 */
-	public boolean canTransferGas();
+	public boolean canTransferGas(TileEntity fromTile);
 }

--- a/src/minecraft/mekanism/common/TileEntityPressurizedTube.java
+++ b/src/minecraft/mekanism/common/TileEntityPressurizedTube.java
@@ -1,17 +1,17 @@
 package mekanism.common;
 
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 import mekanism.api.IPressurizedTube;
 import mekanism.api.ITubeConnection;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraftforge.common.ForgeDirection;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 
 public class TileEntityPressurizedTube extends TileEntity implements IPressurizedTube, ITubeConnection
 {
 	@Override
-	public boolean canTransferGas()
+	public boolean canTransferGas(TileEntity fromTile)
 	{
 		return worldObj.getBlockPowerInput(xCoord, yCoord, zCoord) == 0;
 	}


### PR DESCRIPTION
This allows support for the new Galacticraft feature of colored pipes not connecting to each other to function properly.
