### PR TITLE
Fix for expendable gas containers

### DIFF
--- a/src/minecraft/mekanism/common/TileEntityGasTank.java
+++ b/src/minecraft/mekanism/common/TileEntityGasTank.java
@@ -97,6 +97,10 @@ public class TileEntityGasTank extends TileEntityContainerBlock implements IGasS
 						}
 						
 						setGas(gasType, gasStored + received);
+						
+						// Fix for expendable gas containers.
+                        if (inventory[1].stackSize <= 0)
+                            inventory[1] = null;
 					}
 				}
 			}

--- a/src/minecraft/mekanism/generators/common/TileEntityHydrogenGenerator.java
+++ b/src/minecraft/mekanism/generators/common/TileEntityHydrogenGenerator.java
@@ -63,6 +63,10 @@ public class TileEntityHydrogenGenerator extends TileEntityGenerator implements 
 						}
 						
 						setGas(EnumGas.HYDROGEN, hydrogenStored + received);
+						
+						// Fix for expendable gas containers.
+						if (inventory[0].stackSize <= 0)
+						    inventory[0] = null;
 					}
 				}
 			}


### PR DESCRIPTION
Fixed the gas tank and hydrogen generator for expendable gas containers
so that they will remove the item from their inventory when the stack
size reaches 0.
