### PR TITLE
Improve upgrade behaviour

### DIFF
--- a/src/minecraft/mekanism/common/MekanismUtils.java
+++ b/src/minecraft/mekanism/common/MekanismUtils.java
@@ -507,24 +507,48 @@ public final class MekanismUtils
     
     /**
      * Gets the operating ticks required for a machine via it's upgrades.
-     * @param multiplier - speed multiplier
+     * @param speedUpgrade - number of speed upgrades
      * @param def - the original, default ticks required
      * @return max operating ticks
      */
-    public static int getTicks(int multiplier, int def)
+    public static int getTicks(int speedUpgrade, int def)
     {
-    	return def/(multiplier+1);
+        return (int) (def * Math.pow(10, (-speedUpgrade/9.0)));
+    }
+    
+    /**
+     * Gets the energy required  per tick for a machine via it's upgrades.
+     * @param speedUpgrade - number of speed upgrades
+     * @param energyUpgrade - number of energy upgrades
+     * @param def - the original, default energy required
+     * @return max energy per tick
+     */
+    public static int getEnergyPerTick(int speedUpgrade, int energyUpgrade, int def)
+    {
+        return (int) (def * Math.pow(10, ((speedUpgrade-energyUpgrade)/9.0)));
+    }
+    
+    /**
+     * Gets the energy required  per tick for a machine via it's upgrades.
+     * @param speedUpgrade - number of speed upgrades
+     * @param energyUpgrade - number of energy upgrades
+     * @param def - the original, default energy required
+     * @return max energy per tick
+     */
+    public static double getEnergyPerTick(int speedUpgrade, int energyUpgrade, double def)
+    {
+        return (def * Math.pow(10, ((speedUpgrade-energyUpgrade)/9.0)));
     }
     
     /**
      * Gets the maximum energy for a machine via it's upgrades.
-     * @param multiplier - energy multiplier
+     * @param energyUpgrade - number of energy upgrades
      * @param def - original, default max energy
      * @return max energy
      */
-    public static double getEnergy(int multiplier, double def)
+    public static double getEnergy(int energyUpgrade, double def)
     {
-    	return def*(multiplier+1);
+        return (int) (def * Math.pow(10, (energyUpgrade/9.0)));
     }
     
     /**

--- a/src/minecraft/mekanism/common/TileEntityAdvancedElectricMachine.java
+++ b/src/minecraft/mekanism/common/TileEntityAdvancedElectricMachine.java
@@ -126,21 +126,21 @@ public abstract class TileEntityAdvancedElectricMachine extends TileEntityBasicM
 			
 			handleSecondaryFuel();
 			
-			if(electricityStored >= ENERGY_PER_TICK && secondaryEnergyStored >= SECONDARY_ENERGY_PER_TICK)
+			if(electricityStored >= MekanismUtils.getEnergyPerTick(speedMultiplier, energyMultiplier, ENERGY_PER_TICK) && secondaryEnergyStored >= MekanismUtils.getEnergyPerTick(speedMultiplier, energyMultiplier, SECONDARY_ENERGY_PER_TICK))
 			{
-				if(canOperate() && (operatingTicks+1) < MekanismUtils.getTicks(speedMultiplier, TICKS_REQUIRED) && secondaryEnergyStored >= SECONDARY_ENERGY_PER_TICK)
+				if(canOperate() && (operatingTicks+1) < MekanismUtils.getTicks(speedMultiplier, TICKS_REQUIRED) && secondaryEnergyStored >= MekanismUtils.getEnergyPerTick(speedMultiplier, energyMultiplier, SECONDARY_ENERGY_PER_TICK))
 				{
 					operatingTicks++;
-					secondaryEnergyStored -= SECONDARY_ENERGY_PER_TICK;
-					electricityStored -= ENERGY_PER_TICK;
+					secondaryEnergyStored -= MekanismUtils.getEnergyPerTick(speedMultiplier, energyMultiplier, SECONDARY_ENERGY_PER_TICK);
+					electricityStored -= MekanismUtils.getEnergyPerTick(speedMultiplier, energyMultiplier, ENERGY_PER_TICK);
 				}
 				else if((operatingTicks+1) >= MekanismUtils.getTicks(speedMultiplier, TICKS_REQUIRED))
 				{
 					operate();
 					
 					operatingTicks = 0;
-					secondaryEnergyStored -= SECONDARY_ENERGY_PER_TICK;
-					electricityStored -= ENERGY_PER_TICK;
+					secondaryEnergyStored -= MekanismUtils.getEnergyPerTick(speedMultiplier, energyMultiplier, SECONDARY_ENERGY_PER_TICK);
+					electricityStored -= MekanismUtils.getEnergyPerTick(speedMultiplier, energyMultiplier, ENERGY_PER_TICK);
 				}
 			}
 			
@@ -149,7 +149,7 @@ public abstract class TileEntityAdvancedElectricMachine extends TileEntityBasicM
 				operatingTicks = 0;
 			}
 			
-			if(canOperate() && electricityStored >= ENERGY_PER_TICK && secondaryEnergyStored >= SECONDARY_ENERGY_PER_TICK)
+			if(canOperate() && electricityStored >= MekanismUtils.getEnergyPerTick(speedMultiplier, energyMultiplier, ENERGY_PER_TICK) && secondaryEnergyStored >= MekanismUtils.getEnergyPerTick(speedMultiplier, energyMultiplier, SECONDARY_ENERGY_PER_TICK))
 			{
 				setActive(true);
 			}

--- a/src/minecraft/mekanism/common/TileEntityElectricMachine.java
+++ b/src/minecraft/mekanism/common/TileEntityElectricMachine.java
@@ -93,19 +93,19 @@ public abstract class TileEntityElectricMachine extends TileEntityBasicMachine
 				upgradeTicks = 0;
 			}
 			
-			if(electricityStored >= ENERGY_PER_TICK)
+			if(electricityStored >= MekanismUtils.getEnergyPerTick(speedMultiplier, energyMultiplier, ENERGY_PER_TICK))
 			{
 				if(canOperate() && (operatingTicks+1) < MekanismUtils.getTicks(speedMultiplier, TICKS_REQUIRED))
 				{
 					operatingTicks++;
-					electricityStored -= ENERGY_PER_TICK;
+					electricityStored -= MekanismUtils.getEnergyPerTick(speedMultiplier, energyMultiplier, ENERGY_PER_TICK);
 				}
 				else if(canOperate() && (operatingTicks+1) >= MekanismUtils.getTicks(speedMultiplier, TICKS_REQUIRED))
 				{
 					operate();
 					
 					operatingTicks = 0;
-					electricityStored -= ENERGY_PER_TICK;
+					electricityStored -= MekanismUtils.getEnergyPerTick(speedMultiplier, energyMultiplier, ENERGY_PER_TICK);
 				}
 			}
 			
@@ -114,7 +114,7 @@ public abstract class TileEntityElectricMachine extends TileEntityBasicMachine
 				operatingTicks = 0;
 			}
 			
-			if(canOperate() && electricityStored >= ENERGY_PER_TICK)
+			if(canOperate() && electricityStored >= MekanismUtils.getEnergyPerTick(speedMultiplier, energyMultiplier, ENERGY_PER_TICK))
 			{
 				setActive(true);
 			}

--- a/src/minecraft/mekanism/common/TileEntityFactory.java
+++ b/src/minecraft/mekanism/common/TileEntityFactory.java
@@ -218,19 +218,19 @@ public class TileEntityFactory extends TileEntityElectricBlock implements IEnerg
 			
 			for(int process = 0; process < tier.processes; process++)
 			{
-				if(electricityStored >= ENERGY_PER_TICK)
+				if(electricityStored >= MekanismUtils.getEnergyPerTick(speedMultiplier, energyMultiplier, ENERGY_PER_TICK))
 				{
 					if(canOperate(getInputSlot(process), getOutputSlot(process)) && (progress[process]+1) < MekanismUtils.getTicks(speedMultiplier, TICKS_REQUIRED))
 					{
 						progress[process]++;
-						electricityStored -= ENERGY_PER_TICK;
+						electricityStored -= MekanismUtils.getEnergyPerTick(speedMultiplier, energyMultiplier, ENERGY_PER_TICK);
 					}
 					else if(canOperate(getInputSlot(process), getOutputSlot(process)) && (progress[process]+1) >= MekanismUtils.getTicks(speedMultiplier, TICKS_REQUIRED))
 					{
 						operate(getInputSlot(process), getOutputSlot(process));
 						
 						progress[process] = 0;
-						electricityStored -= ENERGY_PER_TICK;
+						electricityStored -= MekanismUtils.getEnergyPerTick(speedMultiplier, energyMultiplier, ENERGY_PER_TICK);
 					}
 				}
 				
@@ -253,7 +253,7 @@ public class TileEntityFactory extends TileEntityElectricBlock implements IEnerg
 					}
 				}
 				
-				if(hasOperation && electricityStored >= ENERGY_PER_TICK)
+				if(hasOperation && electricityStored >= MekanismUtils.getEnergyPerTick(speedMultiplier, energyMultiplier, ENERGY_PER_TICK))
 				{
 					setActive(true);
 				}


### PR DESCRIPTION
I've slightly changed the behaviour of machine upgrades, to ensure that speed upgrades retain the total energy per item processed. Energy upgrades now reduce the energy requirement to process each item as well as increasing the energy storage of the machine.

I also changed the function from a simple multiplication/division factor to exponential growth/decay. 9 upgrades still improves the machines by a factor of 10, but the progression is smoother now (each upgrade improves the machine by a factor of the ninth root of ten). IIRC, @PonyKuu has been complaining about this a lot lately, so I thought I'd have a go at improving it.
