### PR TITLE
Fix for Electric Chest Automation

### DIFF
--- a/src/minecraft/mekanism/common/TileEntityElectricChest.java
+++ b/src/minecraft/mekanism/common/TileEntityElectricChest.java
@@ -145,12 +145,12 @@ public class TileEntityElectricChest extends TileEntityElectricBlock
 	{
 		if(side == 0)
 		{
-			return new int[] {1};
+			return new int[] {54};
 		}
 		else {
 			int[] ret = new int[54];
 			
-			for(int i = 0; i <= 54; i++)
+			for(int i = 0; i < ret.length; i++)
 			{
 				ret[i] = i;
 			}


### PR DESCRIPTION
...romSide when accessing

this chest via MFR machines. Also the inventory index for the bottom side (1) seemed bogus
considering the code in isStackValidForSlot, that checks for index 54.
