### PR TITLE
Change explicit reference to id 0 to isAirBlock() check

### DIFF
--- a/src/minecraft/mekanism/common/TankUpdateProtocol.java
+++ b/src/minecraft/mekanism/common/TankUpdateProtocol.java
@@ -259,7 +259,7 @@ public class TankUpdateProtocol
 	 */
 	private boolean isAir(int x, int y, int z)
 	{
-		return pointer.worldObj.getBlockId(x, y, z) == 0;
+		return pointer.worldObj.isAirBlock(x, y, z);
 	}
 	
 	/**


### PR DESCRIPTION
This should solve potential issues that arise then the player has been within the volume of a dynamic tank with Railcraft's hidden tracking blocks. See MinecraftForge/MinecraftForge#602. I think it could be the underlying reason for #158.
(Note that I haven't been able to test this as I have a hard time getting Mekanism to compile at all, but it's such a simple change I don't think I could have gotten it wrong)
