### PR TITLE
Add comparator support to Energy Cubes

### DIFF
--- a/src/minecraft/mekanism/common/BlockEnergyCube.java
+++ b/src/minecraft/mekanism/common/BlockEnergyCube.java
@@ -314,4 +314,16 @@ public class BlockEnergyCube extends BlockContainer
         
         return itemStack;
 	}
+	
+    public boolean hasComparatorInputOverride()
+    {
+        return true;
+    }
+
+    public int getComparatorInputOverride(World world, int x, int y, int z, int par5)
+    {
+        TileEntityEnergyCube tileEntity = (TileEntityEnergyCube)world.getBlockTileEntity(x, y, z);
+        return tileEntity.getRedstoneLevel();
+    }
+
 }

--- a/src/minecraft/mekanism/common/TileEntityEnergyCube.java
+++ b/src/minecraft/mekanism/common/TileEntityEnergyCube.java
@@ -22,6 +22,7 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.MathHelper;
 import net.minecraftforge.common.ForgeDirection;
 import net.minecraftforge.common.MinecraftForge;
 import universalelectricity.core.block.IConductor;
@@ -43,6 +44,8 @@ public class TileEntityEnergyCube extends TileEntityElectricBlock implements IEn
 {
 	/** This Energy Cube's tier. */
 	public EnergyCubeTier tier = EnergyCubeTier.BASIC;
+	
+	public int currentRedstoneLevel;
 	
 	/**
 	 * A block used to store and transfer electricity.
@@ -432,5 +435,20 @@ public class TileEntityEnergyCube extends TileEntityElectricBlock implements IEn
 	public boolean canOutputTo(ForgeDirection side)
 	{
 		return side == ForgeDirection.getOrientation(facing);
+	}
+	
+	@Override
+	public void setEnergy(double energy) {
+	    super.setEnergy(energy);
+	    int newRedstoneLevel = getRedstoneLevel();
+	    if (newRedstoneLevel != currentRedstoneLevel) {
+	        onInventoryChanged();
+	        currentRedstoneLevel = newRedstoneLevel;
+	    }
+	}
+	
+	public int getRedstoneLevel() {
+        double fractionFull = getEnergy()/getMaxEnergy();
+        return MathHelper.floor_float((float) (fractionFull * 14.0F)) + (fractionFull > 0 ? 1 : 0);
 	}
 }


### PR DESCRIPTION
Add the comparator methods to BlockEnergyCube and make it's TileEntity onInventoryChanged() when the redstone level changes to update comparators.
