### PR TITLE
Fix crash when using a wrench on a GasTank

### DIFF
--- a/common/mekanism/common/block/BlockGasTank.java
+++ b/common/mekanism/common/block/BlockGasTank.java
@@ -143,9 +143,8 @@ public class BlockGasTank extends BlockContainer
     
 	public ItemStack dismantleBlock(World world, int x, int y, int z, boolean returnBlock) 
 	{
-    	TileEntityElectricBlock tileEntity = (TileEntityElectricBlock)world.getBlockTileEntity(x, y, z);
-    	ItemStack itemStack = new ItemStack(Mekanism.GasTank);
-        
+        ItemStack itemStack = getPickBlock(null, world, x, y, z);
+
         world.setBlockToAir(x, y, z);
         
         if(!returnBlock)


### PR DESCRIPTION
Using a wrench (eg. BuildCraft's) on a GasTank results in the following crash:

```
java.lang.ClassCastException: mekanism.common.tileentity.TileEntityGasTank cannot be cast to mekanism.common.tileentity.TileEntityElectricBlock
at mekanism.common.block.BlockGasTank.dismantleBlock(BlockGasTank.java:146)
at mekanism.common.block.BlockGasTank.onBlockActivated(BlockGasTank.java:84)
at net.minecraft.item.ItemInWorldManager.activateBlockOrUseItem(ItemInWorldManager.java:416)
at net.minecraft.network.NetServerHandler.handlePlace(NetServerHandler.java:556)
at net.minecraft.network.packet.Packet15Place.processPacket(Packet15Place.java:79)
at net.minecraft.network.MemoryConnection.processReadPackets(MemoryConnection.java:89)
at net.minecraft.network.NetServerHandler.networkTick(NetServerHandler.java:141)
at net.minecraft.network.NetworkListenThread.networkTick(NetworkListenThread.java:54)
at net.minecraft.server.integrated.IntegratedServerListenThread.networkTick(IntegratedServerListenThread.java:109)
at net.minecraft.server.MinecraftServer.updateTimeLightAndEntities(MinecraftServer.java:691)
at net.minecraft.server.MinecraftServer.tick(MinecraftServer.java:587)
at net.minecraft.server.integrated.IntegratedServer.tick(IntegratedServer.java:129)
at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:484)
at net.minecraft.server.ThreadMinecraftServer.run(ThreadMinecraftServer.java:16)
```
