### PR TITLE
Use MekanismUtils.getName to pull the right name from OreDict

### DIFF
--- a/common/mekanism/common/transporter/TOreDictFilter.java
+++ b/common/mekanism/common/transporter/TOreDictFilter.java
@@ -18,7 +18,7 @@ public class TOreDictFilter extends TransporterFilter
 	@Override
 	public boolean canFilter(ItemStack itemStack)
 	{
-		String oreKey = MekanismUtils.getOreDictName(itemStack);
+		String oreKey = MekanismUtils.getName(itemStack);
 		
 		if(oreKey == null)
 		{


### PR DESCRIPTION
Address https://github.com/aidancbrady/Mekanism/issues/740 - It appears that the TOreDict filter was not using the correct method to identify the itemStack. Tested on 1.6.4 w/ Forge 9.11.1.953.

Verified by setting up three chests, connnected by logistical pipes. Tagged one as dark green, other as dark blue. Sorter on the third, auto-ejecting w/ two filters: OreDict: _ore_ and OreDict: logWood. Placed Oak Wood, Lapis, Cobble. Without patch, only Lapis went to dark green; cobble and wood went to default (dark blue). With patch, Oak and Lapis went to dark green as desired.
