### PR TITLE
Fix NPE in client GUI

### DIFF
--- a/common/mekanism/client/ClientProxy.java
+++ b/common/mekanism/client/ClientProxy.java
@@ -298,6 +298,9 @@ public class ClientProxy extends CommonProxy
 	{
 		TileEntity tileEntity = world.getBlockTileEntity(x, y, z);
 		
+		if (tileEntity == null)
+			return null;
+			
 		switch(ID)
 		{
 			case 0:


### PR DESCRIPTION
When breaking/right clicking at the same time it can crash the client on an NPE with the tileEntity reference.
