### PR TITLE
Remove redundant energy unit in cable tooltip.

### DIFF
--- a/common/mekanism/common/multipart/ItemPartTransmitter.java
+++ b/common/mekanism/common/multipart/ItemPartTransmitter.java
@@ -88,7 +88,7 @@ public class ItemPartTransmitter extends JItemMultiPart
 		{
 			if(itemstack.getItemDamage() < Tier.CableTier.values().length)
 			{
-				list.add(EnumColor.INDIGO + "Capacity: " + EnumColor.GREY + MekanismUtils.getEnergyDisplay(Tier.CableTier.values()[itemstack.getItemDamage()].cableCapacity) + "J/t");
+				list.add(EnumColor.INDIGO + "Capacity: " + EnumColor.GREY + MekanismUtils.getEnergyDisplay(Tier.CableTier.values()[itemstack.getItemDamage()].cableCapacity) + "/t");
 			}
 			
 			list.add("Hold " + EnumColor.AQUA + "shift" + EnumColor.GREY + " for details.");


### PR DESCRIPTION
MekanismUtils.getEnergyDisplay() already returns a string with the energy unit chosen in config.
