### PR TITLE
Changed PartSidedPipe to be able to place covers on it

### DIFF
--- a/common/mekanism/common/multipart/PartSidedPipe.java
+++ b/common/mekanism/common/multipart/PartSidedPipe.java
@@ -265,7 +265,10 @@ public abstract class PartSidedPipe extends TMultiPart implements TSlottedPart, 
 	@Override
 	public Iterable<Cuboid6> getOcclusionBoxes()
 	{
-		return getCollisionBoxes();
+		List<Cuboid6> boxes = new ArrayList<Cuboid6>();
+		boxes.add(getTransmitter().getSize() == Size.SMALL ? smallSides[6] : largeSides[6]);
+		
+		return boxes;
 	}
 
 	@Override


### PR DESCRIPTION
You can't place other multiparts where there is an occlusion box so if the only one is the one in the middle you can place covers/panels around it and make it disconnect.
I'm not sure if the code is designed to separate the networks when you place a cover between two cables and merge them if a cover is removed. If it's not, you would have to add some code that split/merged the networks when a part of the block is changed but it shouldn't be too difficult.

I hope this helps, it was driving me crazy not being able to place covers to separate the cables xD
