### PR TITLE
Change Digital Miner GUI to show actual energy usage per tick

### DIFF
--- a/common/mekanism/client/gui/GuiDigitalMiner.java
+++ b/common/mekanism/client/gui/GuiDigitalMiner.java
@@ -48,7 +48,7 @@ public class GuiDigitalMiner extends GuiMekanism
 			@Override
 			public List<String> getInfo()
 			{
-				String multiplier = MekanismUtils.getEnergyDisplay(MekanismUtils.getEnergyPerTick(tileEntity.getSpeedMultiplier(), tileEntity.getEnergyMultiplier(), tileEntity.ENERGY_USAGE));
+				String multiplier = MekanismUtils.getEnergyDisplay(tileEntity.getPerTick());
 				return ListUtils.asList("Using: " + multiplier + "/t", "Needed: " + MekanismUtils.getEnergyDisplay(tileEntity.getMaxEnergy()-tileEntity.getEnergy()));
 			}
 		}, this, tileEntity, MekanismUtils.getResource(ResourceType.GUI, "GuiDigitalMiner.png")));


### PR DESCRIPTION
The GUI for the Digital Miner shows the expected energy usage of the digital miner. It doesn't take into account the configured radius and height, or whether silk touch is enabled. This patch alters the display to use the getPerTick() public method on the tile entity to get the actual usage as configured.
