### PR TITLE
Fix Logistical Sorter auto-eject coloring

### DIFF
--- a/src/main/java/mekanism/common/tile/TileEntityLogisticalSorter.java
+++ b/src/main/java/mekanism/common/tile/TileEntityLogisticalSorter.java
@@ -129,7 +129,7 @@ public class TileEntityLogisticalSorter extends TileEntityElectricBlock implemen
 						
 						if(invStack != null && invStack.getStack() != null)
 						{
-							ItemStack used = emitItemToTransporter(front, invStack, null, 0);
+							ItemStack used = emitItemToTransporter(front, invStack, color, 0);
 							
 							if(used != null)
 							{


### PR DESCRIPTION
LogisticalSorter didn't use default color when auto-ejecting (this also happens in current master)
