### PR TITLE
Fix crash when mining BlockMultipart with Atomic Disassembler

### DIFF
--- a/src/main/java/mekanism/common/OreDictCache.java
+++ b/src/main/java/mekanism/common/OreDictCache.java
@@ -20,6 +20,11 @@ public final class OreDictCache
 
 	public static List<String> getOreDictName(ItemStack check)
 	{
+		if (check == null || check.getItem() == null)
+		{
+			return new ArrayList<String>();
+		}
+
 		ItemInfo info = ItemInfo.get(check);
 
 		if(cachedKeys.get(info) != null)


### PR DESCRIPTION
Not sure if this is a Bug in Mekanism or in FMP, but I get the following crash when mining a multipart block with the Atomic Disassembler:

```
java.lang.NullPointerException: Ticking memory connection
    at net.minecraft.item.ItemStack.getItemDamage(ItemStack.java:266)
    at mekanism.api.ItemInfo.get(ItemInfo.java:19)
    at mekanism.common.OreDictCache.getOreDictName(OreDictCache.java:23)
    at mekanism.common.util.MekanismUtils.getOreDictName(MekanismUtils.java:486)
    at mekanism.common.item.ItemAtomicDisassembler.onBlockStartBreak(ItemAtomicDisassembler.java:104)
    at net.minecraft.server.management.ItemInWorldManager.tryHarvestBlock(ItemInWorldManager.java:289)
    at net.minecraft.server.management.ItemInWorldManager.uncheckedTryHarvestBlock(ItemInWorldManager.java:234)
    at net.minecraft.network.NetHandlerPlayServer.processPlayerDigging(NetHandlerPlayServer.java:529)
    at net.minecraft.network.play.client.C07PacketPlayerDigging.processPacket(C07PacketPlayerDigging.java:61)
    at net.minecraft.network.play.client.C07PacketPlayerDigging.processPacket(C07PacketPlayerDigging.java:94)
    at net.minecraft.network.NetworkManager.processReceivedPackets(NetworkManager.java:232)
    at net.minecraft.network.NetworkSystem.networkTick(NetworkSystem.java:182)
    at net.minecraft.server.MinecraftServer.updateTimeLightAndEntities(MinecraftServer.java:720)
    at net.minecraft.server.MinecraftServer.tick(MinecraftServer.java:608)
    at net.minecraft.server.integrated.IntegratedServer.tick(IntegratedServer.java:118)
    at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:482)
    at net.minecraft.server.MinecraftServer$2.run(MinecraftServer.java:746)
```

I was able to trace it back to the ItemStack generated in ItemAtomicDisassembler#onBlockStartBreak(...)

``` java
ItemStack stack = new ItemStack(block, 1, meta);
```

returning null for #getItem() when block is an instance of BlockMultipart, so checking for null in OreDictCache#getOreDictName() probably won't hurt ;-)
