### PR TITLE
Port to forge-10.12.2.1121 (was 10.12.1.1112)

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,5 +1,5 @@
 minecraft_version=1.7.2
-forge_version=10.12.1.1112
+forge_version=10.12.2.1121
 FMP_version=1.1.0.282
 CCLIB_version=1.1.1.81
 NEI_version=1.0.1

--- a/src/main/java/mekanism/client/nei/ChemicalInjectionChamberRecipeHandler.java
+++ b/src/main/java/mekanism/client/nei/ChemicalInjectionChamberRecipeHandler.java
@@ -51,7 +51,8 @@ public class ChemicalInjectionChamberRecipeHandler extends AdvancedMachineRecipe
 	{
 		if(gasType == GasRegistry.getGas("sulfuricAcid"))
 		{
-			List<ItemStack> fuels = OreDictionary.getOres("dustSulfur");
+			List<ItemStack> fuels = new ArrayList<ItemStack>();
+			fuels.addAll(OreDictionary.getOres("dustSulfur"));
 			fuels.add(MekanismUtils.getFullGasTank(GasRegistry.getGas("sulfuricAcid")));
 			return fuels;
 		}
@@ -61,7 +62,8 @@ public class ChemicalInjectionChamberRecipeHandler extends AdvancedMachineRecipe
 		}
 		else if(gasType == GasRegistry.getGas("hydrogenChloride"))
 		{
-			List<ItemStack> fuels = OreDictionary.getOres("dustSalt");
+			List<ItemStack> fuels = new ArrayList<ItemStack>();
+			fuels.addAll(OreDictionary.getOres("dustSalt"));
 			fuels.add(MekanismUtils.getFullGasTank(GasRegistry.getGas("hydrogenChloride")));
 			return fuels;
 		}

--- a/src/main/java/mekanism/common/Mekanism.java
+++ b/src/main/java/mekanism/common/Mekanism.java
@@ -1091,7 +1091,9 @@ public class Mekanism
 		OreDictionary.registerOre("ingotIron", new ItemStack(Items.iron_ingot));
 		OreDictionary.registerOre("ingotGold", new ItemStack(Items.gold_ingot));
 		OreDictionary.registerOre("oreRedstone", new ItemStack(Blocks.redstone_ore));
-		OreDictionary.registerOre("oreRedstone", new ItemStack(Blocks.lit_redstone_ore));
+
+		// This triggers a NullPointerException.  OreDictionary.registerOre calls ItemStack.getItemDamage() which triggers the NPE in minecraft code. (Forge 10.12.2.1121) 
+		//OreDictionary.registerOre("oreRedstone", new ItemStack(Blocks.lit_redstone_ore));
 		
 		if(controlCircuitOreDict || !hooks.BasicComponentsLoaded)
 		{

--- a/src/main/java/mekanism/common/OreDictCache.java
+++ b/src/main/java/mekanism/common/OreDictCache.java
@@ -32,21 +32,7 @@ public final class OreDictCache
 			return cachedKeys.get(info);
 		}
 
-		List<Integer> idsFound = new ArrayList<Integer>();
-		HashMap<Integer, ArrayList<ItemStack>> oreStacks = (HashMap<Integer, ArrayList<ItemStack>>)MekanismUtils.getPrivateValue(null, OreDictionary.class, new String[] {"oreStacks"});
-		oreStacks = (HashMap<Integer, ArrayList<ItemStack>>)oreStacks.clone();
-
-		for(Map.Entry<Integer, ArrayList<ItemStack>> entry : oreStacks.entrySet())
-		{
-			for(ItemStack stack : entry.getValue())
-			{
-				if(StackUtils.equalsWildcard(stack, check))
-				{
-					idsFound.add(entry.getKey());
-					break;
-				}
-			}
-		}
+		int[] idsFound = OreDictionary.getOreIDs(check);
 
 		List<String> ret = new ArrayList<String>();
 


### PR DESCRIPTION
Ported to forge 1121, handling changes to the forge oreDictionary

Of particular note is the new `OreDictionary.getIds(ItemStack)` function, removing the need for reflection to implement `OreDictCache.getOreDictName(ItemStack)`
