### PR TITLE
Fix a server crash relating to a client-side only class initialization

### DIFF
--- a/src/main/java/mekanism/client/ClientProxy.java
+++ b/src/main/java/mekanism/client/ClientProxy.java
@@ -144,6 +144,7 @@ import cpw.mods.fml.client.FMLClientHandler;
 import cpw.mods.fml.client.registry.ClientRegistry;
 import cpw.mods.fml.client.registry.RenderingRegistry;
 import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.common.network.simpleimpl.MessageContext;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
@@ -555,5 +556,10 @@ public class ClientProxy extends CommonProxy
 		{
 			MekanismClient.voiceClient.start();
 		}
+	}
+	
+	@Override
+	public EntityPlayer getPlayer(MessageContext context) {
+		return Minecraft.getMinecraft().thePlayer;
 	}
 }

--- a/src/main/java/mekanism/common/CommonProxy.java
+++ b/src/main/java/mekanism/common/CommonProxy.java
@@ -84,6 +84,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
 import net.minecraftforge.common.config.Configuration;
 import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.common.network.simpleimpl.MessageContext;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.FMLInjectionData;
 
@@ -458,5 +459,9 @@ public class CommonProxy
 		}
 
 		Mekanism.logger.info("Received config from server.");
+	}
+	
+	public EntityPlayer getPlayer(MessageContext context) {
+		return context.getServerHandler().playerEntity;
 	}
 }

--- a/src/main/java/mekanism/common/PacketHandler.java
+++ b/src/main/java/mekanism/common/PacketHandler.java
@@ -189,13 +189,7 @@ public class PacketHandler
 	
 	public static EntityPlayer getPlayer(MessageContext context)
 	{
-		if(context.side.isClient())
-		{
-			return Minecraft.getMinecraft().thePlayer;
-		}
-		else {
-			return context.getServerHandler().playerEntity;
-		}
+		return Mekanism.proxy.getPlayer(context);
 	}
 	
 	/**


### PR DESCRIPTION
The PacketHandler has an if/else block containing a reference to the client-side only Minecraft class. This fix changes that block to a method call to the currently loaded proxy, which fixes the problem!
