### PR TITLE
Stop energy cube core rendering when cube is empty.

### DIFF
--- a/src/main/java/mekanism/client/render/tileentity/RenderEnergyCube.java
+++ b/src/main/java/mekanism/client/render/tileentity/RenderEnergyCube.java
@@ -55,27 +55,32 @@ public class RenderEnergyCube extends TileEntitySpecialRenderer
 		model.render(0.0625F);
 		GL11.glPopMatrix();
 
-		GL11.glPushMatrix();
-		GL11.glTranslated(x + 0.5, y + 0.5, z + 0.5);
-		bindTexture(MekanismUtils.getResource(ResourceType.RENDER, "EnergyCore.png"));
+        if(tileEntity.getEnergy()/tileEntity.getMaxEnergy()>0.1) {
 
-		MekanismRenderer.blendOn();
-		MekanismRenderer.glowOn();
+            GL11.glPushMatrix();
+            GL11.glTranslated(x + 0.5, y + 0.5, z + 0.5);
+            bindTexture(MekanismUtils.getResource(ResourceType.RENDER, "EnergyCore.png"));
 
-		EnumColor c = tileEntity.tier.color;
+            MekanismRenderer.blendOn();
+            MekanismRenderer.glowOn();
 
-		GL11.glPushMatrix();
-		GL11.glScalef(0.4F, 0.4F, 0.4F);
-		GL11.glColor4f(c.getColor(0), c.getColor(1), c.getColor(2), (float)(tileEntity.getEnergy()/tileEntity.getMaxEnergy()));
-		GL11.glTranslatef(0, (float)Math.sin(Math.toRadians((MekanismClient.ticksPassed + partialTick) * 3)) / 7, 0);
-		GL11.glRotatef((MekanismClient.ticksPassed + partialTick) * 4, 0, 1, 0);
-		GL11.glRotatef(36F + (MekanismClient.ticksPassed + partialTick) * 4, 0, 1, 1);
-		core.render(0.0625F);
-		GL11.glPopMatrix();
+            EnumColor c = tileEntity.tier.color;
 
-		MekanismRenderer.glowOff();
-		MekanismRenderer.blendOff();
 
-		GL11.glPopMatrix();
+            GL11.glPushMatrix();
+            GL11.glScalef(0.4F, 0.4F, 0.4F);
+            GL11.glColor4f(c.getColor(0), c.getColor(1), c.getColor(2), (float) (tileEntity.getEnergy() / tileEntity.getMaxEnergy()));
+            GL11.glTranslatef(0, (float) Math.sin(Math.toRadians((MekanismClient.ticksPassed + partialTick) * 3)) / 7, 0);
+            GL11.glRotatef((MekanismClient.ticksPassed + partialTick) * 4, 0, 1, 0);
+            GL11.glRotatef(36F + (MekanismClient.ticksPassed + partialTick) * 4, 0, 1, 1);
+            core.render(0.0625F);
+            GL11.glPopMatrix();
+
+
+            MekanismRenderer.glowOff();
+            MekanismRenderer.blendOff();
+
+            GL11.glPopMatrix();
+        }
 	}
 }


### PR DESCRIPTION
This will stop it from blocking out other rendering when it's not opaque
enough to be visible, for example the universal cable.
