### PR TITLE
Fixed some Electric Chest bugs

### DIFF
--- a/src/main/java/mekanism/common/block/BlockMachine.java
+++ b/src/main/java/mekanism/common/block/BlockMachine.java
@@ -722,7 +722,7 @@ public class BlockMachine extends BlockContainer implements ISpecialBounds, IPer
 			{
 				TileEntityElectricChest electricChest = (TileEntityElectricChest)tileEntity;
 
-				if(!entityplayer.isSneaking())
+				if(!(entityplayer.isSneaking() || world.isSideSolid(x, y + 1, z, ForgeDirection.DOWN)))
 				{
 					if(electricChest.canAccess())
 					{

--- a/src/main/java/mekanism/common/network/PacketElectricChest.java
+++ b/src/main/java/mekanism/common/network/PacketElectricChest.java
@@ -102,6 +102,7 @@ public class PacketElectricChest implements IMessageHandler<ElectricChestMessage
 				{
 					TileEntityElectricChest tileEntity = (TileEntityElectricChest)message.coord4D.getTileEntity(player.worldObj);
 					tileEntity.locked = message.locked;
+					player.worldObj.notifyBlocksOfNeighborChange(message.coord4D.xCoord,message.coord4D.yCoord,message.coord4D.zCoord,Mekanism.MachineBlock);
 				}
 				else {
 					ItemStack stack = player.getCurrentEquippedItem();


### PR DESCRIPTION
Electric Chest was not updating when it was (un)locked, meaning that
mechanical pipes would not (dis)connect and reconnect.

Noticed that Electric Chest won't accept transporters connecting to
the bottom, which I thought was odd, however it looked intentional so I
left it alone. (..?)

Also made it so electric chests will not open if there is a solid block
above them.
