### PR TITLE
Fixed issue "Chemical Oxidizer Bug #1628"

### DIFF
--- a/src/main/java/mekanism/common/inventory/container/ContainerChemicalOxidizer.java
+++ b/src/main/java/mekanism/common/inventory/container/ContainerChemicalOxidizer.java
@@ -72,7 +72,7 @@ public class ContainerChemicalOxidizer extends Container
 			ItemStack slotStack = currentSlot.getStack();
 			stack = slotStack.copy();
 
-			if(RecipeHandler.getItemToGasOutput(slotStack, false, Recipe.CHEMICAL_OXIDIZER.get()) != null)
+			if(RecipeHandler.getItemToGasOutput(slotStack, false, Recipe.CHEMICAL_OXIDIZER.get()) != null && slotID != 0)
 			{
 				if(!mergeItemStack(slotStack, 0, 1, true))
 				{


### PR DESCRIPTION
Adds a check to see if stack is already in the slot and stops it merging
into itself if it is.

https://github.com/aidancbrady/Mekanism/issues/1628
