### PR TITLE
Fixes issue #1589, but note the complication.

### DIFF
--- a/src/main/java/mekanism/common/tile/TileEntityFluidicPlenisher.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFluidicPlenisher.java
@@ -19,6 +19,7 @@ import mekanism.common.util.MekanismUtils;
 import mekanism.common.util.PipeUtils;
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
@@ -32,6 +33,7 @@ import net.minecraftforge.fluids.FluidTank;
 import net.minecraftforge.fluids.FluidTankInfo;
 import net.minecraftforge.fluids.IFluidContainerItem;
 import net.minecraftforge.fluids.IFluidHandler;
+import net.minecraftforge.fluids.FluidRegistry;
 
 public class TileEntityFluidicPlenisher extends TileEntityElectricBlock implements IConfigurable, IFluidHandler, ISustainedTank
 {
@@ -178,11 +180,12 @@ public class TileEntityFluidicPlenisher extends TileEntityElectricBlock implemen
 		{
 			if(coord.exists(worldObj) && canReplace(coord))
 			{
-				worldObj.setBlock(coord.xCoord, coord.yCoord, coord.zCoord, MekanismUtils.getFlowingBlock(fluidTank.getFluid().getFluid()), 0, 3);
-				
-				setEnergy(getEnergy() - Mekanism.fluidicPlenisherUsage);
-				fluidTank.drain(FluidContainerRegistry.BUCKET_VOLUME, true);
-				
+				if(shouldReplace(coord)) {
+					worldObj.setBlock(coord.xCoord, coord.yCoord, coord.zCoord, MekanismUtils.getFlowingBlock(fluidTank.getFluid().getFluid()), 0, 3);
+
+					setEnergy(getEnergy() - Mekanism.fluidicPlenisherUsage);
+					fluidTank.drain(FluidContainerRegistry.BUCKET_VOLUME, true);
+				}
 				for(ForgeDirection dir : dirs)
 				{
 					Coord4D sideCoord = coord.getFromSide(dir);
@@ -224,8 +227,29 @@ public class TileEntityFluidicPlenisher extends TileEntityElectricBlock implemen
 		{
 			return true;
 		}
-		
 		return coord.getBlock(worldObj).isReplaceable(worldObj, coord.xCoord, coord.yCoord, coord.zCoord);
+	}
+
+	public boolean shouldReplace(Coord4D coord){
+		Block block = worldObj.getBlock(coord.xCoord, coord.yCoord, coord.zCoord);
+		int meta = worldObj.getBlockMetadata(coord.xCoord, coord.yCoord, coord.zCoord);
+		if(fluidTank.getFluid().getFluid() == FluidRegistry.WATER){
+			if(block == Blocks.water || block == Blocks.flowing_water){
+				return meta != 0;
+			}
+		}
+		else if(fluidTank.getFluid().getFluid() == FluidRegistry.LAVA){
+			if(block == Blocks.lava || block == Blocks.flowing_lava){
+				return meta != 0;
+			}
+		}
+		else{
+			if(block == fluidTank.getFluid().getFluid().getBlock()){
+				return meta !=0;
+			}
+		}
+	return true;
+
 	}
 	
 	@Override


### PR DESCRIPTION
Fixes issue: Fluidic Plenisher doesn't detect block update directly
below it #1589

Fluidic Plenisher will now reset its' calculations after a neighboring
block updates - in the same way it does when you shift + right click
with a configurator.  In the case of the issue, it will update when you
destroy/remove the obsidian.

However, this can cause problems. Say you have a lake that you have
filled using the Plenisher. Should any block next to the Plenisher
update it will cause a reset, and the Plenisher will replace all the
blocks in the lake with new ones. You essentially re-fill an already
full lake. Obviously this is very wasteful and not particularly wanted.

A possible fix to this could be that the Plenisher does not place the
block on source blocks of the same type? This would also mean "topping
up" a pre-made lake will not waste lava.

Thought I would see what you thought, and then maybe I will also
implement the change above if you think it is a good idea?
