### PR TITLE
Stop pipes connecting to front of Heat Generator.

### DIFF
--- a/src/main/java/mekanism/generators/common/tile/TileEntityHeatGenerator.java
+++ b/src/main/java/mekanism/generators/common/tile/TileEntityHeatGenerator.java
@@ -322,7 +322,7 @@ public class TileEntityHeatGenerator extends TileEntityGenerator implements IFlu
 	@Override
 	public boolean canFill(ForgeDirection from, Fluid fluid)
 	{
-		return fluid == FluidRegistry.LAVA;
+			return (fluid == FluidRegistry.LAVA) && (from != ForgeDirection.getOrientation(facing));
 	}
 
 	@Override
@@ -334,6 +334,9 @@ public class TileEntityHeatGenerator extends TileEntityGenerator implements IFlu
 	@Override
 	public FluidTankInfo[] getTankInfo(ForgeDirection from)
 	{
+		if(from == ForgeDirection.getOrientation(facing)){
+			return new FluidTankInfo[0];
+		}
 		return new FluidTankInfo[] {lavaTank.getInfo()};
 	}
 


### PR DESCRIPTION
Prevents mechanical pipes connecting to the front (energy output) side
of the Heat Generator.

Currently they physically connect, leading you to assume they are
transferring the lava, however they are not as this is the energy output
side and it does not accept lava.
