### PR TITLE
Fixed Logistical Sorter Stuck, Issue #1666

### DIFF
--- a/src/main/java/mekanism/common/tile/TileEntityLogisticalSorter.java
+++ b/src/main/java/mekanism/common/tile/TileEntityLogisticalSorter.java
@@ -120,7 +120,9 @@ public class TileEntityLogisticalSorter extends TileEntityElectricBlock implemen
 									sentItems = true;
 								}
 
-								break;
+								if(!TransporterManager.didEmit(invStack.getStack(),used)) {
+									break;
+								}
 							}
 						}
 					}


### PR DESCRIPTION
Fixed issue #1666.
If nothing is emitted from the Sorter, it will now continue looking down
its list of filters.
