### PR TITLE
add config for salination plant water transformation per update

### DIFF
--- a/src/main/java/mekanism/common/CommonProxy.java
+++ b/src/main/java/mekanism/common/CommonProxy.java
@@ -207,7 +207,8 @@ public class CommonProxy
 		Mekanism.VOICE_PORT = Mekanism.configuration.get(Configuration.CATEGORY_GENERAL, "VoicePort", 36123, null, 1, 65535).getInt();
 		//If this is less than 1, upgrades make machines worse. If less than 0, I don't even know.
 		Mekanism.maxUpgradeMultiplier = Mekanism.configuration.get(Configuration.CATEGORY_GENERAL, "UpgradeModifier", 10, null, 1, Integer.MAX_VALUE).getInt();
-		
+		Mekanism.salinationPlantWaterUsage = Mekanism.configuration.get(Configuration.CATEGORY_GENERAL, "SalinationPlantSpeed", 40.0, "Millibuckets of water turned into brine by the plant per tick", 1.0, 9000.0).getDouble();
+
 		String s = Mekanism.configuration.get(Configuration.CATEGORY_GENERAL, "EnergyType", "J", null, new String[]{"J", "RF", "MJ", "EU"}).getString();
 
 		if(s != null)

--- a/src/main/java/mekanism/common/Mekanism.java
+++ b/src/main/java/mekanism/common/Mekanism.java
@@ -355,6 +355,7 @@ public class Mekanism
 	public static double seismicVibratorUsage;
 	public static double pressurizedReactionBaseUsage;
 	public static double fluidicPlenisherUsage;
+	public static double salinationPlantWaterUsage;
 
 	/**
 	 * Adds all in-game crafting, smelting and machine recipes.

--- a/src/main/java/mekanism/common/tile/TileEntitySalinationController.java
+++ b/src/main/java/mekanism/common/tile/TileEntitySalinationController.java
@@ -33,7 +33,6 @@ public class TileEntitySalinationController extends TileEntitySalinationTank
 	public static final int MAX_BRINE = 10000;
 	public static final int MAX_SOLARS = 4;
 	public static final int WARMUP = 10000;
-	public static final double WATER_USAGE = 40;
 
 	public FluidTank waterTank = new FluidTank(0);
 	public FluidTank brineTank = new FluidTank(MAX_BRINE);
@@ -93,14 +92,14 @@ public class TileEntitySalinationController extends TileEntitySalinationTank
 				int brineNeeded = brineTank.getCapacity()-brineTank.getFluidAmount();
 				int waterStored = waterTank.getFluidAmount();
 				
-				partialWater += Math.min(waterTank.getFluidAmount(), getTemperature()*WATER_USAGE);
+				partialWater += Math.min(waterTank.getFluidAmount(), getTemperature()*Mekanism.salinationPlantWaterUsage);
 				
 				if(partialWater >= 1)
 				{
 					int waterInt = (int)Math.floor(partialWater);
 					waterTank.drain(waterInt, true);
 					partialWater %= 1;
-					partialBrine += ((double)waterInt)/WATER_USAGE;
+					partialBrine += ((double)waterInt)/Mekanism.salinationPlantWaterUsage;
 				}
 				
 				if(partialBrine >= 1)


### PR DESCRIPTION
Partially addresses #1847

Adds a config to increase the amount of water a salination plant turns into brine per update. Increasing this value will make it so you need fewer plants to process the same amount of water into brine, while decreasing would increase the number of plants.

Once again, merge if this kind of config fits your vision. Also, if the storm of PRs is getting annoying, let me know and we can find a better way to do this (maybe I just keep to myself :stuck_out_tongue:).
