### PR TITLE
Added NEI usage handler for infusion objects

### DIFF
--- a/src/main/java/mekanism/client/nei/MetallurgicInfuserRecipeHandler.java
+++ b/src/main/java/mekanism/client/nei/MetallurgicInfuserRecipeHandler.java
@@ -194,6 +194,14 @@ public class MetallurgicInfuserRecipeHandler extends BaseRecipeHandler
 			{
 				arecipes.add(new CachedIORecipe(irecipe, getInfuseStacks(((InfusionInput)irecipe.getKey()).infusionType), ((InfusionInput)irecipe.getKey()).infusionType));
 			}
+			List<ItemStack> infuses;
+			for(ItemStack stack : getInfuseStacks(((InfusionInput)irecipe.getKey()).infusionType)) {
+				if(NEIServerUtils.areStacksSameTypeCrafting(stack, ingredient)) {
+					infuses = new ArrayList<ItemStack>();
+					infuses.add(stack);
+					arecipes.add(new CachedIORecipe(irecipe, infuses, ((InfusionInput)irecipe.getKey()).infusionType));
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
This adds a usage handler in the Metallurgic Infuser NEI handler, so that looking up the usages of infusion objects works now. 
For example, the usages of coal or redstone in the Metallurgic Infuser can be looked up with this.
