### PR TITLE
Add support for configurable machines storage.

### DIFF
--- a/src/main/java/mekanism/client/gui/GuiSeismicVibrator.java
+++ b/src/main/java/mekanism/client/gui/GuiSeismicVibrator.java
@@ -31,7 +31,7 @@ public class GuiSeismicVibrator extends GuiMekanismTile<TileEntitySeismicVibrato
         addGuiElement(new GuiPowerBar(this, tileEntity, resource, 164, 15));
         addGuiElement(new GuiEnergyInfo(() -> {
             String multiplier = MekanismUtils
-                  .getEnergyDisplay(MekanismConfig.current().usage.seismicVibratorUsage.val());
+                  .getEnergyDisplay(MekanismConfig.current().usage.seismicVibrator.val());
             return Arrays.asList(LangUtils.localize("gui.using") + ": " + multiplier + "/t",
                   LangUtils.localize("gui.needed") + ": " + MekanismUtils
                         .getEnergyDisplay(tileEntity.getMaxEnergy() - tileEntity.getEnergy()));

--- a/src/main/java/mekanism/common/CommonProxy.java
+++ b/src/main/java/mekanism/common/CommonProxy.java
@@ -400,8 +400,6 @@ public class CommonProxy implements IGuiProvider {
             MekanismAPI.addBoxBlacklist(Blocks.MOB_SPAWNER, OreDictionary.WILDCARD_VALUE);
         }
 
-        BlockStateMachine.MachineType.updateAllUsages();
-
         if (MekanismConfig.current().general.voiceServerEnabled.val() && Mekanism.voiceManager == null) {
             Mekanism.voiceManager = new VoiceServerManager();
         }

--- a/src/main/java/mekanism/common/CommonProxy.java
+++ b/src/main/java/mekanism/common/CommonProxy.java
@@ -161,6 +161,7 @@ public class CommonProxy implements IGuiProvider {
     public void loadConfiguration() {
         MekanismConfig.local().general.load(Mekanism.configuration);
         MekanismConfig.local().usage.load(Mekanism.configuration);
+        MekanismConfig.local().storage.load(Mekanism.configuration);
 
         if (Mekanism.configuration.hasChanged()) {
             Mekanism.configuration.save();

--- a/src/main/java/mekanism/common/Mekanism.java
+++ b/src/main/java/mekanism/common/Mekanism.java
@@ -591,7 +591,7 @@ public class Mekanism {
                   2 * MekanismConfig.current().general.FROM_H2.val(),
                   new GasStack(MekanismFluids.Sodium, 1), new GasStack(MekanismFluids.Chlorine, 1));
             RecipeHandler.addElectrolyticSeparatorRecipe(FluidRegistry.getFluidStack("heavywater", 2),
-                  MekanismConfig.current().usage.heavyWaterElectrolysisUsage.val(),
+                  MekanismConfig.current().usage.heavyWaterElectrolysis.val(),
                   new GasStack(MekanismFluids.Deuterium, 2),
                   new GasStack(MekanismFluids.Oxygen, 1));
         }

--- a/src/main/java/mekanism/common/base/IFactory.java
+++ b/src/main/java/mekanism/common/base/IFactory.java
@@ -276,6 +276,10 @@ public interface IFactory {
             return 200;
         }
 
+        public double getEnergyStorage() {
+            return type.getStorage();
+        }
+
         public ItemStack getStack() {
             return type.getStack();
         }

--- a/src/main/java/mekanism/common/block/states/BlockStateMachine.java
+++ b/src/main/java/mekanism/common/block/states/BlockStateMachine.java
@@ -195,7 +195,6 @@ public class BlockStateMachine extends ExtendedBlockState {
         public int meta;
         public String blockName;
         public int guiId;
-        public double baseEnergy;
         public Class<? extends TileEntity> tileEntityClass;
         public boolean isElectric;
         public boolean hasModel;
@@ -253,11 +252,6 @@ public class BlockStateMachine extends ExtendedBlockState {
             return null;
         }
 
-        public static void updateAllUsages() {
-            for (MachineType type : values()) {
-                type.updateUsage();
-            }
-        }
 
         public static MachineType get(ItemStack stack) {
             return get(Block.getBlockFromItem(stack.getItem()), stack.getItemDamage());
@@ -287,31 +281,28 @@ public class BlockStateMachine extends ExtendedBlockState {
             }
         }
 
-        /**
-         * Used for getting the base energy storage.
-         */
         public double getUsage() {
             switch (this) {
                 case ENRICHMENT_CHAMBER:
-                    return MekanismConfig.current().usage.enrichmentChamberUsage.val();
+                    return MekanismConfig.current().usage.enrichmentChamber.val();
                 case OSMIUM_COMPRESSOR:
-                    return MekanismConfig.current().usage.osmiumCompressorUsage.val();
+                    return MekanismConfig.current().usage.osmiumCompressor.val();
                 case COMBINER:
-                    return MekanismConfig.current().usage.combinerUsage.val();
+                    return MekanismConfig.current().usage.combiner.val();
                 case CRUSHER:
-                    return MekanismConfig.current().usage.crusherUsage.val();
+                    return MekanismConfig.current().usage.crusher.val();
                 case DIGITAL_MINER:
-                    return MekanismConfig.current().usage.digitalMinerUsage.val();
+                    return MekanismConfig.current().usage.digitalMiner.val();
                 case METALLURGIC_INFUSER:
-                    return MekanismConfig.current().usage.metallurgicInfuserUsage.val();
+                    return MekanismConfig.current().usage.metallurgicInfuser.val();
                 case PURIFICATION_CHAMBER:
-                    return MekanismConfig.current().usage.purificationChamberUsage.val();
+                    return MekanismConfig.current().usage.purificationChamber.val();
                 case ENERGIZED_SMELTER:
-                    return MekanismConfig.current().usage.energizedSmelterUsage.val();
+                    return MekanismConfig.current().usage.energizedSmelter.val();
                 case TELEPORTER:
                     return 12500;
                 case ELECTRIC_PUMP:
-                    return MekanismConfig.current().usage.electricPumpUsage.val();
+                    return MekanismConfig.current().usage.electricPump.val();
                 case PERSONAL_CHEST:
                     return 30;
                 case CHARGEPAD:
@@ -319,33 +310,33 @@ public class BlockStateMachine extends ExtendedBlockState {
                 case LOGISTICAL_SORTER:
                     return 0;
                 case ROTARY_CONDENSENTRATOR:
-                    return MekanismConfig.current().usage.rotaryCondensentratorUsage.val();
+                    return MekanismConfig.current().usage.rotaryCondensentrator.val();
                 case CHEMICAL_OXIDIZER:
-                    return MekanismConfig.current().usage.oxidationChamberUsage.val();
+                    return MekanismConfig.current().usage.oxidationChamber.val();
                 case CHEMICAL_INFUSER:
-                    return MekanismConfig.current().usage.chemicalInfuserUsage.val();
+                    return MekanismConfig.current().usage.chemicalInfuser.val();
                 case CHEMICAL_INJECTION_CHAMBER:
-                    return MekanismConfig.current().usage.chemicalInjectionChamberUsage.val();
+                    return MekanismConfig.current().usage.chemicalInjectionChamber.val();
                 case ELECTROLYTIC_SEPARATOR:
                     return MekanismConfig.current().general.FROM_H2.val() * 2;
                 case PRECISION_SAWMILL:
-                    return MekanismConfig.current().usage.precisionSawmillUsage.val();
+                    return MekanismConfig.current().usage.precisionSawmill.val();
                 case CHEMICAL_DISSOLUTION_CHAMBER:
-                    return MekanismConfig.current().usage.chemicalDissolutionChamberUsage.val();
+                    return MekanismConfig.current().usage.chemicalDissolutionChamber.val();
                 case CHEMICAL_WASHER:
-                    return MekanismConfig.current().usage.chemicalWasherUsage.val();
+                    return MekanismConfig.current().usage.chemicalWasher.val();
                 case CHEMICAL_CRYSTALLIZER:
-                    return MekanismConfig.current().usage.chemicalCrystallizerUsage.val();
+                    return MekanismConfig.current().usage.chemicalCrystallizer.val();
                 case SEISMIC_VIBRATOR:
-                    return MekanismConfig.current().usage.seismicVibratorUsage.val();
+                    return MekanismConfig.current().usage.seismicVibrator.val();
                 case PRESSURIZED_REACTION_CHAMBER:
-                    return MekanismConfig.current().usage.pressurizedReactionBaseUsage.val();
+                    return MekanismConfig.current().usage.pressurizedReactionBase.val();
                 case FLUID_TANK:
                     return 0;
                 case FLUIDIC_PLENISHER:
-                    return MekanismConfig.current().usage.fluidicPlenisherUsage.val();
+                    return MekanismConfig.current().usage.fluidicPlenisher.val();
                 case LASER:
-                    return MekanismConfig.current().usage.laserUsage.val();
+                    return MekanismConfig.current().usage.laser.val();
                 case LASER_AMPLIFIER:
                     return 0;
                 case LASER_TRACTOR_BEAM:
@@ -359,96 +350,71 @@ public class BlockStateMachine extends ExtendedBlockState {
                 case RESISTIVE_HEATER:
                     return 100;
                 case FORMULAIC_ASSEMBLICATOR:
-                    return MekanismConfig.current().usage.formulaicAssemblicatorUsage.val();
+                    return MekanismConfig.current().usage.formulaicAssemblicator.val();
                 default:
                     return 0;
-
+            }
+        }
+        
+        private double getConfigStorage() {
+            switch (this) {
+                case ENRICHMENT_CHAMBER:
+                    return MekanismConfig.current().storage.enrichmentChamber.val();
+                case OSMIUM_COMPRESSOR:
+                    return MekanismConfig.current().storage.osmiumCompressor.val();
+                case COMBINER:
+                    return MekanismConfig.current().storage.combiner.val();
+                case CRUSHER:
+                    return MekanismConfig.current().storage.crusher.val();
+                case DIGITAL_MINER:
+                    return MekanismConfig.current().storage.digitalMiner.val();
+                case METALLURGIC_INFUSER:
+                    return MekanismConfig.current().storage.metallurgicInfuser.val();
+                case PURIFICATION_CHAMBER:
+                    return MekanismConfig.current().storage.purificationChamber.val();
+                case ENERGIZED_SMELTER:
+                    return MekanismConfig.current().storage.energizedSmelter.val();
+                case TELEPORTER:
+                    return MekanismConfig.current().storage.teleporter.val();
+                case ELECTRIC_PUMP:
+                    return MekanismConfig.current().storage.electricPump.val();
+                case CHARGEPAD:
+                    return MekanismConfig.current().storage.chargePad.val();
+                case ROTARY_CONDENSENTRATOR:
+                    return MekanismConfig.current().storage.rotaryCondensentrator.val();
+                case CHEMICAL_OXIDIZER:
+                    return MekanismConfig.current().storage.oxidationChamber.val();
+                case CHEMICAL_INFUSER:
+                    return MekanismConfig.current().storage.chemicalInfuser.val();
+                case CHEMICAL_INJECTION_CHAMBER:
+                    return MekanismConfig.current().storage.chemicalInjectionChamber.val();
+                case ELECTROLYTIC_SEPARATOR:
+                    return MekanismConfig.current().storage.electrolyticSeparator.val();
+                case PRECISION_SAWMILL:
+                    return MekanismConfig.current().storage.precisionSawmill.val();
+                case CHEMICAL_DISSOLUTION_CHAMBER:
+                    return MekanismConfig.current().storage.chemicalDissolutionChamber.val();
+                case CHEMICAL_WASHER:
+                    return MekanismConfig.current().storage.chemicalWasher.val();
+                case CHEMICAL_CRYSTALLIZER:
+                    return MekanismConfig.current().storage.chemicalCrystallizer.val();
+                case SEISMIC_VIBRATOR:
+                    return MekanismConfig.current().storage.seismicVibrator.val();
+                case PRESSURIZED_REACTION_CHAMBER:
+                    return MekanismConfig.current().storage.pressurizedReactionBase.val();
+                case FLUIDIC_PLENISHER:
+                    return MekanismConfig.current().storage.fluidicPlenisher.val();
+                case LASER:
+                    return MekanismConfig.current().storage.laser.val();
+                case FORMULAIC_ASSEMBLICATOR:
+                    return MekanismConfig.current().storage.formulaicAssemblicator.val();
+                default:
+                    return 400 * getUsage();
             }
         }
 
-        public void updateUsage() {
-            double usage = getUsage(), storage;
-            switch (this) {
-                case ENRICHMENT_CHAMBER:
-                    storage = MekanismConfig.current().storage.enrichmentChamberStorage.val();
-                    break;
-                case OSMIUM_COMPRESSOR:
-                    storage = MekanismConfig.current().storage.osmiumCompressorStorage.val();
-                    break;
-                case COMBINER:
-                    storage = MekanismConfig.current().storage.combinerStorage.val();
-                    break;
-                case CRUSHER:
-                    storage = MekanismConfig.current().storage.crusherStorage.val();
-                    break;
-                case DIGITAL_MINER:
-                    storage = MekanismConfig.current().storage.digitalMinerStorage.val();
-                    break;
-                case METALLURGIC_INFUSER:
-                    storage = MekanismConfig.current().storage.metallurgicInfuserStorage.val();
-                    break;
-                case PURIFICATION_CHAMBER:
-                    storage = MekanismConfig.current().storage.purificationChamberStorage.val();
-                    break;
-                case ENERGIZED_SMELTER:
-                    storage = MekanismConfig.current().storage.energizedSmelterStorage.val();
-                    break;
-                case TELEPORTER:
-                    storage = MekanismConfig.current().storage.teleporterStorage.val();
-                    break;
-                case ELECTRIC_PUMP:
-                    storage = MekanismConfig.current().storage.electricPumpStorage.val();
-                    break;
-                case CHARGEPAD:
-                    storage = MekanismConfig.current().storage.chargePadStorage.val();
-                    break;
-                case ROTARY_CONDENSENTRATOR:
-                    storage = MekanismConfig.current().storage.rotaryCondensentratorStorage.val();
-                    break;
-                case CHEMICAL_OXIDIZER:
-                    storage = MekanismConfig.current().storage.oxidationChamberStorage.val();
-                    break;
-                case CHEMICAL_INFUSER:
-                    storage = MekanismConfig.current().storage.chemicalInfuserStorage.val();
-                    break;
-                case CHEMICAL_INJECTION_CHAMBER:
-                    storage = MekanismConfig.current().storage.chemicalInjectionChamberStorage.val();
-                    break;
-                case ELECTROLYTIC_SEPARATOR:
-                    storage = MekanismConfig.current().storage.electrolyticSeparatorStorage.val();
-                    break;
-                case PRECISION_SAWMILL:
-                    storage = MekanismConfig.current().storage.precisionSawmillStorage.val();
-                    break;
-                case CHEMICAL_DISSOLUTION_CHAMBER:
-                    storage = MekanismConfig.current().storage.chemicalDissolutionChamberStorage.val();
-                    break;
-                case CHEMICAL_WASHER:
-                    storage = MekanismConfig.current().storage.chemicalWasherStorage.val();
-                    break;
-                case CHEMICAL_CRYSTALLIZER:
-                    storage = MekanismConfig.current().storage.chemicalCrystallizerStorage.val();
-                    break;
-                case SEISMIC_VIBRATOR:
-                    storage = MekanismConfig.current().storage.seismicVibratorStorage.val();
-                    break;
-                case PRESSURIZED_REACTION_CHAMBER:
-                    storage = MekanismConfig.current().storage.pressurizedReactionBaseStorage.val();
-                    break;
-                case FLUIDIC_PLENISHER:
-                    storage = MekanismConfig.current().storage.fluidicPlenisherStorage.val();
-                    break;
-                case LASER:
-                    storage = MekanismConfig.current().storage.laserStorage.val();
-                    break;
-                case FORMULAIC_ASSEMBLICATOR:
-                    storage = MekanismConfig.current().storage.formulaicAssemblicatorStorage.val();
-                    break;
-                default:
-                    storage = 400 * usage;
-                    break;
-            }
-            baseEnergy = Math.max(usage, storage);
+        public double getStorage() {
+            return Math.max(getConfigStorage(), getUsage());
         }
 
         public String getDescription() {

--- a/src/main/java/mekanism/common/block/states/BlockStateMachine.java
+++ b/src/main/java/mekanism/common/block/states/BlockStateMachine.java
@@ -367,7 +367,88 @@ public class BlockStateMachine extends ExtendedBlockState {
         }
 
         public void updateUsage() {
-            baseEnergy = 400 * getUsage();
+            double usage = getUsage(), storage;
+            switch (this) {
+                case ENRICHMENT_CHAMBER:
+                    storage = MekanismConfig.current().storage.enrichmentChamberStorage.val();
+                    break;
+                case OSMIUM_COMPRESSOR:
+                    storage = MekanismConfig.current().storage.osmiumCompressorStorage.val();
+                    break;
+                case COMBINER:
+                    storage = MekanismConfig.current().storage.combinerStorage.val();
+                    break;
+                case CRUSHER:
+                    storage = MekanismConfig.current().storage.crusherStorage.val();
+                    break;
+                case DIGITAL_MINER:
+                    storage = MekanismConfig.current().storage.digitalMinerStorage.val();
+                    break;
+                case METALLURGIC_INFUSER:
+                    storage = MekanismConfig.current().storage.metallurgicInfuserStorage.val();
+                    break;
+                case PURIFICATION_CHAMBER:
+                    storage = MekanismConfig.current().storage.purificationChamberStorage.val();
+                    break;
+                case ENERGIZED_SMELTER:
+                    storage = MekanismConfig.current().storage.energizedSmelterStorage.val();
+                    break;
+                case TELEPORTER:
+                    storage = MekanismConfig.current().storage.teleporterStorage.val();
+                    break;
+                case ELECTRIC_PUMP:
+                    storage = MekanismConfig.current().storage.electricPumpStorage.val();
+                    break;
+                case CHARGEPAD:
+                    storage = MekanismConfig.current().storage.chargePadStorage.val();
+                    break;
+                case ROTARY_CONDENSENTRATOR:
+                    storage = MekanismConfig.current().storage.rotaryCondensentratorStorage.val();
+                    break;
+                case CHEMICAL_OXIDIZER:
+                    storage = MekanismConfig.current().storage.oxidationChamberStorage.val();
+                    break;
+                case CHEMICAL_INFUSER:
+                    storage = MekanismConfig.current().storage.chemicalInfuserStorage.val();
+                    break;
+                case CHEMICAL_INJECTION_CHAMBER:
+                    storage = MekanismConfig.current().storage.chemicalInjectionChamberStorage.val();
+                    break;
+                case ELECTROLYTIC_SEPARATOR:
+                    storage = MekanismConfig.current().storage.electrolyticSeparatorStorage.val();
+                    break;
+                case PRECISION_SAWMILL:
+                    storage = MekanismConfig.current().storage.precisionSawmillStorage.val();
+                    break;
+                case CHEMICAL_DISSOLUTION_CHAMBER:
+                    storage = MekanismConfig.current().storage.chemicalDissolutionChamberStorage.val();
+                    break;
+                case CHEMICAL_WASHER:
+                    storage = MekanismConfig.current().storage.chemicalWasherStorage.val();
+                    break;
+                case CHEMICAL_CRYSTALLIZER:
+                    storage = MekanismConfig.current().storage.chemicalCrystallizerStorage.val();
+                    break;
+                case SEISMIC_VIBRATOR:
+                    storage = MekanismConfig.current().storage.seismicVibratorStorage.val();
+                    break;
+                case PRESSURIZED_REACTION_CHAMBER:
+                    storage = MekanismConfig.current().storage.pressurizedReactionBaseStorage.val();
+                    break;
+                case FLUIDIC_PLENISHER:
+                    storage = MekanismConfig.current().storage.fluidicPlenisherStorage.val();
+                    break;
+                case LASER:
+                    storage = MekanismConfig.current().storage.laserStorage.val();
+                    break;
+                case FORMULAIC_ASSEMBLICATOR:
+                    storage = MekanismConfig.current().storage.formulaicAssemblicatorStorage.val();
+                    break;
+                default:
+                    storage = 400 * usage;
+                    break;
+            }
+            baseEnergy = Math.max(usage, storage);
         }
 
         public String getDescription() {

--- a/src/main/java/mekanism/common/config/MekanismConfig.java
+++ b/src/main/java/mekanism/common/config/MekanismConfig.java
@@ -38,6 +38,7 @@ public class MekanismConfig {
     public GeneralConfig general = new GeneralConfig();
     public ClientConfig client = new ClientConfig();
     public UsageConfig usage = new UsageConfig();
+    public StorageConfig storage = new StorageConfig();
 
     public GeneratorsConfig generators = Loader.isModLoaded(MekanismGenerators.MODID) ? new GeneratorsConfig() : null;
 

--- a/src/main/java/mekanism/common/config/StorageConfig.java
+++ b/src/main/java/mekanism/common/config/StorageConfig.java
@@ -1,0 +1,82 @@
+package mekanism.common.config;
+
+import mekanism.common.config.options.DoubleOption;
+
+public class StorageConfig extends BaseConfig {
+
+    public final DoubleOption enrichmentChamberStorage = new DoubleOption(this, "storage",
+            "EnrichmentChamberStorage", 20000D, "Base energy storage (Joules).");
+
+    public final DoubleOption osmiumCompressorStorage = new DoubleOption(this, "storage",
+            "OsmiumCompressorStorage", 80000D, "Base energy storage (Joules).");
+
+    public final DoubleOption combinerStorage = new DoubleOption(this, "storage",
+            "CombinerStorage", 40000D, "Base energy storage (Joules).");
+
+    public final DoubleOption crusherStorage = new DoubleOption(this, "storage",
+            "CrusherStorage", 20000D, "Base energy storage (Joules).");
+
+    public final DoubleOption metallurgicInfuserStorage = new DoubleOption(this, "storage",
+            "MetallurgicInfuserStorage", 20000D, "Base energy storage (Joules).");
+
+    public final DoubleOption purificationChamberStorage = new DoubleOption(this, "storage",
+            "PurificationChamberStorage", 80000D, "Base energy storage (Joules).");
+
+    public final DoubleOption energizedSmelterStorage = new DoubleOption(this, "storage",
+            "EnergizedSmelterStorage", 20000D, "Base energy storage (Joules).");
+
+    public final DoubleOption digitalMinerStorage = new DoubleOption(this, "storage",
+            "DigitalMinerStorage", 40000D, "Base energy storage (Joules).");
+
+    public final DoubleOption electricPumpStorage = new DoubleOption(this, "storage",
+            "ElectricPumpStorage", 40000D, "Base energy storage (Joules).");
+
+    public final DoubleOption chargePadStorage = new DoubleOption(this, "storage",
+            "ChargePadStorage", 40000D, "Base energy storage (Joules).");
+
+    public final DoubleOption rotaryCondensentratorStorage = new DoubleOption(this, "storage",
+            "RotaryCondensentratorStorage", 20000D, "Base energy storage (Joules).");
+
+    public final DoubleOption oxidationChamberStorage = new DoubleOption(this, "storage",
+            "OxidationChamberStorage", 80000D, "Base energy storage (Joules).");
+
+    public final DoubleOption chemicalInfuserStorage = new DoubleOption(this, "storage",
+            "ChemicalInfuserStorage", 80000D, "Base energy storage (Joules).");
+
+    public final DoubleOption chemicalInjectionChamberStorage = new DoubleOption(this, "storage",
+            "ChemicalInjectionChamberStorage", 160000D, "Base energy storage (Joules).");
+
+    public final DoubleOption electrolyticSeparatorStorage = new DoubleOption(this, "storage",
+            "ElectrolyticSeparatorStorage", 160000D, "Base energy storage (Joules).");
+
+    public final DoubleOption precisionSawmillStorage = new DoubleOption(this, "storage",
+            "PrecisionSawmillStorage", 20000D, "Base energy storage (Joules).");
+
+    public final DoubleOption chemicalDissolutionChamberStorage = new DoubleOption(this, "storage",
+            "ChemicalDissolutionChamberStorage", 160000D, "Base energy storage (Joules).");
+
+    public final DoubleOption chemicalWasherStorage = new DoubleOption(this, "storage",
+            "ChemicalWasherStorage", 80000D, "Base energy storage (Joules).");
+
+    public final DoubleOption chemicalCrystallizerStorage = new DoubleOption(this, "storage",
+            "ChemicalCrystallizerStorage", 160000D, "Base energy storage (Joules).");
+
+    public final DoubleOption seismicVibratorStorage = new DoubleOption(this, "storage",
+            "SeismicVibratorStorage", 20000D, "Base energy storage (Joules).");
+
+    public final DoubleOption pressurizedReactionBaseStorage = new DoubleOption(this, "storage",
+            "PressurizedReactionBaseStorage", 2000D, "Base energy storage (Joules).");
+
+    public final DoubleOption fluidicPlenisherStorage = new DoubleOption(this, "storage",
+            "FluidicPlenisherStorage", 40000D, "Base energy storage (Joules).");
+
+    public final DoubleOption laserStorage = new DoubleOption(this, "storage",
+            "LaserStorage", 2000000D, "Base energy storage (Joules).");
+
+    public final DoubleOption formulaicAssemblicatorStorage = new DoubleOption(this, "storage",
+            "FormulaicAssemblicatorStorage", 40000D, "Base energy storage (Joules).");
+
+    public final DoubleOption teleporterStorage = new DoubleOption(this, "storage",
+            "TeleporterStorage", 5000000D, "Base energy storage (Joules).");
+
+}

--- a/src/main/java/mekanism/common/config/StorageConfig.java
+++ b/src/main/java/mekanism/common/config/StorageConfig.java
@@ -4,79 +4,79 @@ import mekanism.common.config.options.DoubleOption;
 
 public class StorageConfig extends BaseConfig {
 
-    public final DoubleOption enrichmentChamberStorage = new DoubleOption(this, "storage",
+    public final DoubleOption enrichmentChamber = new DoubleOption(this, "storage",
             "EnrichmentChamberStorage", 20000D, "Base energy storage (Joules).");
 
-    public final DoubleOption osmiumCompressorStorage = new DoubleOption(this, "storage",
+    public final DoubleOption osmiumCompressor = new DoubleOption(this, "storage",
             "OsmiumCompressorStorage", 80000D, "Base energy storage (Joules).");
 
-    public final DoubleOption combinerStorage = new DoubleOption(this, "storage",
+    public final DoubleOption combiner = new DoubleOption(this, "storage",
             "CombinerStorage", 40000D, "Base energy storage (Joules).");
 
-    public final DoubleOption crusherStorage = new DoubleOption(this, "storage",
+    public final DoubleOption crusher = new DoubleOption(this, "storage",
             "CrusherStorage", 20000D, "Base energy storage (Joules).");
 
-    public final DoubleOption metallurgicInfuserStorage = new DoubleOption(this, "storage",
+    public final DoubleOption metallurgicInfuser = new DoubleOption(this, "storage",
             "MetallurgicInfuserStorage", 20000D, "Base energy storage (Joules).");
 
-    public final DoubleOption purificationChamberStorage = new DoubleOption(this, "storage",
+    public final DoubleOption purificationChamber = new DoubleOption(this, "storage",
             "PurificationChamberStorage", 80000D, "Base energy storage (Joules).");
 
-    public final DoubleOption energizedSmelterStorage = new DoubleOption(this, "storage",
+    public final DoubleOption energizedSmelter = new DoubleOption(this, "storage",
             "EnergizedSmelterStorage", 20000D, "Base energy storage (Joules).");
 
-    public final DoubleOption digitalMinerStorage = new DoubleOption(this, "storage",
+    public final DoubleOption digitalMiner = new DoubleOption(this, "storage",
             "DigitalMinerStorage", 40000D, "Base energy storage (Joules).");
 
-    public final DoubleOption electricPumpStorage = new DoubleOption(this, "storage",
+    public final DoubleOption electricPump = new DoubleOption(this, "storage",
             "ElectricPumpStorage", 40000D, "Base energy storage (Joules).");
 
-    public final DoubleOption chargePadStorage = new DoubleOption(this, "storage",
+    public final DoubleOption chargePad = new DoubleOption(this, "storage",
             "ChargePadStorage", 40000D, "Base energy storage (Joules).");
 
-    public final DoubleOption rotaryCondensentratorStorage = new DoubleOption(this, "storage",
+    public final DoubleOption rotaryCondensentrator = new DoubleOption(this, "storage",
             "RotaryCondensentratorStorage", 20000D, "Base energy storage (Joules).");
 
-    public final DoubleOption oxidationChamberStorage = new DoubleOption(this, "storage",
+    public final DoubleOption oxidationChamber = new DoubleOption(this, "storage",
             "OxidationChamberStorage", 80000D, "Base energy storage (Joules).");
 
-    public final DoubleOption chemicalInfuserStorage = new DoubleOption(this, "storage",
+    public final DoubleOption chemicalInfuser = new DoubleOption(this, "storage",
             "ChemicalInfuserStorage", 80000D, "Base energy storage (Joules).");
 
-    public final DoubleOption chemicalInjectionChamberStorage = new DoubleOption(this, "storage",
+    public final DoubleOption chemicalInjectionChamber = new DoubleOption(this, "storage",
             "ChemicalInjectionChamberStorage", 160000D, "Base energy storage (Joules).");
 
-    public final DoubleOption electrolyticSeparatorStorage = new DoubleOption(this, "storage",
+    public final DoubleOption electrolyticSeparator = new DoubleOption(this, "storage",
             "ElectrolyticSeparatorStorage", 160000D, "Base energy storage (Joules).");
 
-    public final DoubleOption precisionSawmillStorage = new DoubleOption(this, "storage",
+    public final DoubleOption precisionSawmill = new DoubleOption(this, "storage",
             "PrecisionSawmillStorage", 20000D, "Base energy storage (Joules).");
 
-    public final DoubleOption chemicalDissolutionChamberStorage = new DoubleOption(this, "storage",
+    public final DoubleOption chemicalDissolutionChamber = new DoubleOption(this, "storage",
             "ChemicalDissolutionChamberStorage", 160000D, "Base energy storage (Joules).");
 
-    public final DoubleOption chemicalWasherStorage = new DoubleOption(this, "storage",
+    public final DoubleOption chemicalWasher = new DoubleOption(this, "storage",
             "ChemicalWasherStorage", 80000D, "Base energy storage (Joules).");
 
-    public final DoubleOption chemicalCrystallizerStorage = new DoubleOption(this, "storage",
+    public final DoubleOption chemicalCrystallizer = new DoubleOption(this, "storage",
             "ChemicalCrystallizerStorage", 160000D, "Base energy storage (Joules).");
 
-    public final DoubleOption seismicVibratorStorage = new DoubleOption(this, "storage",
+    public final DoubleOption seismicVibrator = new DoubleOption(this, "storage",
             "SeismicVibratorStorage", 20000D, "Base energy storage (Joules).");
 
-    public final DoubleOption pressurizedReactionBaseStorage = new DoubleOption(this, "storage",
+    public final DoubleOption pressurizedReactionBase = new DoubleOption(this, "storage",
             "PressurizedReactionBaseStorage", 2000D, "Base energy storage (Joules).");
 
-    public final DoubleOption fluidicPlenisherStorage = new DoubleOption(this, "storage",
+    public final DoubleOption fluidicPlenisher = new DoubleOption(this, "storage",
             "FluidicPlenisherStorage", 40000D, "Base energy storage (Joules).");
 
-    public final DoubleOption laserStorage = new DoubleOption(this, "storage",
+    public final DoubleOption laser = new DoubleOption(this, "storage",
             "LaserStorage", 2000000D, "Base energy storage (Joules).");
 
-    public final DoubleOption formulaicAssemblicatorStorage = new DoubleOption(this, "storage",
+    public final DoubleOption formulaicAssemblicator = new DoubleOption(this, "storage",
             "FormulaicAssemblicatorStorage", 40000D, "Base energy storage (Joules).");
 
-    public final DoubleOption teleporterStorage = new DoubleOption(this, "storage",
+    public final DoubleOption teleporter = new DoubleOption(this, "storage",
             "TeleporterStorage", 5000000D, "Base energy storage (Joules).");
 
 }

--- a/src/main/java/mekanism/common/config/UsageConfig.java
+++ b/src/main/java/mekanism/common/config/UsageConfig.java
@@ -8,80 +8,80 @@ import mekanism.common.config.options.IntOption;
  */
 public class UsageConfig extends BaseConfig {
 
-    public final DoubleOption enrichmentChamberUsage = new DoubleOption(this, "usage", "EnrichmentChamberUsage", 50D,
+    public final DoubleOption enrichmentChamber = new DoubleOption(this, "usage", "EnrichmentChamberUsage", 50D,
           "Energy per operation tick (Joules).");
 
-    public final DoubleOption osmiumCompressorUsage = new DoubleOption(this, "usage", "OsmiumCompressorUsage", 100D,
+    public final DoubleOption osmiumCompressor = new DoubleOption(this, "usage", "OsmiumCompressorUsage", 100D,
           "Energy per operation tick (Joules).");
 
-    public final DoubleOption combinerUsage = new DoubleOption(this, "usage", "CombinerUsage", 50D,
+    public final DoubleOption combiner = new DoubleOption(this, "usage", "CombinerUsage", 50D,
           "Energy per operation tick (Joules).");
 
-    public final DoubleOption crusherUsage = new DoubleOption(this, "usage", "CrusherUsage", 50D,
+    public final DoubleOption crusher = new DoubleOption(this, "usage", "CrusherUsage", 50D,
           "Energy per operation tick (Joules).");
 
-    public final DoubleOption metallurgicInfuserUsage = new DoubleOption(this, "usage", "MetallurgicInfuserUsage", 50D,
+    public final DoubleOption metallurgicInfuser = new DoubleOption(this, "usage", "MetallurgicInfuserUsage", 50D,
           "Energy per operation tick (Joules).");
 
-    public final DoubleOption purificationChamberUsage = new DoubleOption(this, "usage", "PurificationChamberUsage",
+    public final DoubleOption purificationChamber = new DoubleOption(this, "usage", "PurificationChamberUsage",
           200D, "Energy per operation tick (Joules).");
 
-    public final DoubleOption energizedSmelterUsage = new DoubleOption(this, "usage", "EnergizedSmelterUsage", 50D,
+    public final DoubleOption energizedSmelter = new DoubleOption(this, "usage", "EnergizedSmelterUsage", 50D,
           "Energy per operation tick (Joules).");
 
-    public final DoubleOption digitalMinerUsage = new DoubleOption(this, "usage", "DigitalMinerUsage", 100D,
+    public final DoubleOption digitalMiner = new DoubleOption(this, "usage", "DigitalMinerUsage", 100D,
           "Energy per operation tick (Joules).");
 
-    public final DoubleOption electricPumpUsage = new DoubleOption(this, "usage", "ElectricPumpUsage", 100D,
+    public final DoubleOption electricPump = new DoubleOption(this, "usage", "ElectricPumpUsage", 100D,
           "Energy per operation tick (Joules).");
 
-    public final DoubleOption rotaryCondensentratorUsage = new DoubleOption(this, "usage", "RotaryCondensentratorUsage",
+    public final DoubleOption rotaryCondensentrator = new DoubleOption(this, "usage", "RotaryCondensentratorUsage",
           50D, "Energy per operation tick (Joules).");
 
-    public final DoubleOption oxidationChamberUsage = new DoubleOption(this, "usage", "OxidationChamberUsage", 200D,
+    public final DoubleOption oxidationChamber = new DoubleOption(this, "usage", "OxidationChamberUsage", 200D,
           "Energy per operation tick (Joules).");
 
-    public final DoubleOption chemicalInfuserUsage = new DoubleOption(this, "usage", "ChemicalInfuserUsage", 200D,
+    public final DoubleOption chemicalInfuser = new DoubleOption(this, "usage", "ChemicalInfuserUsage", 200D,
           "Energy per operation tick (Joules).");
 
-    public final DoubleOption chemicalInjectionChamberUsage = new DoubleOption(this, "usage",
+    public final DoubleOption chemicalInjectionChamber = new DoubleOption(this, "usage",
           "ChemicalInjectionChamberUsage", 400D, "Energy per operation tick (Joules).");
 
-    public final DoubleOption precisionSawmillUsage = new DoubleOption(this, "usage", "PrecisionSawmillUsage", 50D,
+    public final DoubleOption precisionSawmill = new DoubleOption(this, "usage", "PrecisionSawmillUsage", 50D,
           "Energy per operation tick (Joules).");
 
-    public final DoubleOption chemicalDissolutionChamberUsage = new DoubleOption(this, "usage",
+    public final DoubleOption chemicalDissolutionChamber = new DoubleOption(this, "usage",
           "ChemicalDissolutionChamberUsage", 400D, "Energy per operation tick (Joules).");
 
-    public final DoubleOption chemicalWasherUsage = new DoubleOption(this, "usage", "ChemicalWasherUsage", 200D,
+    public final DoubleOption chemicalWasher = new DoubleOption(this, "usage", "ChemicalWasherUsage", 200D,
           "Energy per operation tick (Joules).");
 
-    public final DoubleOption chemicalCrystallizerUsage = new DoubleOption(this, "usage", "ChemicalCrystallizerUsage",
+    public final DoubleOption chemicalCrystallizer = new DoubleOption(this, "usage", "ChemicalCrystallizerUsage",
           400D, "Energy per operation tick (Joules).");
 
-    public final DoubleOption seismicVibratorUsage = new DoubleOption(this, "usage", "SeismicVibratorUsage", 50D,
+    public final DoubleOption seismicVibrator = new DoubleOption(this, "usage", "SeismicVibratorUsage", 50D,
           "Energy per operation tick (Joules).");
 
-    public final DoubleOption pressurizedReactionBaseUsage = new DoubleOption(this, "usage",
+    public final DoubleOption pressurizedReactionBase = new DoubleOption(this, "usage",
           "PressurizedReactionBaseUsage", 5D, "Energy per operation tick (Joules).");
 
-    public final DoubleOption fluidicPlenisherUsage = new DoubleOption(this, "usage", "FluidicPlenisherUsage", 100D,
+    public final DoubleOption fluidicPlenisher = new DoubleOption(this, "usage", "FluidicPlenisherUsage", 100D,
           "Energy per operation tick (Joules).");
 
-    public final DoubleOption laserUsage = new DoubleOption(this, "usage", "LaserUsage", 5000D,
+    public final DoubleOption laser = new DoubleOption(this, "usage", "LaserUsage", 5000D,
           "Energy per operation tick (Joules).");
 
-    public final DoubleOption heavyWaterElectrolysisUsage = new DoubleOption(this, "usage",
+    public final DoubleOption heavyWaterElectrolysis = new DoubleOption(this, "usage",
           "HeavyWaterElectrolysisUsage", 800D,
           "Energy needed for one [recipe unit] of heavy water production (Joules).");
 
-    public final DoubleOption formulaicAssemblicatorUsage = new DoubleOption(this, "usage",
+    public final DoubleOption formulaicAssemblicator = new DoubleOption(this, "usage",
           "FormulaicAssemblicatorUsage", 100D, "Energy per operation tick (Joules).");
 
-    public final IntOption teleporterBaseUsage = new IntOption(this, "usage", "TeleporterBaseUsage", 1000,
+    public final IntOption teleporterBase = new IntOption(this, "usage", "TeleporterBaseUsage", 1000,
           "Base Joules cost for a teleportation.");
 
-    public final IntOption teleporterDistanceUsage = new IntOption(this, "usage", "TeleporterDistanceUsage", 10,
+    public final IntOption teleporterDistance = new IntOption(this, "usage", "TeleporterDistanceUsage", 10,
           "Joules per unit of distance travelled during teleportation - sqrt(xDiff^2 + yDiff^2 + zDiff^2).");
 
     public final IntOption teleporterDimensionPenalty = new IntOption(this, "usage", "TeleporterDimensionPenalty",

--- a/src/main/java/mekanism/common/item/ItemBlockMachine.java
+++ b/src/main/java/mekanism/common/item/ItemBlockMachine.java
@@ -644,7 +644,10 @@ public class ItemBlockMachine extends ItemBlock implements IEnergizedItem, ISpec
         if (machineType.isFactory()) {
             RecipeType recipeType = getRecipeTypeOrNull(itemStack);
             int tierProcess = machineType.factoryTier.processes;
-            double baseMaxEnergy = 0.5D * tierProcess * (recipeType == null ? 1 : recipeType.getEnergyStorage());
+            double baseMaxEnergy = tierProcess *
+                    (recipeType == null ? 1 :
+                            Math.max(0.5D * recipeType.getEnergyStorage(), recipeType.getEnergyUsage())
+                    );
 
             return MekanismUtils.getMaxEnergy(itemStack, baseMaxEnergy);
         }

--- a/src/main/java/mekanism/common/item/ItemBlockMachine.java
+++ b/src/main/java/mekanism/common/item/ItemBlockMachine.java
@@ -642,15 +642,14 @@ public class ItemBlockMachine extends ItemBlock implements IEnergizedItem, ISpec
               .get(Block.getBlockFromItem(itemStack.getItem()), itemStack.getItemDamage());
 
         if (machineType.isFactory()) {
-            // 200*tier.processes*recipeType.getEnergyUsage(); // From TileEntityFactory
             RecipeType recipeType = getRecipeTypeOrNull(itemStack);
             int tierProcess = machineType.factoryTier.processes;
-            double baseMaxEnergy = 200 * tierProcess * (recipeType == null ? 1 : recipeType.getEnergyUsage());
+            double baseMaxEnergy = 0.5D * tierProcess * (recipeType == null ? 1 : recipeType.getEnergyStorage());
 
             return MekanismUtils.getMaxEnergy(itemStack, baseMaxEnergy);
         }
 
-        return MekanismUtils.getMaxEnergy(itemStack, machineType.baseEnergy);
+        return MekanismUtils.getMaxEnergy(itemStack, machineType.getStorage());
     }
 
     @Override

--- a/src/main/java/mekanism/common/item/ItemPortableTeleporter.java
+++ b/src/main/java/mekanism/common/item/ItemPortableTeleporter.java
@@ -39,13 +39,13 @@ public class ItemPortableTeleporter extends ItemEnergized implements IOwnerItem 
             return 0;
         }
 
-        int neededEnergy = MekanismConfig.current().usage.teleporterBaseUsage.val();
+        int neededEnergy = MekanismConfig.current().usage.teleporterBase.val();
 
         if (entity.world.provider.getDimension() != coords.dimensionId) {
             neededEnergy += MekanismConfig.current().usage.teleporterDimensionPenalty.val();
         } else {
             int distance = (int) entity.getDistance(coords.x, coords.y, coords.z);
-            neededEnergy += (distance * MekanismConfig.current().usage.teleporterDistanceUsage.val());
+            neededEnergy += (distance * MekanismConfig.current().usage.teleporterDistance.val());
         }
 
         return neededEnergy;

--- a/src/main/java/mekanism/common/network/PacketConfigSync.java
+++ b/src/main/java/mekanism/common/network/PacketConfigSync.java
@@ -39,6 +39,7 @@ public class PacketConfigSync implements IMessageHandler<ConfigSyncMessage, IMes
         public void toBytes(ByteBuf dataStream) {
             config.general.write(dataStream);
             config.usage.write(dataStream);
+            config.storage.write(dataStream);
 
             try {
                 for (IModule module : Mekanism.modulesLoaded) {
@@ -53,6 +54,7 @@ public class PacketConfigSync implements IMessageHandler<ConfigSyncMessage, IMes
         public void fromBytes(ByteBuf dataStream) {
             config.general.read(dataStream);
             config.usage.read(dataStream);
+            config.storage.read(dataStream);
 
             try {
                 for (IModule module : Mekanism.modulesLoaded) {

--- a/src/main/java/mekanism/common/tile/TileEntityChanceMachine.java
+++ b/src/main/java/mekanism/common/tile/TileEntityChanceMachine.java
@@ -27,9 +27,9 @@ public abstract class TileEntityChanceMachine<RECIPE extends ChanceMachineRecipe
     private static final String[] methods = new String[]{"getEnergy", "getProgress", "isActive", "facing", "canOperate",
           "getMaxEnergy", "getEnergyNeeded"};
 
-    public TileEntityChanceMachine(String soundPath, String name, double maxEnergy, double baseEnergyUsage,
+    public TileEntityChanceMachine(String soundPath, String name, double baseMaxEnergy, double baseEnergyUsage,
           int ticksRequired, ResourceLocation location) {
-        super(soundPath, name, maxEnergy, baseEnergyUsage, 3, ticksRequired, location);
+        super(soundPath, name, baseMaxEnergy, baseEnergyUsage, 3, ticksRequired, location);
 
         configComponent = new TileComponentConfig(this, TransmissionType.ITEM, TransmissionType.ENERGY);
 

--- a/src/main/java/mekanism/common/tile/TileEntityChargepad.java
+++ b/src/main/java/mekanism/common/tile/TileEntityChargepad.java
@@ -37,7 +37,7 @@ public class TileEntityChargepad extends TileEntityEffectsBlock {
     public Random random = new Random();
 
     public TileEntityChargepad() {
-        super("machine.chargepad", "Chargepad", MachineType.CHARGEPAD.baseEnergy);
+        super("machine.chargepad", "Chargepad", MachineType.CHARGEPAD.getStorage());
         inventory = NonNullList.withSize(0, ItemStack.EMPTY);
     }
 

--- a/src/main/java/mekanism/common/tile/TileEntityChemicalCrystallizer.java
+++ b/src/main/java/mekanism/common/tile/TileEntityChemicalCrystallizer.java
@@ -18,7 +18,6 @@ import mekanism.common.base.ISustainedData;
 import mekanism.common.base.ITankManager;
 import mekanism.common.block.states.BlockStateMachine.MachineType;
 import mekanism.common.capabilities.Capabilities;
-import mekanism.common.config.MekanismConfig;
 import mekanism.common.recipe.RecipeHandler;
 import mekanism.common.recipe.inputs.GasInput;
 import mekanism.common.recipe.machines.CrystallizerRecipe;
@@ -50,8 +49,9 @@ public class TileEntityChemicalCrystallizer extends TileEntityOperationalMachine
     public TileComponentConfig configComponent;
 
     public TileEntityChemicalCrystallizer() {
-        super("machine.crystallizer", "ChemicalCrystallizer", MachineType.CHEMICAL_CRYSTALLIZER.baseEnergy,
-              MekanismConfig.current().usage.chemicalCrystallizerUsage.val(), 3, 200);
+        super("machine.crystallizer", "ChemicalCrystallizer",
+                MachineType.CHEMICAL_CRYSTALLIZER.getStorage(),
+                MachineType.CHEMICAL_CRYSTALLIZER.getUsage(), 3, 200);
 
         configComponent = new TileComponentConfig(this, TransmissionType.ITEM, TransmissionType.ENERGY,
               TransmissionType.GAS);

--- a/src/main/java/mekanism/common/tile/TileEntityChemicalDissolutionChamber.java
+++ b/src/main/java/mekanism/common/tile/TileEntityChemicalDissolutionChamber.java
@@ -15,7 +15,6 @@ import mekanism.common.base.ISustainedData;
 import mekanism.common.base.ITankManager;
 import mekanism.common.block.states.BlockStateMachine.MachineType;
 import mekanism.common.capabilities.Capabilities;
-import mekanism.common.config.MekanismConfig;
 import mekanism.common.recipe.RecipeHandler;
 import mekanism.common.recipe.inputs.ItemStackInput;
 import mekanism.common.recipe.machines.DissolutionRecipe;
@@ -42,7 +41,7 @@ public class TileEntityChemicalDissolutionChamber extends TileEntityMachine impl
     public static final int MAX_GAS = 10000;
     public static final int BASE_INJECT_USAGE = 1;
     public static final int BASE_TICKS_REQUIRED = 100;
-    public final double BASE_ENERGY_USAGE = MekanismConfig.current().usage.chemicalDissolutionChamberUsage.val();
+    public final double BASE_ENERGY_USAGE = MachineType.CHEMICAL_DISSOLUTION_CHAMBER.getUsage();
     public GasTank injectTank = new GasTank(MAX_GAS);
     public GasTank outputTank = new GasTank(MAX_GAS);
     public double injectUsage = BASE_INJECT_USAGE;
@@ -54,8 +53,8 @@ public class TileEntityChemicalDissolutionChamber extends TileEntityMachine impl
 
     public TileEntityChemicalDissolutionChamber() {
         super("machine.dissolution", "ChemicalDissolutionChamber",
-              MachineType.CHEMICAL_DISSOLUTION_CHAMBER.baseEnergy,
-              MekanismConfig.current().usage.chemicalDissolutionChamberUsage.val(), 4);
+                MachineType.CHEMICAL_DISSOLUTION_CHAMBER.getStorage(),
+                MachineType.CHEMICAL_DISSOLUTION_CHAMBER.getUsage(), 4);
 
         inventory = NonNullList.withSize(5, ItemStack.EMPTY);
         upgradeComponent.setSupported(Upgrade.GAS);

--- a/src/main/java/mekanism/common/tile/TileEntityChemicalInfuser.java
+++ b/src/main/java/mekanism/common/tile/TileEntityChemicalInfuser.java
@@ -18,7 +18,6 @@ import mekanism.common.base.ITankManager;
 import mekanism.common.base.IUpgradeTile;
 import mekanism.common.block.states.BlockStateMachine.MachineType;
 import mekanism.common.capabilities.Capabilities;
-import mekanism.common.config.MekanismConfig;
 import mekanism.common.recipe.RecipeHandler;
 import mekanism.common.recipe.inputs.ChemicalPairInput;
 import mekanism.common.recipe.machines.ChemicalInfuserRecipe;
@@ -51,8 +50,9 @@ public class TileEntityChemicalInfuser extends TileEntityMachine implements IGas
     public double clientEnergyUsed;
 
     public TileEntityChemicalInfuser() {
-        super("machine.cheminfuser", "ChemicalInfuser", MachineType.CHEMICAL_INFUSER.baseEnergy,
-              MekanismConfig.current().usage.chemicalInfuserUsage.val(), 4);
+        super("machine.cheminfuser", "ChemicalInfuser",
+                MachineType.CHEMICAL_INFUSER.getStorage(),
+                MachineType.CHEMICAL_INFUSER.getUsage(), 4);
 
         inventory = NonNullList.withSize(5, ItemStack.EMPTY);
     }

--- a/src/main/java/mekanism/common/tile/TileEntityChemicalInjectionChamber.java
+++ b/src/main/java/mekanism/common/tile/TileEntityChemicalInjectionChamber.java
@@ -8,7 +8,6 @@ import mekanism.api.gas.IGasItem;
 import mekanism.api.transmitters.TransmissionType;
 import mekanism.common.SideData;
 import mekanism.common.block.states.BlockStateMachine.MachineType;
-import mekanism.common.config.MekanismConfig;
 import mekanism.common.recipe.RecipeHandler.Recipe;
 import mekanism.common.recipe.inputs.AdvancedMachineInput;
 import mekanism.common.recipe.machines.InjectionRecipe;
@@ -20,9 +19,9 @@ import net.minecraft.util.EnumFacing;
 public class TileEntityChemicalInjectionChamber extends TileEntityAdvancedElectricMachine<InjectionRecipe> {
 
     public TileEntityChemicalInjectionChamber() {
-        super("injection", "ChemicalInjectionChamber", MachineType.CHEMICAL_INJECTION_CHAMBER.baseEnergy,
-              MekanismConfig.current().usage.chemicalInjectionChamberUsage.val(),
-              BASE_TICKS_REQUIRED, BASE_GAS_PER_TICK);
+        super("injection", "ChemicalInjectionChamber",
+                MachineType.CHEMICAL_INJECTION_CHAMBER.getStorage(),
+                MachineType.CHEMICAL_INJECTION_CHAMBER.getUsage(), BASE_TICKS_REQUIRED, BASE_GAS_PER_TICK);
 
         configComponent.addSupported(TransmissionType.GAS);
         configComponent.addOutput(TransmissionType.GAS, new SideData("None", EnumColor.GREY, InventoryUtils.EMPTY));

--- a/src/main/java/mekanism/common/tile/TileEntityChemicalOxidizer.java
+++ b/src/main/java/mekanism/common/tile/TileEntityChemicalOxidizer.java
@@ -13,7 +13,6 @@ import mekanism.common.base.ISustainedData;
 import mekanism.common.base.ITankManager;
 import mekanism.common.block.states.BlockStateMachine.MachineType;
 import mekanism.common.capabilities.Capabilities;
-import mekanism.common.config.MekanismConfig;
 import mekanism.common.recipe.RecipeHandler;
 import mekanism.common.recipe.inputs.ItemStackInput;
 import mekanism.common.recipe.machines.OxidationRecipe;
@@ -42,8 +41,9 @@ public class TileEntityChemicalOxidizer extends TileEntityOperationalMachine imp
     public OxidationRecipe cachedRecipe;
 
     public TileEntityChemicalOxidizer() {
-        super("machine.oxidizer", "ChemicalOxidizer", MachineType.CHEMICAL_OXIDIZER.baseEnergy,
-              MekanismConfig.current().usage.rotaryCondensentratorUsage.val(), 3, 100);
+        super("machine.oxidizer", "ChemicalOxidizer",
+                MachineType.CHEMICAL_OXIDIZER.getStorage(),
+                MachineType.CHEMICAL_OXIDIZER.getUsage(), 3, 100);
 
         inventory = NonNullList.withSize(4, ItemStack.EMPTY);
     }

--- a/src/main/java/mekanism/common/tile/TileEntityChemicalWasher.java
+++ b/src/main/java/mekanism/common/tile/TileEntityChemicalWasher.java
@@ -19,7 +19,6 @@ import mekanism.common.base.ISustainedData;
 import mekanism.common.base.ITankManager;
 import mekanism.common.block.states.BlockStateMachine.MachineType;
 import mekanism.common.capabilities.Capabilities;
-import mekanism.common.config.MekanismConfig;
 import mekanism.common.recipe.RecipeHandler;
 import mekanism.common.recipe.inputs.GasInput;
 import mekanism.common.recipe.machines.WasherRecipe;
@@ -63,8 +62,9 @@ public class TileEntityChemicalWasher extends TileEntityMachine implements IGasH
     public double clientEnergyUsed;
 
     public TileEntityChemicalWasher() {
-        super("machine.washer", "ChemicalWasher", MachineType.CHEMICAL_WASHER.baseEnergy,
-              MekanismConfig.current().usage.chemicalWasherUsage.val(), 4);
+        super("machine.washer", "ChemicalWasher",
+                MachineType.CHEMICAL_WASHER.getStorage(),
+                MachineType.CHEMICAL_WASHER.getUsage(), 4);
         inventory = NonNullList.withSize(5, ItemStack.EMPTY);
     }
 

--- a/src/main/java/mekanism/common/tile/TileEntityCombiner.java
+++ b/src/main/java/mekanism/common/tile/TileEntityCombiner.java
@@ -2,7 +2,6 @@ package mekanism.common.tile;
 
 import java.util.Map;
 import mekanism.common.block.states.BlockStateMachine.MachineType;
-import mekanism.common.config.MekanismConfig;
 import mekanism.common.recipe.RecipeHandler.Recipe;
 import mekanism.common.recipe.inputs.DoubleMachineInput;
 import mekanism.common.recipe.machines.CombinerRecipe;
@@ -11,8 +10,9 @@ import mekanism.common.tile.prefab.TileEntityDoubleElectricMachine;
 public class TileEntityCombiner extends TileEntityDoubleElectricMachine<CombinerRecipe> {
 
     public TileEntityCombiner() {
-        super("combiner", "Combiner", MachineType.COMBINER.baseEnergy,
-              MekanismConfig.current().usage.combinerUsage.val(), 200);
+        super("combiner", "Combiner",
+                MachineType.COMBINER.getStorage(),
+                MachineType.COMBINER.getUsage(), 200);
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/TileEntityCrusher.java
+++ b/src/main/java/mekanism/common/tile/TileEntityCrusher.java
@@ -2,7 +2,6 @@ package mekanism.common.tile;
 
 import java.util.Map;
 import mekanism.common.block.states.BlockStateMachine.MachineType;
-import mekanism.common.config.MekanismConfig;
 import mekanism.common.recipe.RecipeHandler.Recipe;
 import mekanism.common.recipe.inputs.ItemStackInput;
 import mekanism.common.recipe.machines.CrusherRecipe;
@@ -11,8 +10,9 @@ import mekanism.common.tile.prefab.TileEntityElectricMachine;
 public class TileEntityCrusher extends TileEntityElectricMachine<CrusherRecipe> {
 
     public TileEntityCrusher() {
-        super("crusher", "Crusher", MachineType.CRUSHER.baseEnergy,
-              MekanismConfig.current().usage.crusherUsage.val(), 200);
+        super("crusher", "Crusher",
+                MachineType.CRUSHER.getStorage(),
+                MachineType.CRUSHER.getUsage(), 200);
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
+++ b/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
@@ -83,12 +83,12 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
     private static final int[] INV_SLOTS = IntStream.range(0, 28).toArray();
 
     public static int[] EJECT_INV;
-    public final double BASE_ENERGY_USAGE = MekanismConfig.current().usage.digitalMinerUsage.val();
     public Map<Chunk3D, BitSet> oresToMine = new HashMap<>();
     public Map<Integer, MinerFilter> replaceMap = new HashMap<>();
     public HashList<MinerFilter> filters = new HashList<>();
     public ThreadMinerSearch searcher = new ThreadMinerSearch(this);
-    public double energyUsage = MekanismConfig.current().usage.digitalMinerUsage.val();
+    public final double BASE_ENERGY_USAGE = MachineType.DIGITAL_MINER.getUsage();
+    public double energyUsage = BASE_ENERGY_USAGE;
 
     private int radius;
 
@@ -141,7 +141,7 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
           "removeOreFilter", "reset", "start", "stop", "getToMine"};
 
     public TileEntityDigitalMiner() {
-        super("DigitalMiner", MachineType.DIGITAL_MINER.baseEnergy);
+        super("DigitalMiner", MachineType.DIGITAL_MINER.getStorage());
         inventory = NonNullList.withSize(INV_SLOTS.length + 1, ItemStack.EMPTY);
         radius = 10;
 

--- a/src/main/java/mekanism/common/tile/TileEntityElectricPump.java
+++ b/src/main/java/mekanism/common/tile/TileEntityElectricPump.java
@@ -21,6 +21,7 @@ import mekanism.common.base.IRedstoneControl;
 import mekanism.common.base.ISustainedTank;
 import mekanism.common.base.ITankManager;
 import mekanism.common.base.IUpgradeTile;
+import mekanism.common.block.states.BlockStateMachine.MachineType;
 import mekanism.common.capabilities.Capabilities;
 import mekanism.common.config.MekanismConfig;
 import mekanism.common.integration.computer.IComputerIntegration;
@@ -76,7 +77,7 @@ public class TileEntityElectricPump extends TileEntityElectricBlock implements I
     /**
      * How much energy this machine consumes per-tick.
      */
-    public double BASE_ENERGY_PER_TICK = MekanismConfig.current().usage.electricPumpUsage.val();
+    public double BASE_ENERGY_PER_TICK = MachineType.ELECTRIC_PUMP.getUsage();
     public double energyPerTick = BASE_ENERGY_PER_TICK;
     /**
      * How many ticks it takes to run an operation.
@@ -99,7 +100,7 @@ public class TileEntityElectricPump extends TileEntityElectricBlock implements I
     public TileComponentSecurity securityComponent = new TileComponentSecurity(this);
 
     public TileEntityElectricPump() {
-        super("ElectricPump", 10000);
+        super("ElectricPump", MachineType.ELECTRIC_PUMP.getStorage());
         inventory = NonNullList.withSize(4, ItemStack.EMPTY);
 
         upgradeComponent.setSupported(Upgrade.FILTER);

--- a/src/main/java/mekanism/common/tile/TileEntityElectrolyticSeparator.java
+++ b/src/main/java/mekanism/common/tile/TileEntityElectrolyticSeparator.java
@@ -93,7 +93,7 @@ public class TileEntityElectrolyticSeparator extends TileEntityMachine implement
 
     public TileEntityElectrolyticSeparator() {
         super("machine.electrolyticseparator", "ElectrolyticSeparator",
-              MachineType.ELECTROLYTIC_SEPARATOR.baseEnergy, 0, 4);
+                MachineType.ELECTROLYTIC_SEPARATOR.getStorage(), 0, 4);
         inventory = NonNullList.withSize(5, ItemStack.EMPTY);
     }
 

--- a/src/main/java/mekanism/common/tile/TileEntityEnergizedSmelter.java
+++ b/src/main/java/mekanism/common/tile/TileEntityEnergizedSmelter.java
@@ -2,7 +2,6 @@ package mekanism.common.tile;
 
 import java.util.Map;
 import mekanism.common.block.states.BlockStateMachine.MachineType;
-import mekanism.common.config.MekanismConfig;
 import mekanism.common.recipe.RecipeHandler.Recipe;
 import mekanism.common.recipe.inputs.ItemStackInput;
 import mekanism.common.recipe.machines.SmeltingRecipe;
@@ -13,8 +12,9 @@ public class TileEntityEnergizedSmelter extends TileEntityElectricMachine<Smelti
     private static Map<ItemStackInput, SmeltingRecipe> cachedRecipes;
 
     public TileEntityEnergizedSmelter() {
-        super("smelter", "EnergizedSmelter", MachineType.ENERGIZED_SMELTER.baseEnergy,
-              MekanismConfig.current().usage.energizedSmelterUsage.val(), 200);
+        super("smelter", "EnergizedSmelter",
+                MachineType.ENERGIZED_SMELTER.getStorage(),
+                MachineType.ENERGIZED_SMELTER.getUsage(), 200);
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/TileEntityEnrichmentChamber.java
+++ b/src/main/java/mekanism/common/tile/TileEntityEnrichmentChamber.java
@@ -2,7 +2,6 @@ package mekanism.common.tile;
 
 import java.util.Map;
 import mekanism.common.block.states.BlockStateMachine.MachineType;
-import mekanism.common.config.MekanismConfig;
 import mekanism.common.recipe.RecipeHandler.Recipe;
 import mekanism.common.recipe.inputs.ItemStackInput;
 import mekanism.common.recipe.machines.EnrichmentRecipe;
@@ -11,8 +10,9 @@ import mekanism.common.tile.prefab.TileEntityElectricMachine;
 public class TileEntityEnrichmentChamber extends TileEntityElectricMachine<EnrichmentRecipe> {
 
     public TileEntityEnrichmentChamber() {
-        super("enrichment", "EnrichmentChamber", MachineType.ENRICHMENT_CHAMBER.baseEnergy,
-              MekanismConfig.current().usage.enrichmentChamberUsage.val(), 200);
+        super("enrichment", "EnrichmentChamber",
+                MachineType.ENRICHMENT_CHAMBER.getStorage(),
+                MachineType.ENRICHMENT_CHAMBER.getUsage(), 200);
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/TileEntityFactory.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFactory.java
@@ -354,7 +354,8 @@ public class TileEntityFactory extends TileEntityMachine implements IComputerInt
 
     public void setRecipeType(RecipeType type) {
         recipeType = type;
-        BASE_MAX_ENERGY = maxEnergy = 0.5D * tier.processes * recipeType.getEnergyStorage();
+        BASE_MAX_ENERGY = maxEnergy = tier.processes *
+                Math.max(0.5D * recipeType.getEnergyStorage(), recipeType.getEnergyUsage());
         BASE_ENERGY_PER_TICK = energyPerTick = recipeType.getEnergyUsage();
         upgradeComponent.setSupported(Upgrade.GAS, recipeType.fuelEnergyUpgrades());
         secondaryEnergyPerTick = getSecondaryEnergyPerTick(recipeType);

--- a/src/main/java/mekanism/common/tile/TileEntityFactory.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFactory.java
@@ -354,7 +354,7 @@ public class TileEntityFactory extends TileEntityMachine implements IComputerInt
 
     public void setRecipeType(RecipeType type) {
         recipeType = type;
-        BASE_MAX_ENERGY = maxEnergy = 200 * tier.processes * recipeType.getEnergyUsage();
+        BASE_MAX_ENERGY = maxEnergy = 0.5D * tier.processes * recipeType.getEnergyStorage();
         BASE_ENERGY_PER_TICK = energyPerTick = recipeType.getEnergyUsage();
         upgradeComponent.setSupported(Upgrade.GAS, recipeType.fuelEnergyUpgrades());
         secondaryEnergyPerTick = getSecondaryEnergyPerTick(recipeType);

--- a/src/main/java/mekanism/common/tile/TileEntityFluidicPlenisher.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFluidicPlenisher.java
@@ -63,7 +63,7 @@ public class TileEntityFluidicPlenisher extends TileEntityElectricBlock implemen
     /**
      * How much energy this machine consumes per-tick.
      */
-    public double BASE_ENERGY_PER_TICK = MekanismConfig.current().usage.fluidicPlenisherUsage.val();
+    public double BASE_ENERGY_PER_TICK = MachineType.FLUIDIC_PLENISHER.getUsage();
     public double energyPerTick = BASE_ENERGY_PER_TICK;
     /**
      * How many ticks it takes to run an operation.
@@ -79,7 +79,7 @@ public class TileEntityFluidicPlenisher extends TileEntityElectricBlock implemen
     public TileComponentSecurity securityComponent = new TileComponentSecurity(this);
 
     public TileEntityFluidicPlenisher() {
-        super("FluidicPlenisher", MachineType.FLUIDIC_PLENISHER.baseEnergy);
+        super("FluidicPlenisher", MachineType.FLUIDIC_PLENISHER.getStorage());
         inventory = NonNullList.withSize(4, ItemStack.EMPTY);
     }
 

--- a/src/main/java/mekanism/common/tile/TileEntityFormulaicAssemblicator.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFormulaicAssemblicator.java
@@ -15,7 +15,6 @@ import mekanism.common.base.ISideConfiguration;
 import mekanism.common.base.IUpgradeTile;
 import mekanism.common.block.states.BlockStateMachine.MachineType;
 import mekanism.common.capabilities.Capabilities;
-import mekanism.common.config.MekanismConfig;
 import mekanism.common.content.assemblicator.RecipeFormula;
 import mekanism.common.item.ItemCraftingFormula;
 import mekanism.common.security.ISecurityTile;
@@ -41,7 +40,7 @@ public class TileEntityFormulaicAssemblicator extends TileEntityElectricBlock im
 
     public InventoryCrafting dummyInv = MekanismUtils.getDummyCraftingInv();
 
-    public double BASE_ENERGY_PER_TICK = MekanismConfig.current().usage.metallurgicInfuserUsage.val();
+    public double BASE_ENERGY_PER_TICK = MachineType.FORMULAIC_ASSEMBLICATOR.getUsage();
 
     public double energyPerTick = BASE_ENERGY_PER_TICK;
 
@@ -74,7 +73,7 @@ public class TileEntityFormulaicAssemblicator extends TileEntityElectricBlock im
     public ItemStack lastOutputStack = ItemStack.EMPTY;
 
     public TileEntityFormulaicAssemblicator() {
-        super("FormulaicAssemblicator", MachineType.FORMULAIC_ASSEMBLICATOR.baseEnergy);
+        super("FormulaicAssemblicator", MachineType.FORMULAIC_ASSEMBLICATOR.getStorage());
 
         configComponent = new TileComponentConfig(this, TransmissionType.ITEM, TransmissionType.ENERGY);
 

--- a/src/main/java/mekanism/common/tile/TileEntityLaser.java
+++ b/src/main/java/mekanism/common/tile/TileEntityLaser.java
@@ -23,7 +23,7 @@ public class TileEntityLaser extends TileEntityEffectsBlock {
     public double diggingProgress;
 
     public TileEntityLaser() {
-        super("machine.laser", "Laser", 2 * MekanismConfig.current().usage.laserUsage.val());
+        super("machine.laser", "Laser", MekanismConfig.current().storage.laser.val());
         inventory = NonNullList.withSize(0, ItemStack.EMPTY);
     }
 
@@ -34,7 +34,7 @@ public class TileEntityLaser extends TileEntityEffectsBlock {
         if (world.isRemote) {
             if (isActive) {
                 RayTraceResult mop = LaserManager
-                      .fireLaserClient(this, facing, MekanismConfig.current().usage.laserUsage.val(), world);
+                      .fireLaserClient(this, facing, MekanismConfig.current().usage.laser.val(), world);
                 Coord4D hitCoord = mop == null ? null : new Coord4D(mop, world);
 
                 if (hitCoord == null || !hitCoord.equals(digging)) {
@@ -49,7 +49,7 @@ public class TileEntityLaser extends TileEntityEffectsBlock {
 
                     if (!(hardness < 0 || (LaserManager.isReceptor(tileHit, mop.sideHit) && !(LaserManager
                           .getReceptor(tileHit, mop.sideHit).canLasersDig())))) {
-                        diggingProgress += MekanismConfig.current().usage.laserUsage.val();
+                        diggingProgress += MekanismConfig.current().usage.laser.val();
 
                         if (diggingProgress < hardness * MekanismConfig.current().general.laserEnergyNeededPerHardness
                               .val()) {
@@ -59,11 +59,11 @@ public class TileEntityLaser extends TileEntityEffectsBlock {
                 }
             }
         } else {
-            if (getEnergy() >= MekanismConfig.current().usage.laserUsage.val()) {
+            if (getEnergy() >= MekanismConfig.current().usage.laser.val()) {
                 setActive(true);
 
                 LaserInfo info = LaserManager
-                      .fireLaser(this, facing, MekanismConfig.current().usage.laserUsage.val(), world);
+                      .fireLaser(this, facing, MekanismConfig.current().usage.laser.val(), world);
                 Coord4D hitCoord = info.movingPos == null ? null : new Coord4D(info.movingPos, world);
 
                 if (hitCoord == null || !hitCoord.equals(digging)) {
@@ -78,7 +78,7 @@ public class TileEntityLaser extends TileEntityEffectsBlock {
 
                     if (!(hardness < 0 || (LaserManager.isReceptor(tileHit, info.movingPos.sideHit) && !(LaserManager
                           .getReceptor(tileHit, info.movingPos.sideHit).canLasersDig())))) {
-                        diggingProgress += MekanismConfig.current().usage.laserUsage.val();
+                        diggingProgress += MekanismConfig.current().usage.laser.val();
 
                         if (diggingProgress >= hardness * MekanismConfig.current().general.laserEnergyNeededPerHardness
                               .val()) {
@@ -88,7 +88,7 @@ public class TileEntityLaser extends TileEntityEffectsBlock {
                     }
                 }
 
-                setEnergy(getEnergy() - MekanismConfig.current().usage.laserUsage.val());
+                setEnergy(getEnergy() - MekanismConfig.current().usage.laser.val());
             } else {
                 setActive(false);
                 diggingProgress = 0;

--- a/src/main/java/mekanism/common/tile/TileEntityLogisticalSorter.java
+++ b/src/main/java/mekanism/common/tile/TileEntityLogisticalSorter.java
@@ -69,7 +69,7 @@ public class TileEntityLogisticalSorter extends TileEntityElectricBlock implemen
           "addOreFilter", "removeOreFilter"};
 
     public TileEntityLogisticalSorter() {
-        super("LogisticalSorter", MachineType.LOGISTICAL_SORTER.baseEnergy);
+        super("LogisticalSorter", MachineType.LOGISTICAL_SORTER.getStorage());
         inventory = NonNullList.withSize(1, ItemStack.EMPTY);
         doAutoSync = false;
     }

--- a/src/main/java/mekanism/common/tile/TileEntityMetallurgicInfuser.java
+++ b/src/main/java/mekanism/common/tile/TileEntityMetallurgicInfuser.java
@@ -58,8 +58,9 @@ public class TileEntityMetallurgicInfuser extends TileEntityOperationalMachine i
     public TileComponentConfig configComponent;
 
     public TileEntityMetallurgicInfuser() {
-        super("machine.metalinfuser", "MetallurgicInfuser", MachineType.METALLURGIC_INFUSER.baseEnergy,
-              MekanismConfig.current().usage.metallurgicInfuserUsage.val(), 0, 200);
+        super("machine.metalinfuser", "MetallurgicInfuser",
+              MekanismConfig.current().storage.metallurgicInfuser.val(),
+              MekanismConfig.current().usage.metallurgicInfuser.val(), 0, 200);
 
         configComponent = new TileComponentConfig(this, TransmissionType.ITEM);
 

--- a/src/main/java/mekanism/common/tile/TileEntityOsmiumCompressor.java
+++ b/src/main/java/mekanism/common/tile/TileEntityOsmiumCompressor.java
@@ -4,7 +4,6 @@ import java.util.Map;
 import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasStack;
 import mekanism.common.block.states.BlockStateMachine.MachineType;
-import mekanism.common.config.MekanismConfig;
 import mekanism.common.recipe.RecipeHandler.Recipe;
 import mekanism.common.recipe.inputs.AdvancedMachineInput;
 import mekanism.common.recipe.machines.OsmiumCompressorRecipe;
@@ -14,8 +13,9 @@ import net.minecraft.util.EnumFacing;
 public class TileEntityOsmiumCompressor extends TileEntityAdvancedElectricMachine<OsmiumCompressorRecipe> {
 
     public TileEntityOsmiumCompressor() {
-        super("compressor", "OsmiumCompressor", MachineType.OSMIUM_COMPRESSOR.baseEnergy,
-              MekanismConfig.current().usage.osmiumCompressorUsage.val(), BASE_TICKS_REQUIRED, BASE_GAS_PER_TICK);
+        super("compressor", "OsmiumCompressor",
+                MachineType.OSMIUM_COMPRESSOR.getStorage(),
+                MachineType.OSMIUM_COMPRESSOR.getUsage(), BASE_TICKS_REQUIRED, BASE_GAS_PER_TICK);
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/TileEntityPRC.java
+++ b/src/main/java/mekanism/common/tile/TileEntityPRC.java
@@ -20,7 +20,6 @@ import mekanism.common.base.ISustainedData;
 import mekanism.common.base.ITankManager;
 import mekanism.common.block.states.BlockStateMachine.MachineType;
 import mekanism.common.capabilities.Capabilities;
-import mekanism.common.config.MekanismConfig;
 import mekanism.common.item.ItemUpgrade;
 import mekanism.common.recipe.RecipeHandler;
 import mekanism.common.recipe.inputs.PressurizedInput;
@@ -59,9 +58,9 @@ public class TileEntityPRC extends
 
     public TileEntityPRC() {
         super("prc", MachineType.PRESSURIZED_REACTION_CHAMBER.blockName,
-              MachineType.PRESSURIZED_REACTION_CHAMBER.baseEnergy,
-              MekanismConfig.current().usage.pressurizedReactionBaseUsage.val(),
-              3, 100, new ResourceLocation("mekanism", "gui/GuiPRC.png"));
+                MachineType.PRESSURIZED_REACTION_CHAMBER.getStorage(),
+                MachineType.PRESSURIZED_REACTION_CHAMBER.getUsage(), 3, 100,
+                new ResourceLocation("mekanism", "gui/GuiPRC.png"));
 
         configComponent = new TileComponentConfig(this, TransmissionType.ITEM, TransmissionType.ENERGY,
               TransmissionType.FLUID, TransmissionType.GAS);

--- a/src/main/java/mekanism/common/tile/TileEntityPrecisionSawmill.java
+++ b/src/main/java/mekanism/common/tile/TileEntityPrecisionSawmill.java
@@ -2,7 +2,6 @@ package mekanism.common.tile;
 
 import java.util.Map;
 import mekanism.common.block.states.BlockStateMachine.MachineType;
-import mekanism.common.config.MekanismConfig;
 import mekanism.common.recipe.RecipeHandler.Recipe;
 import mekanism.common.recipe.inputs.ItemStackInput;
 import mekanism.common.recipe.machines.SawmillRecipe;
@@ -12,9 +11,10 @@ import mekanism.common.util.MekanismUtils.ResourceType;
 public class TileEntityPrecisionSawmill extends TileEntityChanceMachine<SawmillRecipe> {
 
     public TileEntityPrecisionSawmill() {
-        super("sawmill", "PrecisionSawmill", MachineType.PRECISION_SAWMILL.baseEnergy,
-              MekanismConfig.current().usage.precisionSawmillUsage.val(), 200,
-              MekanismUtils.getResource(ResourceType.GUI, "GuiBasicMachine.png"));
+        super("sawmill", "PrecisionSawmill",
+                MachineType.PRECISION_SAWMILL.getStorage(),
+                MachineType.PRECISION_SAWMILL.getUsage(), 200,
+                MekanismUtils.getResource(ResourceType.GUI, "GuiBasicMachine.png"));
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/TileEntityPurificationChamber.java
+++ b/src/main/java/mekanism/common/tile/TileEntityPurificationChamber.java
@@ -5,7 +5,6 @@ import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasStack;
 import mekanism.api.gas.IGasItem;
 import mekanism.common.block.states.BlockStateMachine.MachineType;
-import mekanism.common.config.MekanismConfig;
 import mekanism.common.recipe.RecipeHandler.Recipe;
 import mekanism.common.recipe.inputs.AdvancedMachineInput;
 import mekanism.common.recipe.machines.PurificationRecipe;
@@ -17,8 +16,9 @@ import net.minecraft.util.EnumFacing;
 public class TileEntityPurificationChamber extends TileEntityAdvancedElectricMachine<PurificationRecipe> {
 
     public TileEntityPurificationChamber() {
-        super("purification", "PurificationChamber", MachineType.PURIFICATION_CHAMBER.baseEnergy,
-              MekanismConfig.current().usage.purificationChamberUsage.val(), BASE_TICKS_REQUIRED, BASE_GAS_PER_TICK);
+        super("purification", "PurificationChamber",
+                MachineType.PURIFICATION_CHAMBER.getStorage(),
+                MachineType.PURIFICATION_CHAMBER.getUsage(), BASE_TICKS_REQUIRED, BASE_GAS_PER_TICK);
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/TileEntityResistiveHeater.java
+++ b/src/main/java/mekanism/common/tile/TileEntityResistiveHeater.java
@@ -56,7 +56,7 @@ public class TileEntityResistiveHeater extends TileEntityEffectsBlock implements
     public TileComponentSecurity securityComponent = new TileComponentSecurity(this);
 
     public TileEntityResistiveHeater() {
-        super("machine.resistiveheater", "ResistiveHeater", MachineType.RESISTIVE_HEATER.baseEnergy);
+        super("machine.resistiveheater", "ResistiveHeater", MachineType.RESISTIVE_HEATER.getStorage());
         inventory = NonNullList.withSize(SLOTS.length, ItemStack.EMPTY);
     }
 

--- a/src/main/java/mekanism/common/tile/TileEntityRotaryCondensentrator.java
+++ b/src/main/java/mekanism/common/tile/TileEntityRotaryCondensentrator.java
@@ -22,7 +22,6 @@ import mekanism.common.base.ISustainedData;
 import mekanism.common.base.ITankManager;
 import mekanism.common.block.states.BlockStateMachine.MachineType;
 import mekanism.common.capabilities.Capabilities;
-import mekanism.common.config.MekanismConfig;
 import mekanism.common.network.PacketTileEntity.TileEntityMessage;
 import mekanism.common.tile.prefab.TileEntityMachine;
 import mekanism.common.util.ChargeUtils;
@@ -65,8 +64,8 @@ public class TileEntityRotaryCondensentrator extends TileEntityMachine implement
 
     public TileEntityRotaryCondensentrator() {
         super("machine.rotarycondensentrator", "RotaryCondensentrator",
-              MachineType.ROTARY_CONDENSENTRATOR.baseEnergy,
-              MekanismConfig.current().usage.rotaryCondensentratorUsage.val(), 5);
+              MachineType.ROTARY_CONDENSENTRATOR.getStorage(),
+              MachineType.ROTARY_CONDENSENTRATOR.getUsage(), 5);
         inventory = NonNullList.withSize(6, ItemStack.EMPTY);
     }
 

--- a/src/main/java/mekanism/common/tile/TileEntitySeismicVibrator.java
+++ b/src/main/java/mekanism/common/tile/TileEntitySeismicVibrator.java
@@ -39,12 +39,14 @@ public class TileEntitySeismicVibrator extends TileEntityElectricBlock implement
 
     public int clientPiston;
 
+    public double BASE_ENERGY_PER_TICK = MachineType.SEISMIC_VIBRATOR.getUsage();
+
     public RedstoneControl controlType = RedstoneControl.DISABLED;
 
     public TileComponentSecurity securityComponent = new TileComponentSecurity(this);
 
     public TileEntitySeismicVibrator() {
-        super("SeismicVibrator", MachineType.SEISMIC_VIBRATOR.baseEnergy);
+        super("SeismicVibrator", MachineType.SEISMIC_VIBRATOR.getStorage());
 
         inventory = NonNullList.withSize(SLOTS .length, ItemStack.EMPTY);
     }
@@ -79,10 +81,9 @@ public class TileEntitySeismicVibrator extends TileEntityElectricBlock implement
 
             ChargeUtils.discharge(0, this);
 
-            if (MekanismUtils.canFunction(this) && getEnergy() >= MekanismConfig.current().usage.seismicVibratorUsage
-                  .val()) {
+            if (MekanismUtils.canFunction(this) && getEnergy() >= BASE_ENERGY_PER_TICK) {
                 setActive(true);
-                setEnergy(getEnergy() - MekanismConfig.current().usage.seismicVibratorUsage.val());
+                setEnergy(getEnergy() - BASE_ENERGY_PER_TICK);
             } else {
                 setActive(false);
             }

--- a/src/main/java/mekanism/common/tile/TileEntityTeleporter.java
+++ b/src/main/java/mekanism/common/tile/TileEntityTeleporter.java
@@ -82,7 +82,7 @@ public class TileEntityTeleporter extends TileEntityElectricBlock implements ICo
     public TileComponentUpgrade upgradeComponent;
 
     public TileEntityTeleporter() {
-        super("Teleporter", MachineType.TELEPORTER.baseEnergy);
+        super("Teleporter", MachineType.TELEPORTER.getStorage());
         inventory = NonNullList.withSize(2, ItemStack.EMPTY);
 
         securityComponent = new TileComponentSecurity(this);
@@ -398,13 +398,13 @@ public class TileEntityTeleporter extends TileEntityElectricBlock implements ICo
     }
 
     public int calculateEnergyCost(Entity entity, Coord4D coords) {
-        int energyCost = MekanismConfig.current().usage.teleporterBaseUsage.val();
+        int energyCost = MekanismConfig.current().usage.teleporterBase.val();
 
         if (entity.world.provider.getDimension() != coords.dimensionId) {
             energyCost += MekanismConfig.current().usage.teleporterDimensionPenalty.val();
         } else {
             int distance = (int) entity.getDistance(coords.x, coords.y, coords.z);
-            energyCost += (distance * MekanismConfig.current().usage.teleporterDistanceUsage.val());
+            energyCost += (distance * MekanismConfig.current().usage.teleporterDistance.val());
         }
 
         return energyCost;

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityAdvancedElectricMachine.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityAdvancedElectricMachine.java
@@ -64,14 +64,14 @@ public abstract class TileEntityAdvancedElectricMachine<RECIPE extends AdvancedM
      *
      * @param soundPath - location of the sound effect
      * @param name - full name of this machine
-     * @param maxEnergy - maximum amount of energy this machine can hold.
+     * @param baseMaxEnergy - maximum amount of energy this machine can hold.
      * @param baseEnergyUsage - how much energy this machine uses per tick.
      * @param ticksRequired - how many ticks it takes to smelt an item.
      * @param secondaryPerTick - how much secondary energy (fuel) this machine uses per tick.
      */
-    public TileEntityAdvancedElectricMachine(String soundPath, String name, double maxEnergy, double baseEnergyUsage,
+    public TileEntityAdvancedElectricMachine(String soundPath, String name, double baseMaxEnergy, double baseEnergyUsage,
           int ticksRequired, int secondaryPerTick) {
-        super(soundPath, name, maxEnergy, baseEnergyUsage, 4, ticksRequired,
+        super(soundPath, name, baseMaxEnergy, baseEnergyUsage, 4, ticksRequired,
               MekanismUtils.getResource(ResourceType.GUI, "GuiAdvancedMachine.png"));
 
         configComponent = new TileComponentConfig(this, TransmissionType.ITEM, TransmissionType.ENERGY);

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityBasicMachine.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityBasicMachine.java
@@ -33,12 +33,12 @@ public abstract class TileEntityBasicMachine<INPUT extends MachineInput<INPUT>, 
      *
      * @param soundPath - location of the sound effect
      * @param name - full name of this machine
-     * @param maxEnergy - how much energy this machine can store
+     * @param baseMaxEnergy - how much energy this machine can store
      * @param baseTicksRequired - how many ticks it takes to run a cycle
      */
-    public TileEntityBasicMachine(String soundPath, String name, double maxEnergy, double baseEnergyUsage,
+    public TileEntityBasicMachine(String soundPath, String name, double baseMaxEnergy, double baseEnergyUsage,
           int upgradeSlot, int baseTicksRequired, ResourceLocation location) {
-        super("machine." + soundPath, name, maxEnergy, baseEnergyUsage, upgradeSlot, baseTicksRequired);
+        super("machine." + soundPath, name, baseMaxEnergy, baseEnergyUsage, upgradeSlot, baseTicksRequired);
 
         guiLocation = location;
     }

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityDoubleElectricMachine.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityDoubleElectricMachine.java
@@ -33,13 +33,13 @@ public abstract class TileEntityDoubleElectricMachine<RECIPE extends DoubleMachi
      *
      * @param soundPath - location of the sound effect
      * @param name - full name of this machine
-     * @param maxEnergy - maximum amount of energy this machine can hold.
+     * @param baseMaxEnergy - maximum amount of energy this machine can hold.
      * @param baseEnergyUsage - how much energy this machine uses per tick.
      * @param ticksRequired - how many ticks it takes to smelt an item.
      */
-    public TileEntityDoubleElectricMachine(String soundPath, String name, double maxEnergy, double baseEnergyUsage,
+    public TileEntityDoubleElectricMachine(String soundPath, String name, double baseMaxEnergy, double baseEnergyUsage,
           int ticksRequired) {
-        super(soundPath, name, maxEnergy, baseEnergyUsage, 4, ticksRequired,
+        super(soundPath, name, baseMaxEnergy, baseEnergyUsage, 4, ticksRequired,
               MekanismUtils.getResource(ResourceType.GUI, "guibasicmachine.png"));
 
         configComponent = new TileComponentConfig(this, TransmissionType.ITEM, TransmissionType.ENERGY);

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityEffectsBlock.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityEffectsBlock.java
@@ -42,10 +42,10 @@ public abstract class TileEntityEffectsBlock extends TileEntityElectricBlock imp
      *
      * @param sound - the sound path of this block
      * @param name - full name of this block
-     * @param maxEnergy - how much energy this block can store
+     * @param baseMaxEnergy - how much energy this block can store
      */
-    public TileEntityEffectsBlock(String sound, String name, double maxEnergy) {
-        super(name, maxEnergy);
+    public TileEntityEffectsBlock(String sound, String name, double baseMaxEnergy) {
+        super(name, baseMaxEnergy);
 
         // TODO: Have subclasses pass in a static SoundEvent so we avoid per-instance # of SoundEvents for same sound
         // TODO: Factories don't currently pass in the right value for sound ID of wrapped machine; overhaul this.

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityMachine.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityMachine.java
@@ -30,8 +30,8 @@ public abstract class TileEntityMachine extends TileEntityEffectsBlock implement
     public TileComponentUpgrade upgradeComponent;
     public TileComponentSecurity securityComponent = new TileComponentSecurity(this);
 
-    public TileEntityMachine(String sound, String name, double maxEnergy, double baseEnergyUsage, int upgradeSlot) {
-        super(sound, name, maxEnergy);
+    public TileEntityMachine(String sound, String name, double baseMaxEnergy, double baseEnergyUsage, int upgradeSlot) {
+        super(sound, name, baseMaxEnergy);
 
         energyPerTick = BASE_ENERGY_PER_TICK = baseEnergyUsage;
 

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityOperationalMachine.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityOperationalMachine.java
@@ -16,9 +16,9 @@ public abstract class TileEntityOperationalMachine extends TileEntityMachine {
 
     public int ticksRequired;
 
-    protected TileEntityOperationalMachine(String sound, String name, double maxEnergy, double baseEnergyUsage,
+    protected TileEntityOperationalMachine(String sound, String name, double baseMaxEnergy, double baseEnergyUsage,
           int upgradeSlot, int baseTicksRequired) {
-        super(sound, name, maxEnergy, baseEnergyUsage, upgradeSlot);
+        super(sound, name, baseMaxEnergy, baseEnergyUsage, upgradeSlot);
 
         ticksRequired = BASE_TICKS_REQUIRED = baseTicksRequired;
     }

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityUpgradeableMachine.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityUpgradeableMachine.java
@@ -21,12 +21,12 @@ public abstract class TileEntityUpgradeableMachine<INPUT extends MachineInput<IN
      *
      * @param soundPath - location of the sound effect
      * @param name - full name of this machine
-     * @param maxEnergy - how much energy this machine can store
+     * @param baseMaxEnergy - how much energy this machine can store
      * @param baseTicksRequired - how many ticks it takes to run a cycle
      */
-    public TileEntityUpgradeableMachine(String soundPath, String name, double maxEnergy, double baseEnergyUsage,
+    public TileEntityUpgradeableMachine(String soundPath, String name, double baseMaxEnergy, double baseEnergyUsage,
           int upgradeSlot, int baseTicksRequired, ResourceLocation location) {
-        super(soundPath, name, maxEnergy, baseEnergyUsage, upgradeSlot, baseTicksRequired, location);
+        super(soundPath, name, baseMaxEnergy, baseEnergyUsage, upgradeSlot, baseTicksRequired, location);
     }
 
     @Override


### PR DESCRIPTION
fixes #5367 

I added a configuration category called storage, which is loaded both on client and server.
Created default values for the storage, for most of the machines, that were in the switch in `getUsage()` function.
Notably added an option for `TELEPORTER` and `CHARGEPAD`, which had hard-wired values in `getUsage()`. Using the previous method of determining storage as default.

As suggested by @thiakil , the code does:  `baseEnergy = Math.max(usage, storage);` 
This is not perfect though, if you put some speed upgrades into the machine, you can still get it into a state when it requires more energy, than can hold, or when the energy use increases due to some settings (eg. using silk touch in digital miner).

I see no straightforward way how to fix these machine issues (which can anyway happen only with very unusual config values). If you would like it to work somehow, feel free to suggest me something.
I did test the changes and they seem to work as expected, other than what was mentioned.