### PR TITLE
Miner cleanup

### DIFF
--- a/src/main/java/mekanism/common/LaserManager.java
+++ b/src/main/java/mekanism/common/LaserManager.java
@@ -21,6 +21,7 @@ import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.util.Constants.WorldEvents;
 import net.minecraftforge.event.world.BlockEvent;
 
 public class LaserManager {
@@ -94,7 +95,7 @@ public class LaserManager {
 
         blockHit.breakBlock(world, blockCoord.getPos(), state);
         world.setBlockToAir(blockCoord.getPos());
-        world.playEvent(2001, blockCoord.getPos(), Block.getStateId(state));
+        world.playEvent(WorldEvents.BREAK_BLOCK_EFFECTS, blockCoord.getPos(), Block.getStateId(state));
 
         return ret;
     }

--- a/src/main/java/mekanism/common/entity/EntityFlame.java
+++ b/src/main/java/mekanism/common/entity/EntityFlame.java
@@ -27,6 +27,7 @@ import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.util.math.RayTraceResult.Type;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
+import net.minecraftforge.common.util.Constants.WorldEvents;
 import net.minecraftforge.fml.common.registry.IEntityAdditionalSpawnData;
 
 public class EntityFlame extends Entity implements IEntityAdditionalSpawnData {
@@ -239,7 +240,7 @@ public class EntityFlame extends Entity implements IEntityAdditionalSpawnData {
                     world.spawnEntity(item);
                 }
 
-                world.playEvent(null, 2001, block.getPos(), Block.getStateId(state));
+                world.playEvent(WorldEvents.BREAK_BLOCK_EFFECTS, block.getPos(), Block.getStateId(state));
             }
 
             spawnParticlesAt(new Pos3D(block).translate(0.5, 0.5, 0.5));

--- a/src/main/java/mekanism/common/item/ItemAtomicDisassembler.java
+++ b/src/main/java/mekanism/common/item/ItemAtomicDisassembler.java
@@ -38,6 +38,7 @@ import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.util.text.TextComponentString;
 import net.minecraft.world.World;
+import net.minecraftforge.common.util.Constants.WorldEvents;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
@@ -157,7 +158,7 @@ public class ItemAtomicDisassembler extends ItemEnergized {
                     Block block2 = coord.getBlock(player.world);
 
                     block2.onBlockHarvested(player.world, coord.getPos(), state, player);
-                    player.world.playEvent(null, 2001, coord.getPos(), Block.getStateId(state));
+                    player.world.playEvent(WorldEvents.BREAK_BLOCK_EFFECTS, coord.getPos(), Block.getStateId(state));
                     player.world.setBlockToAir(coord.getPos());
                     block2.breakBlock(player.world, coord.getPos(), state);
                     block2.dropBlockAsItem(player.world, coord.getPos(), state, 0);

--- a/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
+++ b/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
@@ -70,6 +70,7 @@ import net.minecraft.world.WorldServer;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.util.Constants.NBT;
+import net.minecraftforge.common.util.Constants.WorldEvents;
 import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.fml.common.FMLCommonHandler;
@@ -264,7 +265,8 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
                                     it.remove();
                                 }
 
-                                world.playEvent(null, 2001, coord.getPos(), Block.getStateId(state));
+                                world.playEvent(WorldEvents.BREAK_BLOCK_EFFECTS, coord.getPos(),
+                                      Block.getStateId(state));
 
                                 missingStack = ItemStack.EMPTY;
                             }

--- a/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
+++ b/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
@@ -7,6 +7,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -63,6 +64,7 @@ import net.minecraft.nbt.NBTTagList;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntityShulkerBox;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumHand;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
@@ -256,7 +258,7 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
                                 continue;
                             }
 
-                            List<ItemStack> drops = MinerUtils.getDrops(world, coord, silkTouch);
+                            List<ItemStack> drops = MinerUtils.getDrops(world, coord, silkTouch, this.pos);
 
                             if (canInsert(drops) && setReplace(coord, index)) {
                                 did = true;
@@ -364,6 +366,7 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
     public boolean setReplace(Coord4D obj, int index) {
         ItemStack stack = getReplace(index);
         BlockPos pos = obj.getPos();
+        EntityPlayer fakePlayer = Objects.requireNonNull(Mekanism.proxy.getDummyPlayer((WorldServer) world, this.pos).get());
 
         //if its a shulker box, remove it TE so it can't drop itself in breakBlock - we've already captured its itemblock
         TileEntity te = world.getTileEntity(pos);
@@ -374,8 +377,7 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
         }
 
         if (!stack.isEmpty()) {
-            world.setBlockState(pos,
-                  Block.getBlockFromItem(stack.getItem()).getStateFromMeta(stack.getItemDamage()), 3);
+            world.setBlockState(pos, StackUtils.getStateForPlacement(stack, world, pos, fakePlayer), 3);
 
             IBlockState s = obj.getBlockState(world);
             if (s.getBlock() instanceof BlockBush && !((BlockBush) s.getBlock())
@@ -409,7 +411,7 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
     private boolean canMine(Coord4D coord) {
         IBlockState state = coord.getBlockState(world);
 
-        EntityPlayer dummy = Mekanism.proxy.getDummyPlayer((WorldServer) world, pos).get();
+        EntityPlayer dummy = Objects.requireNonNull(Mekanism.proxy.getDummyPlayer((WorldServer) world, pos).get());
         BlockEvent.BreakEvent event = new BlockEvent.BreakEvent(world, coord.getPos(), state, dummy);
         MinecraftForge.EVENT_BUS.post(event);
 

--- a/src/main/java/mekanism/common/util/MinerUtils.java
+++ b/src/main/java/mekanism/common/util/MinerUtils.java
@@ -14,7 +14,6 @@ import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.NonNullList;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
 import net.minecraftforge.event.ForgeEventFactory;
@@ -70,8 +69,8 @@ public final class MinerUtils {
                 return ret;
             }
         } else {
-            NonNullList<ItemStack> blockDrops = NonNullList.create();
-            block.getDrops(blockDrops, world, coord.getPos(), state, 0);
+            @SuppressWarnings("deprecation")//needed for backwards compatibility
+            List<ItemStack> blockDrops = block.getDrops(world, coord.getPos(), state, 0);
             if (blockDrops.size() > 0) {
                 ForgeEventFactory.fireBlockHarvesting(blockDrops, world, coord.getPos(), state, 0, 1.0F, false, null);
             } else if (block == Blocks.CHORUS_FLOWER) {

--- a/src/main/java/mekanism/common/util/MinerUtils.java
+++ b/src/main/java/mekanism/common/util/MinerUtils.java
@@ -14,9 +14,12 @@ import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.NonNullList;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldServer;
+import net.minecraftforge.event.ForgeEventFactory;
 import net.minecraftforge.fml.relauncher.ReflectionHelper;
+import net.minecraftforge.fml.relauncher.ReflectionHelper.UnableToFindMethodException;
 
 public final class MinerUtils {
 
@@ -28,54 +31,55 @@ public final class MinerUtils {
         try {
             getSilkTouchDrop = ReflectionHelper
                   .findMethod(Block.class, "getSilkTouchDrop", "func_180643_i", IBlockState.class);
-        } catch (ReflectionHelper.UnableToFindMethodException e) {
+        } catch (UnableToFindMethodException e) {
             Mekanism.logger.error("Unable to find method Block.getSilkTouchDrop");
         }
     }
 
-    public static List<ItemStack> getDrops(World world, Coord4D obj, boolean silk) {
-        IBlockState state = obj.getBlockState(world);
+    public static List<ItemStack> getDrops(World world, Coord4D coord, boolean silk) {
+        IBlockState state = coord.getBlockState(world);
         Block block = state.getBlock();
 
-        if (block.isAir(state, world, obj.getPos())) {
-            return Collections.EMPTY_LIST;
+        if (block.isAir(state, world, coord.getPos())) {
+            return Collections.emptyList();
         }
 
-        if (silk && (
-              block.canSilkHarvest(world, obj.getPos(), state, Mekanism.proxy.getDummyPlayer((WorldServer) world).get())
-                    || specialSilkIDs.contains(block))) {
+        if (silk && (block.canSilkHarvest(world, coord.getPos(), state,
+              Mekanism.proxy.getDummyPlayer((WorldServer) world).get()) || specialSilkIDs.contains(block))) {
             List<ItemStack> ret = new ArrayList<>();
             if (getSilkTouchDrop != null) {
                 try {
                     Object it = getSilkTouchDrop.invoke(block, state);
-                    if (it instanceof ItemStack && !((ItemStack) it).isEmpty()) {
-                        ret.add((ItemStack) it);
-                    } else if (it instanceof ItemStack && ((ItemStack) it)
-                          .isEmpty()) {//silk touch drop is empty, fallback to grabbing an itemblock
-                        fallbackGetSilkTouch(block, state, ret);
+                    if (it instanceof ItemStack) {
+                        //Should always be an ItemStack
+                        ItemStack silkDrop = (ItemStack) it;
+                        if (!silkDrop.isEmpty()) {
+                            ret.add(silkDrop);
+                        } else {
+                            //silk touch drop is empty, fallback to grabbing an itemblock
+                            fallbackGetSilkTouch(block, state, ret);
+                        }
                     }
                 } catch (InvocationTargetException | IllegalAccessException e) {
                     Mekanism.logger.error("Block.getSilkTouchDrop errored", e);
                     fallbackGetSilkTouch(block, state, ret);
                 }
-            } else//fallback to old method
-            {
+            } else {
+                //fallback to old method
                 fallbackGetSilkTouch(block, state, ret);
             }
 
             if (ret.size() > 0) {
-                net.minecraftforge.event.ForgeEventFactory
-                      .fireBlockHarvesting(ret, world, obj.getPos(), state, 0, 1.0f, true, null);
+                ForgeEventFactory.fireBlockHarvesting(ret, world, coord.getPos(), state, 0, 1.0F, true, null);
                 return ret;
             }
         } else {
-            @SuppressWarnings("deprecation")
-            List<ItemStack> blockDrops = block.getDrops(world, obj.getPos(), state, 0);
+            NonNullList<ItemStack> blockDrops = NonNullList.create();
+            block.getDrops(blockDrops, world, coord.getPos(), state, 0);
             if (blockDrops.size() > 0) {
-                net.minecraftforge.event.ForgeEventFactory
-                      .fireBlockHarvesting(blockDrops, world, obj.getPos(), state, 0, 1.0f, false, null);
-            } else if (block
-                  == Blocks.CHORUS_FLOWER) {//Chorus flower returns AIR for itemDropped... and for silkTouchDrop.
+                ForgeEventFactory.fireBlockHarvesting(blockDrops, world, coord.getPos(), state, 0, 1.0F, false, null);
+            } else if (block == Blocks.CHORUS_FLOWER) {
+                //Chorus flower returns AIR for itemDropped... and for silkTouchDrop.
                 blockDrops.add(new ItemStack(Blocks.CHORUS_FLOWER));
             }
             return blockDrops;

--- a/src/main/java/mekanism/common/util/StackUtils.java
+++ b/src/main/java/mekanism/common/util/StackUtils.java
@@ -147,6 +147,6 @@ public final class StackUtils {
     @Nonnull
     public static IBlockState getStateForPlacement(ItemStack stack, World world, BlockPos pos, EntityPlayer player) {
         Block blockFromItem = Block.getBlockFromItem(stack.getItem());
-        return blockFromItem.getStateForPlacement(world, pos, EnumFacing.NORTH, 0,0,0, stack.getMetadata(), player, EnumHand.MAIN_HAND);
+        return blockFromItem.getStateForPlacement(world, pos, EnumFacing.UP, 0,0,0, stack.getMetadata(), player, EnumHand.MAIN_HAND);
     }
 }

--- a/src/main/java/mekanism/common/util/StackUtils.java
+++ b/src/main/java/mekanism/common/util/StackUtils.java
@@ -2,9 +2,17 @@ package mekanism.common.util;
 
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nonnull;
+import net.minecraft.block.Block;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumHand;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
 import net.minecraftforge.oredict.OreDictionary;
 
 public final class StackUtils {
@@ -125,5 +133,20 @@ public final class StackUtils {
         ResourceLocation registryName = stack.getItem().getRegistryName();
         int nameHash = registryName == null ? 0 : registryName.hashCode();
         return nameHash << 8 | stack.getMetadata();
+    }
+
+    /**
+     * Get state for placement for a generic item, with our fake player
+     *
+     * @param stack the item to place
+     * @param world which universe
+     * @param pos where
+     * @param player our fake player, usually
+     * @return the result of {@link Block#getStateForPlacement(net.minecraft.world.World, net.minecraft.util.math.BlockPos, net.minecraft.util.EnumFacing, float, float, float, int, net.minecraft.entity.EntityLivingBase, net.minecraft.util.EnumHand)}
+     */
+    @Nonnull
+    public static IBlockState getStateForPlacement(ItemStack stack, World world, BlockPos pos, EntityPlayer player) {
+        Block blockFromItem = Block.getBlockFromItem(stack.getItem());
+        return blockFromItem.getStateForPlacement(world, pos, EnumFacing.NORTH, 0,0,0, stack.getMetadata(), player, EnumHand.MAIN_HAND);
     }
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Cleans up calls to world.playEvent, making it more clear which event is being called
- Made `MinerUtils` easier to read by cleaning up some of the logic so that it has less else branches calling `fallbackGetSilkTouch` this allowed me to also inline `fallbackGetSilkTouch` as it only was being called in one spot.

I still need to look more into #5453 and https://github.com/mekanism/Mekanism/issues/5453#issuecomment-489216976 to see if that is how we should do it or if there is a better way.