### PR TITLE
Change unused map (values) to use a set

### DIFF
--- a/src/main/java/mekanism/api/MekanismAPI.java
+++ b/src/main/java/mekanism/api/MekanismAPI.java
@@ -18,7 +18,7 @@ public class MekanismAPI {
     /**
      * The version of the api classes - may not always match the mod's version
      */
-    public static final String API_VERSION = "9.7.3";
+    public static final String API_VERSION = "9.7.5";
 
     /**
      * Mekanism debug mode

--- a/src/main/java/mekanism/api/transmitters/DynamicNetwork.java
+++ b/src/main/java/mekanism/api/transmitters/DynamicNetwork.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -28,13 +29,13 @@ import org.apache.commons.lang3.tuple.Pair;
 public abstract class DynamicNetwork<ACCEPTOR, NETWORK extends DynamicNetwork<ACCEPTOR, NETWORK, BUFFER>, BUFFER> implements
       IClientTicker, INetworkDataHandler {
 
-    public LinkedHashSet<IGridTransmitter<ACCEPTOR, NETWORK, BUFFER>> transmitters = Sets.newLinkedHashSet();
-    public LinkedHashSet<IGridTransmitter<ACCEPTOR, NETWORK, BUFFER>> transmittersToAdd = Sets.newLinkedHashSet();
-    public LinkedHashSet<IGridTransmitter<ACCEPTOR, NETWORK, BUFFER>> transmittersAdded = Sets.newLinkedHashSet();
+    protected Set<IGridTransmitter<ACCEPTOR, NETWORK, BUFFER>> transmitters = Sets.newLinkedHashSet();
+    protected Set<IGridTransmitter<ACCEPTOR, NETWORK, BUFFER>> transmittersToAdd = Sets.newLinkedHashSet();
+    protected Set<IGridTransmitter<ACCEPTOR, NETWORK, BUFFER>> transmittersAdded = Sets.newLinkedHashSet();
 
-    public Set<Coord4D> possibleAcceptors = new HashSet<>();
-    public HashMap<Coord4D, EnumSet<EnumFacing>> acceptorDirections = new HashMap<>();
-    public HashMap<IGridTransmitter<ACCEPTOR, NETWORK, BUFFER>, EnumSet<EnumFacing>> changedAcceptors = Maps
+    protected Set<Coord4D> possibleAcceptors = new HashSet<>();
+    protected Map<Coord4D, EnumSet<EnumFacing>> acceptorDirections = new HashMap<>();
+    protected Map<IGridTransmitter<ACCEPTOR, NETWORK, BUFFER>, EnumSet<EnumFacing>> changedAcceptors = Maps
           .newHashMap();
     protected Range4D packetRange = null;
     protected int capacity = 0;
@@ -365,6 +366,50 @@ public abstract class DynamicNetwork<ACCEPTOR, NETWORK extends DynamicNetwork<AC
 
     public boolean compatibleWithBuffer(BUFFER buffer) {
         return true;
+    }
+
+    public Set<IGridTransmitter<ACCEPTOR, NETWORK, BUFFER>> getTransmitters() {
+        return transmitters;
+    }
+
+    public boolean addTransmitter(IGridTransmitter<ACCEPTOR, NETWORK, BUFFER> transmitter) {
+        return transmitters.add(transmitter);
+    }
+
+    public boolean removeTransmitter(IGridTransmitter<ACCEPTOR, NETWORK, BUFFER> transmitter) {
+        boolean removed = transmitters.remove(transmitter);
+        if (transmitters.isEmpty()) {
+            deregister();
+        }
+        return removed;
+    }
+
+    public IGridTransmitter<ACCEPTOR, NETWORK, BUFFER> firstTransmitter() {
+        return transmitters.iterator().next();
+    }
+
+    public int transmittersSize() {
+        return transmitters.size();
+    }
+
+    public Set<IGridTransmitter<ACCEPTOR, NETWORK, BUFFER>> getTransmittersToAdd() {
+        return transmittersToAdd;
+    }
+
+    public Set<IGridTransmitter<ACCEPTOR, NETWORK, BUFFER>> getTransmittersAdded() {
+        return transmittersAdded;
+    }
+
+    public Set<Coord4D> getPossibleAcceptors() {
+        return possibleAcceptors;
+    }
+
+    public Map<Coord4D, EnumSet<EnumFacing>> getAcceptorDirections() {
+        return acceptorDirections;
+    }
+
+    public Map<IGridTransmitter<ACCEPTOR, NETWORK, BUFFER>, EnumSet<EnumFacing>> getChangedAcceptors() {
+        return changedAcceptors;
     }
 
     public static class TransmittersAddedEvent extends Event {

--- a/src/main/java/mekanism/api/transmitters/DynamicNetwork.java
+++ b/src/main/java/mekanism/api/transmitters/DynamicNetwork.java
@@ -7,6 +7,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.Map.Entry;
@@ -31,7 +32,7 @@ public abstract class DynamicNetwork<ACCEPTOR, NETWORK extends DynamicNetwork<AC
     public LinkedHashSet<IGridTransmitter<ACCEPTOR, NETWORK, BUFFER>> transmittersToAdd = Sets.newLinkedHashSet();
     public LinkedHashSet<IGridTransmitter<ACCEPTOR, NETWORK, BUFFER>> transmittersAdded = Sets.newLinkedHashSet();
 
-    public HashMap<Coord4D, ACCEPTOR> possibleAcceptors = new HashMap<>();
+    public Set<Coord4D> possibleAcceptors = new HashSet<>();
     public HashMap<Coord4D, EnumSet<EnumFacing>> acceptorDirections = new HashMap<>();
     public HashMap<IGridTransmitter<ACCEPTOR, NETWORK, BUFFER>, EnumSet<EnumFacing>> changedAcceptors = Maps
           .newHashMap();
@@ -96,7 +97,7 @@ public abstract class DynamicNetwork<ACCEPTOR, NETWORK extends DynamicNetwork<AC
         EnumSet<EnumFacing> directions = acceptorDirections.get(acceptorCoord);
 
         if (acceptor != null) {
-            possibleAcceptors.put(acceptorCoord, acceptor);
+            possibleAcceptors.add(acceptorCoord);
 
             if (directions != null) {
                 directions.add(side.getOpposite());
@@ -178,7 +179,7 @@ public abstract class DynamicNetwork<ACCEPTOR, NETWORK extends DynamicNetwork<AC
 
         transmittersToAdd.addAll(net.transmittersToAdd);
 
-        possibleAcceptors.putAll(net.possibleAcceptors);
+        possibleAcceptors.addAll(net.possibleAcceptors);
 
         for (Entry<Coord4D, EnumSet<EnumFacing>> entry : net.acceptorDirections.entrySet()) {
             Coord4D coord = entry.getKey();

--- a/src/main/java/mekanism/common/Mekanism.java
+++ b/src/main/java/mekanism/common/Mekanism.java
@@ -1033,7 +1033,7 @@ public class Mekanism {
     public void onEnergyTransferred(EnergyTransferEvent event) {
         try {
             packetHandler.sendToReceivers(new TransmitterUpdateMessage(PacketType.ENERGY,
-                        event.energyNetwork.transmitters.iterator().next().coord(), event.power),
+                        event.energyNetwork.firstTransmitter().coord(), event.power),
                   event.energyNetwork.getPacketRange());
         } catch (Exception ignored) {
         }
@@ -1043,7 +1043,7 @@ public class Mekanism {
     public void onGasTransferred(GasTransferEvent event) {
         try {
             packetHandler.sendToReceivers(
-                  new TransmitterUpdateMessage(PacketType.GAS, event.gasNetwork.transmitters.iterator().next().coord(),
+                  new TransmitterUpdateMessage(PacketType.GAS, event.gasNetwork.firstTransmitter().coord(),
                         event.transferType, event.didTransfer), event.gasNetwork.getPacketRange());
         } catch (Exception ignored) {
         }
@@ -1053,7 +1053,7 @@ public class Mekanism {
     public void onLiquidTransferred(FluidTransferEvent event) {
         try {
             packetHandler.sendToReceivers(new TransmitterUpdateMessage(PacketType.FLUID,
-                        event.fluidNetwork.transmitters.iterator().next().coord(), event.fluidType, event.didTransfer),
+                        event.fluidNetwork.firstTransmitter().coord(), event.fluidType, event.didTransfer),
                   event.fluidNetwork.getPacketRange());
         } catch (Exception ignored) {
         }
@@ -1063,7 +1063,7 @@ public class Mekanism {
     public void onTransmittersAddedEvent(TransmittersAddedEvent event) {
         try {
             packetHandler.sendToReceivers(
-                  new TransmitterUpdateMessage(PacketType.UPDATE, event.network.transmitters.iterator().next().coord(),
+                  new TransmitterUpdateMessage(PacketType.UPDATE, event.network.firstTransmitter().coord(),
                         event.newNetwork, event.newTransmitters), event.network.getPacketRange());
         } catch (Exception ignored) {
         }

--- a/src/main/java/mekanism/common/item/ItemNetworkReader.java
+++ b/src/main/java/mekanism/common/item/ItemNetworkReader.java
@@ -124,7 +124,7 @@ public class ItemNetworkReader extends ItemEnergized {
                                   .getCapability(tile, Capabilities.GRID_TRANSMITTER_CAPABILITY,
                                         iterSide.getOpposite());
 
-                            if (transmitter.getTransmitterNetwork().possibleAcceptors
+                            if (transmitter.getTransmitterNetwork().getPossibleAcceptors()
                                   .contains(coord.offset(iterSide.getOpposite())) && !iteratedNetworks
                                   .contains(transmitter.getTransmitterNetwork())) {
                                 player.sendMessage(new TextComponentString(
@@ -133,7 +133,7 @@ public class ItemNetworkReader extends ItemEnergized {
                                             + " -------------"));
                                 player.sendMessage(new TextComponentString(
                                       EnumColor.GREY + " *Connected sides: " + EnumColor.DARK_GREY + transmitter
-                                            .getTransmitterNetwork().acceptorDirections
+                                            .getTransmitterNetwork().getAcceptorDirections()
                                             .get(coord.offset(iterSide.getOpposite()))));
                                 player.sendMessage(new TextComponentString(
                                       EnumColor.GREY + "------------- " + EnumColor.DARK_BLUE + "[=======]"

--- a/src/main/java/mekanism/common/item/ItemNetworkReader.java
+++ b/src/main/java/mekanism/common/item/ItemNetworkReader.java
@@ -125,7 +125,7 @@ public class ItemNetworkReader extends ItemEnergized {
                                         iterSide.getOpposite());
 
                             if (transmitter.getTransmitterNetwork().possibleAcceptors
-                                  .containsKey(coord.offset(iterSide.getOpposite())) && !iteratedNetworks
+                                  .contains(coord.offset(iterSide.getOpposite())) && !iteratedNetworks
                                   .contains(transmitter.getTransmitterNetwork())) {
                                 player.sendMessage(new TextComponentString(
                                       EnumColor.GREY + "------------- " + EnumColor.DARK_BLUE + "[" + transmitter

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityMechanicalPipe.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityMechanicalPipe.java
@@ -89,17 +89,16 @@ public class TileEntityMechanicalPipe extends TileEntityTransmitter<IFluidHandle
     }
 
     private FluidStack getSaveShare() {
-        if (getTransmitter().hasTransmitterNetwork() && getTransmitter().getTransmitterNetwork().buffer != null) {
-            int remain = getTransmitter().getTransmitterNetwork().buffer.amount % getTransmitter()
-                  .getTransmitterNetwork().transmitters.size();
-            int toSave = getTransmitter().getTransmitterNetwork().buffer.amount / getTransmitter()
-                  .getTransmitterNetwork().transmitters.size();
+        FluidNetwork transmitterNetwork = getTransmitter().getTransmitterNetwork();
+        if (getTransmitter().hasTransmitterNetwork() && transmitterNetwork.buffer != null) {
+            int remain = transmitterNetwork.buffer.amount % transmitterNetwork.transmittersSize();
+            int toSave = transmitterNetwork.buffer.amount / transmitterNetwork.transmittersSize();
 
-            if (getTransmitter().getTransmitterNetwork().transmitters.iterator().next().equals(getTransmitter())) {
+            if (transmitterNetwork.firstTransmitter().equals(getTransmitter())) {
                 toSave += remain;
             }
 
-            return PipeUtils.copy(getTransmitter().getTransmitterNetwork().buffer, toSave);
+            return PipeUtils.copy(transmitterNetwork.buffer, toSave);
         }
 
         return null;

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityPressurizedTube.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityPressurizedTube.java
@@ -124,11 +124,11 @@ public class TileEntityPressurizedTube extends TileEntityTransmitter<IGasHandler
     private GasStack getSaveShare() {
         if (getTransmitter().hasTransmitterNetwork() && getTransmitter().getTransmitterNetwork().buffer != null) {
             int remain = getTransmitter().getTransmitterNetwork().buffer.amount % getTransmitter()
-                  .getTransmitterNetwork().transmitters.size();
+                  .getTransmitterNetwork().transmittersSize();
             int toSave = getTransmitter().getTransmitterNetwork().buffer.amount / getTransmitter()
-                  .getTransmitterNetwork().transmitters.size();
+                  .getTransmitterNetwork().transmittersSize();
 
-            if (getTransmitter().getTransmitterNetwork().transmitters.iterator().next().equals(getTransmitter())) {
+            if (getTransmitter().getTransmitterNetwork().firstTransmitter().equals(getTransmitter())) {
                 toSave += remain;
             }
 

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityTransmitter.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityTransmitter.java
@@ -1,11 +1,8 @@
 package mekanism.common.tile.transmitter;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.Set;
+import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import mekanism.api.Coord4D;
@@ -154,7 +151,7 @@ public abstract class TileEntityTransmitter<A, N extends DynamicNetwork<A, N, BU
         N network = getTransmitter().getTransmitterNetwork();
         network.queueClientUpdate(network.getTransmitters());
         //Copy values into an array so that we don't risk a CME
-       IGridTransmitter[] transmitters = network.getTransmitters().toArray(new IGridTransmitter[network.transmittersSize()]);
+        IGridTransmitter[] transmitters = network.getTransmitters().toArray(new IGridTransmitter[0]);
         //TODO: Make some better way of refreshing the connections, given we only need to refresh
         // connections to ourself anyways
         // The best way to do this is probably by making a method that updates the values for
@@ -229,10 +226,9 @@ public abstract class TileEntityTransmitter<A, N extends DynamicNetwork<A, N, BU
     public void onAlloyInteraction(EntityPlayer player, EnumHand hand, ItemStack stack, int tierOrdinal) {
         if (getTransmitter().hasTransmitterNetwork()) {
             int upgraded = 0;
-            ArrayList<IGridTransmitter<A,N,BUFFER>> list = new ArrayList<>(getTransmitter().getTransmitterNetwork().getTransmitters());
+            List<IGridTransmitter<A, N, BUFFER>> list = new ArrayList<>(getTransmitter().getTransmitterNetwork().getTransmitters());
 
-            list.sort((o1, o2) ->
-            {
+            list.sort((o1, o2) -> {
                 if (o1 != null && o2 != null) {
                     Coord4D thisCoord = new Coord4D(getPos(), getWorld());
 
@@ -245,7 +241,7 @@ public abstract class TileEntityTransmitter<A, N extends DynamicNetwork<A, N, BU
                 return 0;
             });
 
-            for (IGridTransmitter<A,N,BUFFER> iter : list) {
+            for (IGridTransmitter<A, N, BUFFER> iter : list) {
                 if (iter instanceof TransmitterImpl) {
                     TileEntityTransmitter t = ((TransmitterImpl) iter).containingTile;
 

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityTransmitter.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityTransmitter.java
@@ -153,16 +153,16 @@ public abstract class TileEntityTransmitter<A, N extends DynamicNetwork<A, N, BU
         // and to update the rendering of them
         N network = getTransmitter().getTransmitterNetwork();
         network.queueClientUpdate(network.getTransmitters());
-        //Copy values into a set so that we don't risk a CME
-        Set<IGridTransmitter<A, N, BUFFER>> transmitters = new HashSet<>(network.getTransmitters());
+        //Copy values into an array so that we don't risk a CME
+       IGridTransmitter[] transmitters = network.getTransmitters().toArray(new IGridTransmitter[network.transmittersSize()]);
         //TODO: Make some better way of refreshing the connections, given we only need to refresh
         // connections to ourself anyways
         // The best way to do this is probably by making a method that updates the values for
         // the valid transmitters manually if the network is the same object.
-        for (IGridTransmitter<A, N, BUFFER> transmitter : transmitters) {
+        for (IGridTransmitter transmitter : transmitters) {
             if (transmitter instanceof TransmitterImpl) {
                 //Refresh the connections because otherwise sometimes they need to wait for a block update
-                ((TransmitterImpl<A, N, BUFFER>) transmitter).containingTile.refreshConnections();
+                ((TransmitterImpl) transmitter).containingTile.refreshConnections();
             }
         }
     }

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityTransmitter.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityTransmitter.java
@@ -1,5 +1,6 @@
 package mekanism.common.tile.transmitter;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
@@ -151,9 +152,9 @@ public abstract class TileEntityTransmitter<A, N extends DynamicNetwork<A, N, BU
         //Queue an update for all the transmitters in the network just in case something went wrong
         // and to update the rendering of them
         N network = getTransmitter().getTransmitterNetwork();
-        network.queueClientUpdate(network.transmitters);
+        network.queueClientUpdate(network.getTransmitters());
         //Copy values into a set so that we don't risk a CME
-        Set<IGridTransmitter<A, N, BUFFER>> transmitters = new HashSet<>(network.transmitters);
+        Set<IGridTransmitter<A, N, BUFFER>> transmitters = new HashSet<>(network.getTransmitters());
         //TODO: Make some better way of refreshing the connections, given we only need to refresh
         // connections to ourself anyways
         // The best way to do this is probably by making a method that updates the values for
@@ -228,15 +229,15 @@ public abstract class TileEntityTransmitter<A, N extends DynamicNetwork<A, N, BU
     public void onAlloyInteraction(EntityPlayer player, EnumHand hand, ItemStack stack, int tierOrdinal) {
         if (getTransmitter().hasTransmitterNetwork()) {
             int upgraded = 0;
-            Object[] array = ((LinkedHashSet) getTransmitter().getTransmitterNetwork().transmitters.clone()).toArray();
+            ArrayList<IGridTransmitter<A,N,BUFFER>> list = new ArrayList<>(getTransmitter().getTransmitterNetwork().getTransmitters());
 
-            Arrays.sort(array, (o1, o2) ->
+            list.sort((o1, o2) ->
             {
-                if (o1 instanceof IGridTransmitter && o2 instanceof IGridTransmitter) {
+                if (o1 != null && o2 != null) {
                     Coord4D thisCoord = new Coord4D(getPos(), getWorld());
 
-                    Coord4D o1Coord = ((IGridTransmitter) o1).coord();
-                    Coord4D o2Coord = ((IGridTransmitter) o2).coord();
+                    Coord4D o1Coord = o1.coord();
+                    Coord4D o2Coord = o2.coord();
 
                     return Integer.compare(o1Coord.distanceTo(thisCoord), o2Coord.distanceTo(thisCoord));
                 }
@@ -244,7 +245,7 @@ public abstract class TileEntityTransmitter<A, N extends DynamicNetwork<A, N, BU
                 return 0;
             });
 
-            for (Object iter : array) {
+            for (IGridTransmitter<A,N,BUFFER> iter : list) {
                 if (iter instanceof TransmitterImpl) {
                     TileEntityTransmitter t = ((TransmitterImpl) iter).containingTile;
 

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityUniversalCable.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityUniversalCable.java
@@ -186,7 +186,7 @@ public class TileEntityUniversalCable extends
     private double getSaveShare() {
         if (getTransmitter().hasTransmitterNetwork()) {
             return EnergyNetwork.round(getTransmitter().getTransmitterNetwork().buffer.amount * (1F / getTransmitter()
-                  .getTransmitterNetwork().transmitters.size()));
+                  .getTransmitterNetwork().transmittersSize()));
         } else {
             return buffer.amount;
         }

--- a/src/main/java/mekanism/common/transmitters/Transmitter.java
+++ b/src/main/java/mekanism/common/transmitters/Transmitter.java
@@ -21,18 +21,14 @@ public abstract class Transmitter<ACCEPTOR, NETWORK extends DynamicNetwork<ACCEP
         }
 
         if (world().isRemote && theNetwork != null) {
-            theNetwork.transmitters.remove(this);
-
-            if (theNetwork.transmitters.isEmpty()) {
-                theNetwork.deregister();
-            }
+            theNetwork.removeTransmitter(this);
         }
 
         theNetwork = network;
         orphaned = theNetwork == null;
 
         if (world().isRemote && theNetwork != null) {
-            theNetwork.transmitters.add(this);
+            theNetwork.addTransmitter(this);
         }
 
         setRequestsUpdate();

--- a/src/main/java/mekanism/common/transmitters/grid/EnergyNetwork.java
+++ b/src/main/java/mekanism/common/transmitters/grid/EnergyNetwork.java
@@ -104,7 +104,7 @@ public class EnergyNetwork extends DynamicNetwork<EnergyAcceptorWrapper, EnergyN
     private double tickEmit(double energyToSend) {
         Set<EnergyAcceptorTarget> targets = new HashSet<>();
         int totalHandlers = 0;
-        for (Coord4D coord : possibleAcceptors.keySet()) {
+        for (Coord4D coord : possibleAcceptors) {
             EnumSet<EnumFacing> sides = acceptorDirections.get(coord);
             if (sides == null || sides.isEmpty()) {
                 continue;

--- a/src/main/java/mekanism/common/transmitters/grid/FluidNetwork.java
+++ b/src/main/java/mekanism/common/transmitters/grid/FluidNetwork.java
@@ -127,7 +127,7 @@ public class FluidNetwork extends DynamicNetwork<IFluidHandler, FluidNetwork, Fl
     private int tickEmit(FluidStack fluidToSend) {
         Set<FluidHandlerTarget> availableAcceptors = new HashSet<>();
         int totalHandlers = 0;
-        for (Coord4D coord : possibleAcceptors.keySet()) {
+        for (Coord4D coord : possibleAcceptors) {
             EnumSet<EnumFacing> sides = acceptorDirections.get(coord);
             if (sides == null || sides.isEmpty()) {
                 continue;

--- a/src/main/java/mekanism/common/transmitters/grid/GasNetwork.java
+++ b/src/main/java/mekanism/common/transmitters/grid/GasNetwork.java
@@ -132,7 +132,7 @@ public class GasNetwork extends DynamicNetwork<IGasHandler, GasNetwork, GasStack
         Set<GasHandlerTarget> availableAcceptors = new HashSet<>();
         int totalHandlers = 0;
         Gas type = stack.getGas();
-        for (Coord4D coord : possibleAcceptors.keySet()) {
+        for (Coord4D coord : possibleAcceptors) {
             EnumSet<EnumFacing> sides = acceptorDirections.get(coord);
             if (sides == null || sides.isEmpty()) {
                 continue;

--- a/src/main/java/mekanism/common/transmitters/grid/InventoryNetwork.java
+++ b/src/main/java/mekanism/common/transmitters/grid/InventoryNetwork.java
@@ -34,7 +34,7 @@ public class InventoryNetwork extends DynamicNetwork<TileEntity, InventoryNetwor
     public List<AcceptorData> calculateAcceptors(TransitRequest request, TransporterStack stack) {
         List<AcceptorData> toReturn = new ArrayList<>();
 
-        for (Coord4D coord : possibleAcceptors.keySet()) {
+        for (Coord4D coord : possibleAcceptors) {
             if (coord == null || coord.equals(stack.homeLocation)) {
                 continue;
             }


### PR DESCRIPTION
## Changes proposed in this pull request:
`mekanism.api.transmitters.DynamicNetwork#possibleAcceptors` no longer seems to have its values used, so given it stores TileEntities, best to be rid of it to avoid being the cause of a memory leak.

Technically is a breaking change to the api hovever.
