### PR TITLE
Transporter performance improvements

### DIFF
--- a/src/main/java/mekanism/api/infuse/InfuseRegistry.java
+++ b/src/main/java/mekanism/api/infuse/InfuseRegistry.java
@@ -2,6 +2,7 @@ package mekanism.api.infuse;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import net.minecraft.item.ItemStack;
 
 /**
@@ -81,7 +82,7 @@ public class InfuseRegistry {
      * @return the ItemStack's InfuseObject
      */
     public static InfuseObject getObject(ItemStack itemStack) {
-        for (Map.Entry<ItemStack, InfuseObject> obj : infuseObjects.entrySet()) {
+        for (Entry<ItemStack, InfuseObject> obj : infuseObjects.entrySet()) {
             if (itemStack.isItemEqual(obj.getKey())) {
                 return obj.getValue();
             }

--- a/src/main/java/mekanism/client/gui/GuiDigitalMinerConfig.java
+++ b/src/main/java/mekanism/client/gui/GuiDigitalMinerConfig.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
@@ -97,38 +98,42 @@ public class GuiDigitalMinerConfig extends GuiMekanismTile<TileEntityDigitalMine
         }
 
         if (stackSwitch == 0) {
-            for (Map.Entry<MOreDictFilter, StackData> entry : oreDictStacks.entrySet()) {
-                if (entry.getValue().iterStacks != null && entry.getValue().iterStacks.size() > 0) {
-                    if (entry.getValue().stackIndex == -1 || entry.getValue().stackIndex == entry.getValue().iterStacks.size() - 1) {
-                        entry.getValue().stackIndex = 0;
-                    } else if (entry.getValue().stackIndex < entry.getValue().iterStacks.size() - 1) {
-                        entry.getValue().stackIndex++;
+            for (Entry<MOreDictFilter, StackData> entry : oreDictStacks.entrySet()) {
+                StackData data = entry.getValue();
+                if (data.iterStacks != null && data.iterStacks.size() > 0) {
+                    if (data.stackIndex == -1 || data.stackIndex == data.iterStacks.size() - 1) {
+                        data.stackIndex = 0;
+                    } else if (data.stackIndex < data.iterStacks.size() - 1) {
+                        data.stackIndex++;
                     }
-                    entry.getValue().renderStack = entry.getValue().iterStacks.get(entry.getValue().stackIndex);
+                    data.renderStack = data.iterStacks.get(data.stackIndex);
                 }
             }
 
-            for (Map.Entry<MModIDFilter, StackData> entry : modIDStacks.entrySet()) {
-                if (entry.getValue().iterStacks != null && entry.getValue().iterStacks.size() > 0) {
-                    if (entry.getValue().stackIndex == -1 || entry.getValue().stackIndex == entry.getValue().iterStacks.size() - 1) {
-                        entry.getValue().stackIndex = 0;
-                    } else if (entry.getValue().stackIndex < entry.getValue().iterStacks.size() - 1) {
-                        entry.getValue().stackIndex++;
+            for (Entry<MModIDFilter, StackData> entry : modIDStacks.entrySet()) {
+                StackData data = entry.getValue();
+                if (data.iterStacks != null && data.iterStacks.size() > 0) {
+                    if (data.stackIndex == -1 || data.stackIndex == data.iterStacks.size() - 1) {
+                        data.stackIndex = 0;
+                    } else if (data.stackIndex < data.iterStacks.size() - 1) {
+                        data.stackIndex++;
                     }
-                    entry.getValue().renderStack = entry.getValue().iterStacks.get(entry.getValue().stackIndex);
+                    data.renderStack = data.iterStacks.get(data.stackIndex);
                 }
             }
 
             stackSwitch = 20;
         } else {
-            for (Map.Entry<MOreDictFilter, StackData> entry : oreDictStacks.entrySet()) {
-                if (entry.getValue().iterStacks != null && entry.getValue().iterStacks.size() == 0) {
-                    entry.getValue().renderStack = ItemStack.EMPTY;
+            for (Entry<MOreDictFilter, StackData> entry : oreDictStacks.entrySet()) {
+                StackData data = entry.getValue();
+                if (data.iterStacks != null && data.iterStacks.size() == 0) {
+                    data.renderStack = ItemStack.EMPTY;
                 }
             }
-            for (Map.Entry<MModIDFilter, StackData> entry : modIDStacks.entrySet()) {
-                if (entry.getValue().iterStacks != null && entry.getValue().iterStacks.size() == 0) {
-                    entry.getValue().renderStack = ItemStack.EMPTY;
+            for (Entry<MModIDFilter, StackData> entry : modIDStacks.entrySet()) {
+                StackData data = entry.getValue();
+                if (data.iterStacks != null && data.iterStacks.size() == 0) {
+                    data.renderStack = ItemStack.EMPTY;
                 }
             }
         }

--- a/src/main/java/mekanism/client/gui/GuiLogisticalSorter.java
+++ b/src/main/java/mekanism/client/gui/GuiLogisticalSorter.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
@@ -115,22 +116,24 @@ public class GuiLogisticalSorter extends GuiMekanismTile<TileEntityLogisticalSor
 
         // Update displayed stacks
         if (stackSwitch == 0) {
-            for (final Map.Entry<TOreDictFilter, StackData> entry : oreDictStacks.entrySet()) {
+            for (final Entry<TOreDictFilter, StackData> entry : oreDictStacks.entrySet()) {
                 setNextRenderStack(entry.getValue());
             }
-            for (final Map.Entry<TModIDFilter, StackData> entry : modIDStacks.entrySet()) {
+            for (final Entry<TModIDFilter, StackData> entry : modIDStacks.entrySet()) {
                 setNextRenderStack(entry.getValue());
             }
             stackSwitch = 20;
         } else {
-            for (final Map.Entry<TOreDictFilter, StackData> entry : oreDictStacks.entrySet()) {
-                if (entry.getValue().iterStacks != null && entry.getValue().iterStacks.size() == 0) {
-                    entry.getValue().renderStack = ItemStack.EMPTY;
+            for (final Entry<TOreDictFilter, StackData> entry : oreDictStacks.entrySet()) {
+                StackData data = entry.getValue();
+                if (data.iterStacks != null && data.iterStacks.size() == 0) {
+                    data.renderStack = ItemStack.EMPTY;
                 }
             }
-            for (final Map.Entry<TModIDFilter, StackData> entry : modIDStacks.entrySet()) {
-                if (entry.getValue().iterStacks != null && entry.getValue().iterStacks.size() == 0) {
-                    entry.getValue().renderStack = ItemStack.EMPTY;
+            for (Entry<TModIDFilter, StackData> entry : modIDStacks.entrySet()) {
+                StackData data = entry.getValue();
+                if (data.iterStacks != null && data.iterStacks.size() == 0) {
+                    data.renderStack = ItemStack.EMPTY;
                 }
             }
         }

--- a/src/main/java/mekanism/client/gui/GuiSideConfiguration.java
+++ b/src/main/java/mekanism/client/gui/GuiSideConfiguration.java
@@ -46,7 +46,7 @@ public class GuiSideConfiguration extends GuiMekanismTile<TileEntityContainerBlo
         ySize = 95;
         configurable = tile;
         ResourceLocation resource = getGuiLocation();
-        for (TransmissionType type : configurable.getConfig().transmissions) {
+        for (TransmissionType type : configurable.getConfig().getTransmissions()) {
             GuiConfigTypeTab tab = new GuiConfigTypeTab(this, type, resource);
             addGuiElement(tab);
             configTabs.add(tab);
@@ -62,7 +62,7 @@ public class GuiSideConfiguration extends GuiMekanismTile<TileEntityContainerBlo
     }
 
     public TransmissionType getTopTransmission() {
-        return configurable.getConfig().transmissions.get(0);
+        return configurable.getConfig().getTransmissions().get(0);
     }
 
     public void setCurrentType(TransmissionType type) {

--- a/src/main/java/mekanism/client/render/ColourTemperature.java
+++ b/src/main/java/mekanism/client/render/ColourTemperature.java
@@ -1,12 +1,13 @@
 package mekanism.client.render;
 
 import java.util.HashMap;
+import java.util.Map;
 import mekanism.api.IHeatTransfer;
 import mekanism.common.ColourRGBA;
 
 public class ColourTemperature extends ColourRGBA {
 
-    public static HashMap<Integer, ColourTemperature> cache = new HashMap<>();
+    public static Map<Integer, ColourTemperature> cache = new HashMap<>();
 
     public double temp;
 

--- a/src/main/java/mekanism/client/render/ColourTemperature.java
+++ b/src/main/java/mekanism/client/render/ColourTemperature.java
@@ -1,5 +1,7 @@
 package mekanism.client.render;
 
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import java.util.HashMap;
 import java.util.Map;
 import mekanism.api.IHeatTransfer;
@@ -7,7 +9,7 @@ import mekanism.common.ColourRGBA;
 
 public class ColourTemperature extends ColourRGBA {
 
-    public static Map<Integer, ColourTemperature> cache = new HashMap<>();
+    public static Int2ObjectMap<ColourTemperature> cache = new Int2ObjectOpenHashMap<>();
 
     public double temp;
 
@@ -77,33 +79,11 @@ public class ColourTemperature extends ColourRGBA {
 
         alpha = temperature / 1000;
 
-        if (red < 0) {
-            red = 0;
-        }
-        if (red > 1) {
-            red = 1;
-        }
-
-        if (green < 0) {
-            green = 0;
-        }
-        if (green > 1) {
-            green = 1;
-        }
-
-        if (blue < 0) {
-            blue = 0;
-        }
-        if (blue > 1) {
-            blue = 1;
-        }
-
-        if (alpha < 0) {
-            alpha = 0;
-        }
-        if (alpha > 1) {
-            alpha = 1;
-        }
+        //clamp to 0 <= n >= 1
+        red = Math.min(Math.max(red, 0), 1);
+        green = Math.min(Math.max(green, 0), 1);
+        blue = Math.min(Math.max(blue, 0), 1);
+        alpha = Math.min(Math.max(alpha, 0), 1);
 
         ColourTemperature colourTemperature = new ColourTemperature(red, green, blue, alpha, temperature);
         cache.put((int) absTemp, colourTemperature);

--- a/src/main/java/mekanism/client/render/MekanismRenderer.java
+++ b/src/main/java/mekanism/client/render/MekanismRenderer.java
@@ -1,7 +1,7 @@
 package mekanism.client.render;
 
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.Map;
 import mekanism.api.EnumColor;
 import mekanism.api.gas.Gas;
@@ -56,7 +56,7 @@ public class MekanismRenderer {
     public static TextureAtlasSprite heatIcon;
     public static TextureAtlasSprite laserIcon;
     public static float GAS_RENDER_BASE = 0.2F;
-    public static Map<TransmissionType, TextureAtlasSprite> overlays = new HashMap<>();
+    public static Map<TransmissionType, TextureAtlasSprite> overlays = new EnumMap<>(TransmissionType.class);
     public static int[] directionMap = new int[]{3, 0, 1, 2};
     private static RenderConfigurableMachine machineRenderer = new RenderConfigurableMachine();
     public static TextureAtlasSprite missingIcon;

--- a/src/main/java/mekanism/client/render/item/basicblock/RenderBasicBlockItem.java
+++ b/src/main/java/mekanism/client/render/item/basicblock/RenderBasicBlockItem.java
@@ -1,6 +1,6 @@
 package mekanism.client.render.item.basicblock;
 
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -15,7 +15,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 @SideOnly(Side.CLIENT)
 public class RenderBasicBlockItem extends SubTypeItemRenderer<BasicBlockType> {
 
-    public static Map<BasicBlockType, ItemLayerWrapper> modelMap = new HashMap<>();
+    public static Map<BasicBlockType, ItemLayerWrapper> modelMap = new EnumMap<>(BasicBlockType.class);
 
     @Override
     protected boolean earlyExit() {

--- a/src/main/java/mekanism/client/render/item/machine/RenderMachineItem.java
+++ b/src/main/java/mekanism/client/render/item/machine/RenderMachineItem.java
@@ -1,6 +1,6 @@
 package mekanism.client.render.item.machine;
 
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -15,7 +15,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 @SideOnly(Side.CLIENT)
 public class RenderMachineItem extends SubTypeItemRenderer<MachineType> {
 
-    public static Map<MachineType, ItemLayerWrapper> modelMap = new HashMap<>();
+    public static Map<MachineType, ItemLayerWrapper> modelMap = new EnumMap<>(MachineType.class);
 
     @Override
     protected boolean earlyExit() {

--- a/src/main/java/mekanism/client/render/tileentity/RenderConfigurableMachine.java
+++ b/src/main/java/mekanism/client/render/tileentity/RenderConfigurableMachine.java
@@ -1,5 +1,6 @@
 package mekanism.client.render.tileentity;
 
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -109,7 +110,7 @@ public class RenderConfigurableMachine<S extends TileEntity & ISideConfiguration
         if (cachedOverlays.containsKey(side)) {
             cachedOverlays.get(side).put(type, display);
         } else {
-            Map<TransmissionType, DisplayInteger> map = new HashMap<>();
+            Map<TransmissionType, DisplayInteger> map = new EnumMap<>(TransmissionType.class);
             map.put(type, display);
             cachedOverlays.put(side, map);
         }

--- a/src/main/java/mekanism/client/render/tileentity/RenderConfigurableMachine.java
+++ b/src/main/java/mekanism/client/render/tileentity/RenderConfigurableMachine.java
@@ -1,7 +1,6 @@
 package mekanism.client.render.tileentity;
 
 import java.util.EnumMap;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import mekanism.api.transmitters.TransmissionType;
@@ -34,7 +33,7 @@ public class RenderConfigurableMachine<S extends TileEntity & ISideConfiguration
 
     private Minecraft mc = FMLClientHandler.instance().getClient();
 
-    private Map<EnumFacing, Map<TransmissionType, DisplayInteger>> cachedOverlays = new HashMap<>();
+    private Map<EnumFacing, Map<TransmissionType, DisplayInteger>> cachedOverlays = new EnumMap<>(EnumFacing.class);
 
     public RenderConfigurableMachine() {
         rendererDispatcher = TileEntityRendererDispatcher.instance;

--- a/src/main/java/mekanism/client/render/tileentity/RenderEnergyCube.java
+++ b/src/main/java/mekanism/client/render/tileentity/RenderEnergyCube.java
@@ -1,6 +1,6 @@
 package mekanism.client.render.tileentity;
 
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.Map;
 import mekanism.api.transmitters.TransmissionType;
 import mekanism.client.MekanismClient;
@@ -23,7 +23,7 @@ import org.lwjgl.opengl.GL11;
 public class RenderEnergyCube extends TileEntitySpecialRenderer<TileEntityEnergyCube> {
 
     public static int[][] COLORS = new int[][]{new int[]{100, 210, 125}, new int[]{215, 85, 70}, new int[]{80, 125, 230}, new int[]{154, 120, 200}, new int[]{0, 0, 0}};
-    public static Map<EnergyCubeTier, ResourceLocation> resources = new HashMap<>();
+    public static Map<EnergyCubeTier, ResourceLocation> resources = new EnumMap<>(EnergyCubeTier.class);
     public static ResourceLocation baseTexture = MekanismUtils.getResource(ResourceType.RENDER, "EnergyCube.png");
     public static ResourceLocation coreTexture = MekanismUtils.getResource(ResourceType.RENDER, "EnergyCore.png");
 

--- a/src/main/java/mekanism/client/render/tileentity/RenderTeleporter.java
+++ b/src/main/java/mekanism/client/render/tileentity/RenderTeleporter.java
@@ -1,6 +1,7 @@
 package mekanism.client.render.tileentity;
 
 import java.util.HashMap;
+import java.util.Map;
 import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
 import mekanism.client.render.MekanismRenderer;
@@ -18,15 +19,14 @@ import org.lwjgl.opengl.GL11;
 
 public class RenderTeleporter extends TileEntitySpecialRenderer<TileEntityTeleporter> {
 
-    private HashMap<Integer, DisplayInteger> cachedOverlays = new HashMap<>();
+    private Map<Integer, DisplayInteger> cachedOverlays = new HashMap<>();
 
     @Override
     public void render(TileEntityTeleporter tileEntity, double x, double y, double z, float partialTick, int destroyStage, float alpha) {
         if (tileEntity.shouldRender) {
             push();
 
-            GL11.glColor4f(EnumColor.PURPLE.getColor(0), EnumColor.PURPLE.getColor(1), EnumColor.PURPLE.getColor(2),
-                  0.75F);
+            GL11.glColor4f(EnumColor.PURPLE.getColor(0), EnumColor.PURPLE.getColor(1), EnumColor.PURPLE.getColor(2), 0.75F);
 
             bindTexture(MekanismRenderer.getBlocksTexture());
             GlStateManager.translate((float) x, (float) y, (float) z);

--- a/src/main/java/mekanism/client/render/transmitter/RenderLogisticalTransporter.java
+++ b/src/main/java/mekanism/client/render/transmitter/RenderLogisticalTransporter.java
@@ -98,7 +98,7 @@ public class RenderLogisticalTransporter extends RenderTransmitterBase<TileEntit
             if (pos != null && !itemStack.isEmpty() && itemStack.getItem() instanceof ItemConfigurator) {
                 Coord4D obj = new Coord4D(pos.getBlockPos(), transporter.getWorld());
 
-                if (obj.equals(new Coord4D(transporter.getPos(), transporter.getWorld()))) {
+                if (obj.equals(new Coord4D(transporter.getPos(), transporter.getWorld())) && pos.sideHit != null) {
                     int mode = ((TileEntityDiversionTransporter) transporter).modes[pos.sideHit.ordinal()];
 
                     pushTransporter();

--- a/src/main/java/mekanism/client/render/transmitter/RenderLogisticalTransporter.java
+++ b/src/main/java/mekanism/client/render/transmitter/RenderLogisticalTransporter.java
@@ -1,6 +1,8 @@
 package mekanism.client.render.transmitter;
 
+import java.util.EnumMap;
 import java.util.HashMap;
+import java.util.Map;
 import mekanism.api.Coord4D;
 import mekanism.client.model.ModelTransporterBox;
 import mekanism.client.render.MekanismRenderer;
@@ -30,7 +32,7 @@ import org.lwjgl.opengl.GL11;
 
 public class RenderLogisticalTransporter extends RenderTransmitterBase<TileEntityLogisticalTransporter> {
 
-    private static HashMap<EnumFacing, HashMap<Integer, DisplayInteger>> cachedOverlays = new HashMap<>();
+    private static Map<EnumFacing, Map<Integer, DisplayInteger>> cachedOverlays = new EnumMap<>(EnumFacing.class);
     private static TextureAtlasSprite gunpowderIcon;
     private static TextureAtlasSprite torchOffIcon;
     private static TextureAtlasSprite torchOnIcon;
@@ -147,7 +149,7 @@ public class RenderLogisticalTransporter extends RenderTransmitterBase<TileEntit
         if (cachedOverlays.containsKey(side)) {
             cachedOverlays.get(side).put(mode, display);
         } else {
-            HashMap<Integer, DisplayInteger> map = new HashMap<>();
+            Map<Integer, DisplayInteger> map = new HashMap<>();
             map.put(mode, display);
             cachedOverlays.put(side, map);
         }

--- a/src/main/java/mekanism/client/render/transmitter/RenderMechanicalPipe.java
+++ b/src/main/java/mekanism/client/render/transmitter/RenderMechanicalPipe.java
@@ -1,5 +1,8 @@
 package mekanism.client.render.transmitter;
 
+import it.unimi.dsi.fastutil.ints.Int2ObjectArrayMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
 import mekanism.client.render.FluidRenderMap;
@@ -26,7 +29,8 @@ public class RenderMechanicalPipe extends RenderTransmitterBase<TileEntityMechan
     private static final int stages = 100;
     private static final double height = 0.45;
     private static final double offset = 0.015;
-    private static Map<Integer, FluidRenderMap<DisplayInteger[]>> cachedLiquids = new HashMap<>();
+    //TODO this is basically used as an enum map (EnumFacing), but null key is possible, which EnumMap doesn't support. 6 is used for null side
+    private static Int2ObjectMap<FluidRenderMap<DisplayInteger[]>> cachedLiquids = new Int2ObjectArrayMap<>(7);
 
     public static void onStitch() {
         cachedLiquids.clear();

--- a/src/main/java/mekanism/client/render/transmitter/RenderMechanicalPipe.java
+++ b/src/main/java/mekanism/client/render/transmitter/RenderMechanicalPipe.java
@@ -1,6 +1,7 @@
 package mekanism.client.render.transmitter;
 
 import java.util.HashMap;
+import java.util.Map;
 import mekanism.client.render.FluidRenderMap;
 import mekanism.client.render.MekanismRenderer;
 import mekanism.client.render.MekanismRenderer.DisplayInteger;
@@ -25,7 +26,7 @@ public class RenderMechanicalPipe extends RenderTransmitterBase<TileEntityMechan
     private static final int stages = 100;
     private static final double height = 0.45;
     private static final double offset = 0.015;
-    private static HashMap<Integer, FluidRenderMap<DisplayInteger[]>> cachedLiquids = new HashMap<>();
+    private static Map<Integer, FluidRenderMap<DisplayInteger[]>> cachedLiquids = new HashMap<>();
 
     public static void onStitch() {
         cachedLiquids.clear();

--- a/src/main/java/mekanism/client/render/transmitter/RenderTransmitterBase.java
+++ b/src/main/java/mekanism/client/render/transmitter/RenderTransmitterBase.java
@@ -46,8 +46,8 @@ public abstract class RenderTransmitterBase<T extends TileEntityTransmitter> ext
         }
     }
 
-    public static HashMap<String, IBakedModel> buildModelMap(OBJModel objModel) {
-        HashMap<String, IBakedModel> modelParts = new HashMap<>();
+    public static Map<String, IBakedModel> buildModelMap(OBJModel objModel) {
+        Map<String, IBakedModel> modelParts = new HashMap<>();
         Set<String> keys = objModel.getMatLib().getGroups().keySet();
         if (!keys.isEmpty()) {
             for (String key : keys) {

--- a/src/main/java/mekanism/common/CommonWorldTickHandler.java
+++ b/src/main/java/mekanism/common/CommonWorldTickHandler.java
@@ -1,5 +1,7 @@
 package mekanism.common;
 
+import it.unimi.dsi.fastutil.ints.Int2ObjectArrayMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
@@ -19,11 +21,11 @@ public class CommonWorldTickHandler {
 
     private static final long maximumDeltaTimeNanoSecs = 16000000; // 16 milliseconds
 
-    private Map<Integer, Queue<ChunkPos>> chunkRegenMap;
+    private Int2ObjectMap<Queue<ChunkPos>> chunkRegenMap;
 
     public void addRegenChunk(int dimensionId, ChunkPos chunkCoord) {
         if (chunkRegenMap == null) {
-            chunkRegenMap = new HashMap<>();
+            chunkRegenMap = new Int2ObjectArrayMap<>();
         }
         if (!chunkRegenMap.containsKey(dimensionId)) {
             LinkedList<ChunkPos> list = new LinkedList<>();

--- a/src/main/java/mekanism/common/CommonWorldTickHandler.java
+++ b/src/main/java/mekanism/common/CommonWorldTickHandler.java
@@ -2,6 +2,7 @@ package mekanism.common;
 
 import java.util.HashMap;
 import java.util.LinkedList;
+import java.util.Map;
 import java.util.Queue;
 import java.util.Random;
 import mekanism.common.frequency.FrequencyManager;
@@ -18,7 +19,7 @@ public class CommonWorldTickHandler {
 
     private static final long maximumDeltaTimeNanoSecs = 16000000; // 16 milliseconds
 
-    private HashMap<Integer, Queue<ChunkPos>> chunkRegenMap;
+    private Map<Integer, Queue<ChunkPos>> chunkRegenMap;
 
     public void addRegenChunk(int dimensionId, ChunkPos chunkCoord) {
         if (chunkRegenMap == null) {

--- a/src/main/java/mekanism/common/FuelHandler.java
+++ b/src/main/java/mekanism/common/FuelHandler.java
@@ -4,6 +4,7 @@ import buildcraft.api.fuels.BuildcraftFuelRegistry;
 import buildcraft.api.fuels.IFuel;
 import buildcraft.api.mj.MjAPI;
 import java.util.HashMap;
+import java.util.Map;
 import mekanism.api.gas.Gas;
 import mekanism.common.config.MekanismConfig;
 import mekanism.common.util.MekanismUtils;
@@ -13,7 +14,7 @@ import net.minecraftforge.fml.common.ModAPIManager;
 
 public class FuelHandler {
 
-    public static HashMap<String, FuelGas> fuels = new HashMap<>();
+    public static Map<String, FuelGas> fuels = new HashMap<>();
 
     public static void addGas(Gas gas, int burnTicks, double energyPerMilliBucket) {
         fuels.put(gas.getName(), new FuelGas(burnTicks, energyPerMilliBucket));

--- a/src/main/java/mekanism/common/Mekanism.java
+++ b/src/main/java/mekanism/common/Mekanism.java
@@ -8,6 +8,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.UUID;
 import mekanism.api.Coord4D;
@@ -865,7 +866,7 @@ public class Mekanism {
 
         // Add all furnace recipes to the energized smelter
         // Must happen after CraftTweaker for vanilla stuff has run.
-        for (Map.Entry<ItemStack, ItemStack> entry : FurnaceRecipes.instance().getSmeltingList().entrySet()) {
+        for (Entry<ItemStack, ItemStack> entry : FurnaceRecipes.instance().getSmeltingList().entrySet()) {
             SmeltingRecipe recipe = new SmeltingRecipe(new ItemStackInput(entry.getKey()), new ItemStackOutput(entry.getValue()));
             Recipe.ENERGIZED_SMELTER.put(recipe);
         }

--- a/src/main/java/mekanism/common/OreDictCache.java
+++ b/src/main/java/mekanism/common/OreDictCache.java
@@ -3,6 +3,7 @@ package mekanism.common;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import mekanism.api.util.ItemInfo;
 import mekanism.common.util.ItemRegistryUtils;
 import net.minecraft.item.ItemBlock;
@@ -11,9 +12,9 @@ import net.minecraftforge.oredict.OreDictionary;
 
 public final class OreDictCache {
 
-    public static HashMap<ItemInfo, List<String>> cachedKeys = new HashMap<>();
-    public static HashMap<String, List<ItemStack>> oreDictStacks = new HashMap<>();
-    public static HashMap<String, List<ItemStack>> modIDStacks = new HashMap<>();
+    public static Map<ItemInfo, List<String>> cachedKeys = new HashMap<>();
+    public static Map<String, List<ItemStack>> oreDictStacks = new HashMap<>();
+    public static Map<String, List<ItemStack>> modIDStacks = new HashMap<>();
 
     public static List<String> getOreDictName(ItemStack check) {
         if (check.isEmpty()) {

--- a/src/main/java/mekanism/common/Upgrade.java
+++ b/src/main/java/mekanism/common/Upgrade.java
@@ -1,9 +1,10 @@
 package mekanism.common;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import javax.annotation.Nullable;
 import mekanism.api.EnumColor;
 import mekanism.common.base.IUpgradeTile;
@@ -34,7 +35,7 @@ public enum Upgrade {
     }
 
     public static Map<Upgrade, Integer> buildMap(@Nullable NBTTagCompound nbtTags) {
-        Map<Upgrade, Integer> upgrades = new HashMap<>();
+        Map<Upgrade, Integer> upgrades = new EnumMap<>(Upgrade.class);
         if (nbtTags != null) {
             if (nbtTags.hasKey("upgrades")) {
                 NBTTagList list = nbtTags.getTagList("upgrades", NBT.TAG_COMPOUND);
@@ -50,7 +51,7 @@ public enum Upgrade {
 
     public static void saveMap(Map<Upgrade, Integer> upgrades, NBTTagCompound nbtTags) {
         NBTTagList list = new NBTTagList();
-        for (Map.Entry<Upgrade, Integer> entry : upgrades.entrySet()) {
+        for (Entry<Upgrade, Integer> entry : upgrades.entrySet()) {
             list.appendTag(getTagFor(entry.getKey(), entry.getValue()));
         }
         nbtTags.setTag("upgrades", list);

--- a/src/main/java/mekanism/common/capabilities/CapabilityWrapperManager.java
+++ b/src/main/java/mekanism/common/capabilities/CapabilityWrapperManager.java
@@ -1,15 +1,14 @@
 package mekanism.common.capabilities;
 
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.Map;
 import net.minecraft.util.EnumFacing;
 
 public class CapabilityWrapperManager<IMPL, WRAPPER> {
 
-    public Map<EnumFacing, WRAPPER> wrappers = new HashMap<>();
-
-    public Class<IMPL> typeClass;
-    public Class<WRAPPER> wrapperClass;
+    private Map<EnumFacing, WRAPPER> wrappers = new EnumMap<>(EnumFacing.class);
+    private Class<IMPL> typeClass;
+    private Class<WRAPPER> wrapperClass;
 
     public CapabilityWrapperManager(Class<IMPL> type, Class<WRAPPER> wrapper) {
         typeClass = type;

--- a/src/main/java/mekanism/common/content/transporter/PathfinderCache.java
+++ b/src/main/java/mekanism/common/content/transporter/PathfinderCache.java
@@ -1,25 +1,28 @@
 package mekanism.common.content.transporter;
 
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import mekanism.api.Coord4D;
 import net.minecraft.util.EnumFacing;
 
 public class PathfinderCache {
 
-    public static Map<PathData, List<Coord4D>> cachedPaths = new HashMap<>();
+    private static Map<PathData, List<Coord4D>> cachedPaths = new HashMap<>();
 
     public static void onChanged(Coord4D location) {
         reset();
     }
 
-    public static List<Coord4D> getCache(Coord4D start, Coord4D end, EnumSet<EnumFacing> sides) {
+    public static void addCachedPath(PathData data, List<Coord4D> coords) {
+        cachedPaths.put(data, coords);
+    }
+
+    public static List<Coord4D> getCache(Coord4D start, Coord4D end, Set<EnumFacing> sides) {
         List<Coord4D> ret = null;
         for (EnumFacing side : sides) {
-            PathData data = new PathData(start, end, side);
-            List<Coord4D> test = cachedPaths.get(data);
+            List<Coord4D> test = cachedPaths.get(new PathData(start, end, side));
             if (ret == null || (test != null && test.size() < ret.size())) {
                 ret = test;
             }
@@ -33,29 +36,34 @@ public class PathfinderCache {
 
     public static class PathData {
 
-        public Coord4D startTransporter;
-
-        public Coord4D end;
-        public EnumFacing endSide;
+        private final Coord4D startTransporter;
+        private final Coord4D end;
+        private final EnumFacing endSide;
+        private final int hash;
 
         public PathData(Coord4D s, Coord4D e, EnumFacing es) {
             startTransporter = s;
             end = e;
             endSide = es;
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            return obj instanceof PathData && ((PathData) obj).startTransporter.equals(startTransporter) && ((PathData) obj).end.equals(end) && ((PathData) obj).endSide.equals(endSide);
-        }
-
-        @Override
-        public int hashCode() {
             int code = 1;
             code = 31 * code + startTransporter.hashCode();
             code = 31 * code + end.hashCode();
             code = 31 * code + endSide.hashCode();
-            return code;
+            hash = code;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj instanceof PathData) {
+                PathData data = (PathData) obj;
+                return data.startTransporter.equals(startTransporter) && data.end.equals(end) && data.endSide.equals(endSide);
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            return hash;
         }
     }
 }

--- a/src/main/java/mekanism/common/content/transporter/TransporterManager.java
+++ b/src/main/java/mekanism/common/content/transporter/TransporterManager.java
@@ -25,20 +25,14 @@ import org.apache.commons.lang3.tuple.Pair;
 
 public class TransporterManager {
 
-    public static Map<Coord4D, Set<TransporterStack>> flowingStacks = new HashMap<>();
+    private static Map<Coord4D, Set<TransporterStack>> flowingStacks = new HashMap<>();
 
     public static void reset() {
         flowingStacks.clear();
     }
 
     public static void add(TransporterStack stack) {
-        Set<TransporterStack> set = new HashSet<>();
-        set.add(stack);
-        if (flowingStacks.get(stack.getDest()) == null) {
-            flowingStacks.put(stack.getDest(), set);
-        } else {
-            flowingStacks.get(stack.getDest()).addAll(set);
-        }
+        flowingStacks.computeIfAbsent(stack.getDest(), k -> new HashSet<>()).add(stack);
     }
 
     public static void remove(TransporterStack stack) {
@@ -47,7 +41,7 @@ public class TransporterManager {
         }
     }
 
-    public static List<TransporterStack> getStacksToDest(Coord4D dest) {
+    private static List<TransporterStack> getStacksToDest(Coord4D dest) {
         List<TransporterStack> ret = new ArrayList<>();
         Set<TransporterStack> transporterStacks = flowingStacks.get(dest);
         if (transporterStacks != null) {

--- a/src/main/java/mekanism/common/content/transporter/TransporterManager.java
+++ b/src/main/java/mekanism/common/content/transporter/TransporterManager.java
@@ -36,22 +36,9 @@ public class TransporterManager {
     }
 
     public static void remove(TransporterStack stack) {
-        if (stack.hasPath() && stack.pathType != Path.NONE) {
+        if (stack.hasPath() && stack.getPathType() != Path.NONE) {
             flowingStacks.get(stack.getDest()).remove(stack);
         }
-    }
-
-    private static List<TransporterStack> getStacksToDest(Coord4D dest) {
-        List<TransporterStack> ret = new ArrayList<>();
-        Set<TransporterStack> transporterStacks = flowingStacks.get(dest);
-        if (transporterStacks != null) {
-            for (TransporterStack stack : transporterStacks) {
-                if (stack != null && stack.pathType != Path.NONE && stack.hasPath() && stack.getDest().equals(dest)) {
-                    ret.add(stack);
-                }
-            }
-        }
-        return ret;
     }
 
     private static int simulateInsert(IItemHandler handler, InventoryInfo inventoryInfo, ItemStack stack) {
@@ -157,10 +144,15 @@ public class TransporterManager {
 
         //For each of the in-flight stacks, simulate their insert into the tile entity. Note that stackSizes
         // for inventoryInfo is updated each time
-        for (TransporterStack s : getStacksToDest(Coord4D.get(tileEntity))) {
-            if (simulateInsert(handler, inventoryInfo, s.itemStack) > 0) {
-                // Failed to successfully insert this in-flight item; there's no room for anyone else
-                return TransitResponse.EMPTY;
+        Set<TransporterStack> transporterStacks = flowingStacks.get(Coord4D.get(tileEntity));
+        if (transporterStacks != null) {
+            for (TransporterStack stack : transporterStacks) {
+                if (stack != null && stack.getPathType() != Path.NONE) {
+                    if (simulateInsert(handler, inventoryInfo, stack.itemStack) > 0) {
+                        // Failed to successfully insert this in-flight item; there's no room for anyone else
+                        return TransitResponse.EMPTY;
+                    }
+                }
             }
         }
 

--- a/src/main/java/mekanism/common/content/transporter/TransporterManager.java
+++ b/src/main/java/mekanism/common/content/transporter/TransporterManager.java
@@ -49,12 +49,11 @@ public class TransporterManager {
 
     public static List<TransporterStack> getStacksToDest(Coord4D dest) {
         List<TransporterStack> ret = new ArrayList<>();
-        if (flowingStacks.containsKey(dest)) {
-            for (TransporterStack stack : flowingStacks.get(dest)) {
-                if (stack != null && stack.pathType != Path.NONE && stack.hasPath()) {
-                    if (stack.getDest().equals(dest)) {
-                        ret.add(stack);
-                    }
+        Set<TransporterStack> transporterStacks = flowingStacks.get(dest);
+        if (transporterStacks != null) {
+            for (TransporterStack stack : transporterStacks) {
+                if (stack != null && stack.pathType != Path.NONE && stack.hasPath() && stack.getDest().equals(dest)) {
+                    ret.add(stack);
                 }
             }
         }

--- a/src/main/java/mekanism/common/content/transporter/TransporterManager.java
+++ b/src/main/java/mekanism/common/content/transporter/TransporterManager.java
@@ -116,10 +116,7 @@ public class TransporterManager {
     }
 
     public static ItemStack getToUse(ItemStack stack, ItemStack returned) {
-        if (returned.isEmpty() || returned.getCount() == 0) {
-            return stack;
-        }
-        return StackUtils.size(stack, stack.getCount() - returned.getCount());
+        return returned.isEmpty() ? stack : StackUtils.size(stack, stack.getCount() - returned.getCount());
     }
 
     /**

--- a/src/main/java/mekanism/common/content/transporter/TransporterPathfinder.java
+++ b/src/main/java/mekanism/common/content/transporter/TransporterPathfinder.java
@@ -63,7 +63,7 @@ public final class TransporterPathfinder {
         return true;
     }
 
-    public static Destination getPath(DestChecker checker, EnumSet<EnumFacing> sides, ILogisticalTransporter start, Coord4D dest, TransporterStack stack,
+    public static Destination getPath(DestChecker checker, Set<EnumFacing> sides, ILogisticalTransporter start, Coord4D dest, TransporterStack stack,
           TransitResponse response, int min) {
         if (response.getStack().getCount() >= min) {
             List<Coord4D> test = PathfinderCache.getCache(start.coord(), dest, sides);
@@ -74,7 +74,7 @@ public final class TransporterPathfinder {
             Pathfinder p = new Pathfinder(checker, start.world(), dest, start.coord(), stack);
             List<Coord4D> path = p.getPath();
             if (path.size() >= 2) {
-                PathfinderCache.cachedPaths.put(new PathData(start.coord(), dest, p.getSide()), path);
+                PathfinderCache.addCachedPath(new PathData(start.coord(), dest, p.getSide()), path);
                 return new Destination(path, false, response, p.finalScore);
             }
         }

--- a/src/main/java/mekanism/common/content/transporter/TransporterPathfinder.java
+++ b/src/main/java/mekanism/common/content/transporter/TransporterPathfinder.java
@@ -55,9 +55,6 @@ public final class TransporterPathfinder {
     public static boolean checkPath(World world, List<Coord4D> path, TransporterStack stack) {
         for (int i = path.size() - 1; i > 0; i--) {
             TileEntity tile = path.get(i).getTileEntity(world);
-            if (!CapabilityUtils.hasCapability(tile, Capabilities.LOGISTICAL_TRANSPORTER_CAPABILITY, null)) {
-                return false;
-            }
             ILogisticalTransporter transporter = CapabilityUtils.getCapability(tile, Capabilities.LOGISTICAL_TRANSPORTER_CAPABILITY, null);
             if (transporter == null || (transporter.getColor() != null && transporter.getColor() != stack.color)) {
                 return false;
@@ -75,9 +72,10 @@ public final class TransporterPathfinder {
             }
 
             Pathfinder p = new Pathfinder(checker, start.world(), dest, start.coord(), stack);
-            if (p.getPath().size() >= 2) {
-                PathfinderCache.cachedPaths.put(new PathData(start.coord(), dest, p.side), p.getPath());
-                return new Destination(p.getPath(), false, response, p.finalScore);
+            List<Coord4D> path = p.getPath();
+            if (path.size() >= 2) {
+                PathfinderCache.cachedPaths.put(new PathData(start.coord(), dest, p.getSide()), path);
+                return new Destination(path, false, response, p.finalScore);
             }
         }
         return null;
@@ -95,8 +93,10 @@ public final class TransporterPathfinder {
         List<Destination> paths = getPaths(start, stack, request, min);
         Map<Coord4D, Destination> destPaths = new HashMap<>();
         for (Destination d : paths) {
-            if (destPaths.get(d.path.get(0)) == null || destPaths.get(d.path.get(0)).path.size() < d.path.size()) {
-                destPaths.put(d.path.get(0), d);
+            Coord4D dest = d.getPath().get(0);
+            Destination destination = destPaths.get(dest);
+            if (destination == null || destination.getPath().size() < d.getPath().size()) {
+                destPaths.put(dest, d);
             }
         }
 
@@ -116,10 +116,6 @@ public final class TransporterPathfinder {
                 outputter.rrIndex = 0;
             }
         }
-
-        if (closest == null) {
-            return null;
-        }
         return closest;
     }
 
@@ -135,9 +131,8 @@ public final class TransporterPathfinder {
             List<Coord4D> path = p.getPath();
             if (path.size() >= 2) {
                 return Pair.of(path, Path.HOME);
-            } else {
-                stack.homeLocation = null;
             }
+            stack.homeLocation = null;
         }
 
         IdlePath d = new IdlePath(start.world(), start.coord(), stack);
@@ -145,19 +140,17 @@ public final class TransporterPathfinder {
         if (dest == null) {
             return null;
         }
-        return Pair.of(dest.path, dest.pathType);
+        return Pair.of(dest.getPath(), dest.getPathType());
     }
 
     public static class IdlePath {
 
-        public World worldObj;
-
-        public Coord4D start;
-
-        public TransporterStack transportStack;
+        private World world;
+        private Coord4D start;
+        private TransporterStack transportStack;
 
         public IdlePath(World world, Coord4D obj, TransporterStack stack) {
-            worldObj = world;
+            this.world = world;
             start = obj;
             transportStack = stack;
         }
@@ -173,38 +166,35 @@ public final class TransporterPathfinder {
                 transportStack.idleDir = newSide;
                 loopSide(ret, newSide);
                 return new Destination(ret, true, null, 0).setPathType(Path.NONE);
-            } else {
-                TileEntity tile = start.offset(transportStack.idleDir).getTileEntity(worldObj);
-                if (transportStack.canInsertToTransporter(tile, transportStack.idleDir)) {
-                    loopSide(ret, transportStack.idleDir);
-                    return new Destination(ret, true, null, 0).setPathType(Path.NONE);
-                } else {
-                    TransitRequest request = TransitRequest.getFromTransport(transportStack);
-                    Destination newPath = TransporterPathfinder.getNewBasePath(CapabilityUtils.getCapability(start.getTileEntity(worldObj),
-                          Capabilities.LOGISTICAL_TRANSPORTER_CAPABILITY, null), transportStack, request, 0);
-
-                    if (newPath != null && newPath.response != null) {
-                        transportStack.idleDir = null;
-                        newPath.setPathType(Path.DEST);
-                        return newPath;
-                    } else {
-                        EnumFacing newSide = findSide();
-                        if (newSide == null) {
-                            return null;
-                        }
-                        transportStack.idleDir = newSide;
-                        loopSide(ret, newSide);
-                        return new Destination(ret, true, null, 0).setPathType(Path.NONE);
-                    }
-                }
             }
+            TileEntity tile = start.offset(transportStack.idleDir).getTileEntity(world);
+            if (transportStack.canInsertToTransporter(tile, transportStack.idleDir)) {
+                loopSide(ret, transportStack.idleDir);
+                return new Destination(ret, true, null, 0).setPathType(Path.NONE);
+            }
+            TransitRequest request = TransitRequest.getFromTransport(transportStack);
+            Destination newPath = TransporterPathfinder.getNewBasePath(CapabilityUtils.getCapability(start.getTileEntity(world),
+                  Capabilities.LOGISTICAL_TRANSPORTER_CAPABILITY, null), transportStack, request, 0);
+
+            if (newPath != null && newPath.getResponse() != null) {
+                transportStack.idleDir = null;
+                newPath.setPathType(Path.DEST);
+                return newPath;
+            }
+            EnumFacing newSide = findSide();
+            if (newSide == null) {
+                return null;
+            }
+            transportStack.idleDir = newSide;
+            loopSide(ret, newSide);
+            return new Destination(ret, true, null, 0).setPathType(Path.NONE);
         }
 
         private void loopSide(List<Coord4D> list, EnumFacing side) {
             int count = 1;
             while (true) {
                 Coord4D coord = start.offset(side, count);
-                if (!transportStack.canInsertToTransporter(coord.getTileEntity(worldObj), side)) {
+                if (!transportStack.canInsertToTransporter(coord.getTileEntity(world), side)) {
                     break;
                 }
                 list.add(coord);
@@ -215,21 +205,22 @@ public final class TransporterPathfinder {
         private EnumFacing findSide() {
             if (transportStack.idleDir == null) {
                 for (EnumFacing side : EnumFacing.VALUES) {
-                    TileEntity tile = start.offset(side).getTileEntity(worldObj);
+                    TileEntity tile = start.offset(side).getTileEntity(world);
                     if (transportStack.canInsertToTransporter(tile, side)) {
                         return side;
                     }
                 }
             } else {
-                for (EnumFacing side : EnumSet.complementOf(EnumSet.of(transportStack.idleDir.getOpposite()))) {
-                    TileEntity tile = start.offset(side).getTileEntity(worldObj);
+                EnumFacing opposite = transportStack.idleDir.getOpposite();
+                for (EnumFacing side : EnumSet.complementOf(EnumSet.of(opposite))) {
+                    TileEntity tile = start.offset(side).getTileEntity(world);
                     if (transportStack.canInsertToTransporter(tile, side)) {
                         return side;
                     }
                 }
-                TileEntity tile = start.offset(transportStack.idleDir.getOpposite()).getTileEntity(worldObj);
-                if (transportStack.canInsertToTransporter(tile, transportStack.idleDir.getOpposite())) {
-                    return transportStack.idleDir.getOpposite();
+                TileEntity tile = start.offset(opposite).getTileEntity(world);
+                if (transportStack.canInsertToTransporter(tile, opposite)) {
+                    return opposite;
                 }
             }
             return null;
@@ -238,10 +229,10 @@ public final class TransporterPathfinder {
 
     public static class Destination implements Comparable<Destination> {
 
-        public List<Coord4D> path;
-        public Path pathType;
-        public TransitResponse response;
-        public double score;
+        private List<Coord4D> path;
+        private Path pathType;
+        private TransitResponse response;
+        private double score;
 
         public Destination(List<Coord4D> list, boolean inv, TransitResponse ret, double gScore) {
             path = new ArrayList<>(list);
@@ -260,9 +251,9 @@ public final class TransporterPathfinder {
         public Destination calculateScore(World world) {
             score = 0;
             for (Coord4D location : path) {
-                TileEntity tile = location.getTileEntity(world);
-                if (CapabilityUtils.hasCapability(tile, Capabilities.LOGISTICAL_TRANSPORTER_CAPABILITY, null)) {
-                    score += CapabilityUtils.getCapability(tile, Capabilities.LOGISTICAL_TRANSPORTER_CAPABILITY, null).getCost();
+                ILogisticalTransporter capability = CapabilityUtils.getCapability(location.getTileEntity(world), Capabilities.LOGISTICAL_TRANSPORTER_CAPABILITY, null);
+                if (capability != null) {
+                    score += capability.getCost();
                 }
             }
             return this;
@@ -289,35 +280,38 @@ public final class TransporterPathfinder {
             }
             return path.size() - dest.path.size();
         }
+
+        public TransitResponse getResponse() {
+            return response;
+        }
+
+        public Path getPathType() {
+            return pathType;
+        }
+
+        public List<Coord4D> getPath() {
+            return path;
+        }
     }
 
     public static class Pathfinder {
 
-        public final Set<Coord4D> openSet, closedSet;
+        private final Set<Coord4D> openSet, closedSet;
+        private final Map<Coord4D, Coord4D> navMap;
+        private final Map<Coord4D, Double> gScore, fScore;
+        private final Coord4D start;
+        private final Coord4D finalNode;
+        private final TransporterStack transportStack;
+        private final DestChecker destChecker;
 
-        public final HashMap<Coord4D, Coord4D> navMap;
-
-        public final HashMap<Coord4D, Double> gScore, fScore;
-
-        public final Coord4D start;
-
-        public final Coord4D finalNode;
-
-        public final TransporterStack transportStack;
-
-        public final DestChecker destChecker;
-
-        public double finalScore;
-
-        public EnumFacing side;
-
-        public ArrayList<Coord4D> results;
-
-        private World worldObj;
+        private double finalScore;
+        private EnumFacing side;
+        private List<Coord4D> results;
+        private World world;
 
         public Pathfinder(DestChecker checker, World world, Coord4D finishObj, Coord4D startObj, TransporterStack stack) {
             destChecker = checker;
-            worldObj = world;
+            this.world = world;
 
             finalNode = finishObj;
             start = startObj;
@@ -346,8 +340,8 @@ public final class TransporterPathfinder {
 
             for (EnumFacing direction : EnumFacing.VALUES) {
                 Coord4D neighbor = start.offset(direction);
-                if (!transportStack.canInsertToTransporter(neighbor.getTileEntity(worldObj), direction) &&
-                    (!neighbor.equals(finalNode) || !destChecker.isValid(transportStack, direction, neighbor.getTileEntity(worldObj)))) {
+                if (!transportStack.canInsertToTransporter(neighbor.getTileEntity(world), direction) &&
+                    (!neighbor.equals(finalNode) || !destChecker.isValid(transportStack, direction, neighbor.getTileEntity(world)))) {
                     blockCount++;
                 }
             }
@@ -356,7 +350,7 @@ public final class TransporterPathfinder {
             }
 
             double maxSearchDistance = start.distanceTo(finalNode) * 2;
-            ArrayList<EnumFacing> directionsToCheck = new ArrayList<>();
+            List<EnumFacing> directionsToCheck = new ArrayList<>();
             Coord4D[] neighbors = new Coord4D[EnumFacing.VALUES.length];
             TileEntity[] neighborEntities = new TileEntity[neighbors.length];
             while (!openSet.isEmpty()) {
@@ -375,17 +369,13 @@ public final class TransporterPathfinder {
                 openSet.remove(currentNode);
                 closedSet.add(currentNode);
 
-                TileEntity currentNodeTile = currentNode.getTileEntity(worldObj);
-                ILogisticalTransporter currentNodeTransporter = null;
-                if (currentNodeTile.hasCapability(Capabilities.LOGISTICAL_TRANSPORTER_CAPABILITY, null)) {
-                    currentNodeTransporter = CapabilityUtils.getCapability(currentNodeTile, Capabilities.LOGISTICAL_TRANSPORTER_CAPABILITY, null);
-                }
-
+                TileEntity currentNodeTile = currentNode.getTileEntity(world);
+                ILogisticalTransporter currentNodeTransporter = CapabilityUtils.getCapability(currentNodeTile, Capabilities.LOGISTICAL_TRANSPORTER_CAPABILITY, null);
                 directionsToCheck.clear();
                 for (EnumFacing direction : EnumFacing.VALUES) {
                     Coord4D neighbor = currentNode.offset(direction);
                     neighbors[direction.ordinal()] = neighbor;
-                    TileEntity neighborEntity = neighbor.getTileEntity(worldObj);
+                    TileEntity neighborEntity = neighbor.getTileEntity(world);
                     neighborEntities[direction.ordinal()] = neighborEntity;
                     if (currentNodeTransporter == null || currentNodeTransporter.canEmitTo(neighborEntity, direction) ||
                         (neighbor.equals(finalNode) && destChecker.isValid(transportStack, direction, neighborEntities[direction.ordinal()]))) {
@@ -393,25 +383,24 @@ public final class TransporterPathfinder {
                     }
                 }
 
+                double currentScore = gScore.get(currentNode);
                 for (EnumFacing direction : directionsToCheck) {
                     Coord4D neighbor = neighbors[direction.ordinal()];
-                    if (transportStack.canInsertToTransporter(neighborEntities[direction.ordinal()], direction)) {
-                        TileEntity tile = neighborEntities[direction.ordinal()];
-                        double tentativeG = gScore.get(currentNode) + CapabilityUtils.getCapability(tile, Capabilities.LOGISTICAL_TRANSPORTER_CAPABILITY, direction.getOpposite()).getCost();
-
-                        if (closedSet.contains(neighbor)) {
-                            if (tentativeG >= gScore.get(neighbor)) {
-                                continue;
-                            }
+                    TileEntity neighborEntity = neighborEntities[direction.ordinal()];
+                    if (transportStack.canInsertToTransporter(neighborEntity, direction)) {
+                        double tentativeG = currentScore + CapabilityUtils.getCapability(neighborEntity, Capabilities.LOGISTICAL_TRANSPORTER_CAPABILITY, direction.getOpposite()).getCost();
+                        double neighborScore = gScore.get(neighbor);
+                        if (closedSet.contains(neighbor) && tentativeG >= neighborScore) {
+                            continue;
                         }
 
-                        if (!openSet.contains(neighbor) || tentativeG < gScore.get(neighbor)) {
+                        if (!openSet.contains(neighbor) || tentativeG < neighborScore) {
                             navMap.put(neighbor, currentNode);
                             gScore.put(neighbor, tentativeG);
-                            fScore.put(neighbor, gScore.get(neighbor) + getEstimate(neighbor, finalNode));
+                            fScore.put(neighbor, neighborScore + getEstimate(neighbor, finalNode));
                             openSet.add(neighbor);
                         }
-                    } else if (neighbor.equals(finalNode) && destChecker.isValid(transportStack, direction, neighborEntities[direction.ordinal()])) {
+                    } else if (neighbor.equals(finalNode) && destChecker.isValid(transportStack, direction, neighborEntity)) {
                         side = direction;
                         results = reconstructPath(navMap, currentNode);
                         return true;
@@ -421,8 +410,8 @@ public final class TransporterPathfinder {
             return false;
         }
 
-        private ArrayList<Coord4D> reconstructPath(HashMap<Coord4D, Coord4D> naviMap, Coord4D currentNode) {
-            ArrayList<Coord4D> path = new ArrayList<>();
+        private List<Coord4D> reconstructPath(Map<Coord4D, Coord4D> naviMap, Coord4D currentNode) {
+            List<Coord4D> path = new ArrayList<>();
             path.add(currentNode);
             if (naviMap.containsKey(currentNode)) {
                 path.addAll(reconstructPath(naviMap, naviMap.get(currentNode)));
@@ -431,11 +420,15 @@ public final class TransporterPathfinder {
             return path;
         }
 
-        public ArrayList<Coord4D> getPath() {
-            ArrayList<Coord4D> path = new ArrayList<>();
+        public List<Coord4D> getPath() {
+            List<Coord4D> path = new ArrayList<>();
             path.add(finalNode);
             path.addAll(results);
             return path;
+        }
+
+        public EnumFacing getSide() {
+            return side;
         }
 
         private double getEstimate(Coord4D start, Coord4D target2) {

--- a/src/main/java/mekanism/common/content/transporter/TransporterPathfinder.java
+++ b/src/main/java/mekanism/common/content/transporter/TransporterPathfinder.java
@@ -389,15 +389,14 @@ public final class TransporterPathfinder {
                     TileEntity neighborEntity = neighborEntities[direction.ordinal()];
                     if (transportStack.canInsertToTransporter(neighborEntity, direction)) {
                         double tentativeG = currentScore + CapabilityUtils.getCapability(neighborEntity, Capabilities.LOGISTICAL_TRANSPORTER_CAPABILITY, direction.getOpposite()).getCost();
-                        double neighborScore = gScore.get(neighbor);
-                        if (closedSet.contains(neighbor) && tentativeG >= neighborScore) {
+                        if (closedSet.contains(neighbor) && tentativeG >= gScore.get(neighbor)) {
                             continue;
                         }
 
-                        if (!openSet.contains(neighbor) || tentativeG < neighborScore) {
+                        if (!openSet.contains(neighbor) || tentativeG < gScore.get(neighbor)) {
                             navMap.put(neighbor, currentNode);
                             gScore.put(neighbor, tentativeG);
-                            fScore.put(neighbor, neighborScore + getEstimate(neighbor, finalNode));
+                            fScore.put(neighbor, gScore.get(neighbor) + getEstimate(neighbor, finalNode));
                             openSet.add(neighbor);
                         }
                     } else if (neighbor.equals(finalNode) && destChecker.isValid(transportStack, direction, neighborEntity)) {

--- a/src/main/java/mekanism/common/content/transporter/TransporterPathfinder.java
+++ b/src/main/java/mekanism/common/content/transporter/TransporterPathfinder.java
@@ -52,7 +52,7 @@ public final class TransporterPathfinder {
 
     private static Destination getPath(AcceptorData data, ILogisticalTransporter start, TransporterStack stack, int min) {
         TransitResponse response = data.getResponse();
-        if (response.getStack().getCount() >= min) {
+        if (response.getSendingAmount() >= min) {
             Coord4D dest = data.getLocation();
             List<Coord4D> test = PathfinderCache.getCache(start.coord(), dest, data.getSides());
             if (test != null && checkPath(start.world(), test, stack)) {

--- a/src/main/java/mekanism/common/content/transporter/TransporterStack.java
+++ b/src/main/java/mekanism/common/content/transporter/TransporterStack.java
@@ -153,9 +153,9 @@ public class TransporterStack {
             return TransitResponse.EMPTY;
         }
         idleDir = null;
-        setPath(newPath.path, Path.DEST);
+        setPath(newPath.getPath(), Path.DEST);
         initiatedPath = true;
-        return newPath.response;
+        return newPath.getResponse();
     }
 
     public TransitResponse recalculateRRPath(TransitRequest request, TileEntityLogisticalSorter outputter, ILogisticalTransporter transporter, int min) {
@@ -164,9 +164,9 @@ public class TransporterStack {
             return TransitResponse.EMPTY;
         }
         idleDir = null;
-        setPath(newPath.path, Path.DEST);
+        setPath(newPath.getPath(), Path.DEST);
         initiatedPath = true;
-        return newPath.response;
+        return newPath.getResponse();
     }
 
     public boolean calculateIdle(ILogisticalTransporter transporter) {

--- a/src/main/java/mekanism/common/content/transporter/TransporterStack.java
+++ b/src/main/java/mekanism/common/content/transporter/TransporterStack.java
@@ -226,21 +226,16 @@ public class TransporterStack {
     }
 
     public boolean canInsertToTransporter(TileEntity tileEntity, EnumFacing from) {
-        if (!CapabilityUtils.hasCapability(tileEntity, Capabilities.LOGISTICAL_TRANSPORTER_CAPABILITY, from.getOpposite())) {
-            return false;
+        EnumFacing opposite = from.getOpposite();
+        ILogisticalTransporter transporter = CapabilityUtils.getCapability(tileEntity, Capabilities.LOGISTICAL_TRANSPORTER_CAPABILITY, opposite);
+        if (transporter != null && CapabilityUtils.getCapability(tileEntity, Capabilities.BLOCKABLE_CONNECTION_CAPABILITY, opposite).canConnectMutual(opposite)) {
+            return transporter.getColor() == color || transporter.getColor() == null;
         }
-        ILogisticalTransporter transporter = CapabilityUtils.getCapability(tileEntity, Capabilities.LOGISTICAL_TRANSPORTER_CAPABILITY, from.getOpposite());
-        if (!CapabilityUtils.getCapability(tileEntity, Capabilities.BLOCKABLE_CONNECTION_CAPABILITY, from.getOpposite()).canConnectMutual(from.getOpposite())) {
-            return false;
-        }
-        return transporter.getColor() == color || transporter.getColor() == null;
+        return false;
     }
 
     public boolean canInsertToTransporter(ILogisticalTransporter transporter, EnumFacing side) {
-        if (!transporter.canConnectMutual(side)) {
-            return false;
-        }
-        return transporter.getColor() == color || transporter.getColor() == null;
+        return transporter.canConnectMutual(side) && (transporter.getColor() == color || transporter.getColor() == null);
     }
 
     public Coord4D getDest() {

--- a/src/main/java/mekanism/common/content/transporter/TransporterStack.java
+++ b/src/main/java/mekanism/common/content/transporter/TransporterStack.java
@@ -33,9 +33,9 @@ public class TransporterStack {
     public EnumFacing idleDir = null;
     public Coord4D originalLocation;
     public Coord4D homeLocation;
-    public Coord4D clientNext;
-    public Coord4D clientPrev;
-    public Path pathType;
+    private Coord4D clientNext;
+    private Coord4D clientPrev;
+    private Path pathType;
     private List<Coord4D> pathToTarget = new ArrayList<>();
 
     public static TransporterStack readFromNBT(NBTTagCompound nbtTags) {
@@ -145,6 +145,10 @@ public class TransporterStack {
 
     public List<Coord4D> getPath() {
         return pathToTarget;
+    }
+
+    public Path getPathType() {
+        return pathType;
     }
 
     public TransitResponse recalculatePath(TransitRequest request, ILogisticalTransporter transporter, int min) {

--- a/src/main/java/mekanism/common/content/transporter/TransporterStack.java
+++ b/src/main/java/mekanism/common/content/transporter/TransporterStack.java
@@ -140,7 +140,7 @@ public class TransporterStack {
     }
 
     public boolean hasPath() {
-        return getPath() != null && getPath().size() >= 2;
+        return pathToTarget != null && pathToTarget.size() >= 2;
     }
 
     public List<Coord4D> getPath() {
@@ -239,7 +239,7 @@ public class TransporterStack {
     }
 
     public Coord4D getDest() {
-        return getPath().get(0);
+        return pathToTarget.get(0);
     }
 
     public enum Path {

--- a/src/main/java/mekanism/common/integration/crafttweaker/util/RecipeMapModification.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/util/RecipeMapModification.java
@@ -15,7 +15,7 @@ import mekanism.common.recipe.machines.MachineRecipe;
 
 public abstract class RecipeMapModification<INPUT extends MachineInput<INPUT>, RECIPE extends MachineRecipe<INPUT, ?, RECIPE>> implements IAction {
 
-    protected final HashMap<INPUT, RECIPE> recipes;
+    protected final Map<INPUT, RECIPE> recipes;
     protected final Map<INPUT, RECIPE> map;
     protected final String name;
     protected boolean add;

--- a/src/main/java/mekanism/common/integration/multipart/MultipartTileNetworkJoiner.java
+++ b/src/main/java/mekanism/common/integration/multipart/MultipartTileNetworkJoiner.java
@@ -3,6 +3,7 @@ package mekanism.common.integration.multipart;
 import io.netty.buffer.ByteBuf;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import mcmultipart.api.container.IMultipartContainer;
 import mcmultipart.api.multipart.IMultipartTile;
@@ -25,7 +26,7 @@ import net.minecraft.world.IBlockAccess;
  */
 public class MultipartTileNetworkJoiner implements ITileNetwork {
 
-    private final HashMap<Byte, ITileNetwork> tileSideMap;
+    private final Map<Byte, ITileNetwork> tileSideMap;
 
     /**
      * Called by MCMP's multipart container when more than one part implements {@link ITileNetwork}.<br>

--- a/src/main/java/mekanism/common/integration/multipart/MultipartTileNetworkJoiner.java
+++ b/src/main/java/mekanism/common/integration/multipart/MultipartTileNetworkJoiner.java
@@ -1,6 +1,9 @@
 package mekanism.common.integration.multipart;
 
 import io.netty.buffer.ByteBuf;
+import it.unimi.dsi.fastutil.ints.Int2ObjectArrayMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.IntIterator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -26,7 +29,8 @@ import net.minecraft.world.IBlockAccess;
  */
 public class MultipartTileNetworkJoiner implements ITileNetwork {
 
-    private final Map<Byte, ITileNetwork> tileSideMap;
+    //TODO nullable-ish enum map
+    private final Int2ObjectMap<ITileNetwork> tileSideMap;
 
     /**
      * Called by MCMP's multipart container when more than one part implements {@link ITileNetwork}.<br>
@@ -36,7 +40,7 @@ public class MultipartTileNetworkJoiner implements ITileNetwork {
      * @param tileList A list of the tile entities that implement {@link ITileNetwork} in the container.
      */
     public MultipartTileNetworkJoiner(List<ITileNetwork> tileList) {
-        tileSideMap = new HashMap<>();
+        tileSideMap = new Int2ObjectArrayMap<>(7);
         IMultipartContainer container = null;
 
         TileEntity first = (TileEntity) tileList.get(0);
@@ -104,7 +108,8 @@ public class MultipartTileNetworkJoiner implements ITileNetwork {
     @Override
     public TileNetworkList getNetworkedData(TileNetworkList data) {
         TileNetworkList childData = new TileNetworkList();
-        for (byte slotValue : tileSideMap.keySet()) {
+        for (IntIterator iterator = tileSideMap.keySet().iterator(); iterator.hasNext(); ) {
+            int slotValue = iterator.nextInt();
             tileSideMap.get(slotValue).getNetworkedData(childData);
             data.addAll(childData);
             childData.clear();

--- a/src/main/java/mekanism/common/inventory/container/ContainerDoubleElectricMachine.java
+++ b/src/main/java/mekanism/common/inventory/container/ContainerDoubleElectricMachine.java
@@ -1,6 +1,7 @@
 package mekanism.common.inventory.container;
 
 import java.util.Map;
+import java.util.Map.Entry;
 import javax.annotation.Nonnull;
 import mekanism.common.inventory.slot.SlotEnergy.SlotDischarge;
 import mekanism.common.inventory.slot.SlotOutput;
@@ -79,7 +80,7 @@ public class ContainerDoubleElectricMachine extends ContainerMekanism<TileEntity
     }
 
     private boolean isInputItem(ItemStack itemstack) {
-        for (Map.Entry<DoubleMachineInput, ItemStack> entry : ((Map<DoubleMachineInput, ItemStack>) tileEntity.getRecipes()).entrySet()) {
+        for (Entry<DoubleMachineInput, ItemStack> entry : ((Map<DoubleMachineInput, ItemStack>) tileEntity.getRecipes()).entrySet()) {
             if (entry.getKey().itemStack.isItemEqual(itemstack)) {
                 return true;
             }
@@ -88,7 +89,7 @@ public class ContainerDoubleElectricMachine extends ContainerMekanism<TileEntity
     }
 
     private boolean isExtraItem(ItemStack itemstack) {
-        for (Map.Entry<DoubleMachineInput, ItemStack> entry : ((Map<DoubleMachineInput, ItemStack>) tileEntity.getRecipes()).entrySet()) {
+        for (Entry<DoubleMachineInput, ItemStack> entry : ((Map<DoubleMachineInput, ItemStack>) tileEntity.getRecipes()).entrySet()) {
             if (entry.getKey().extraStack.isItemEqual(itemstack)) {
                 return true;
             }

--- a/src/main/java/mekanism/common/item/ItemBlockMachine.java
+++ b/src/main/java/mekanism/common/item/ItemBlockMachine.java
@@ -6,6 +6,7 @@ import ic2.api.item.ISpecialElectricItem;
 import io.netty.buffer.ByteBuf;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.UUID;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -222,7 +223,7 @@ public class ItemBlockMachine extends ItemBlock implements IEnergizedItem, ISpec
             }
             if (type.supportsUpgrades && ItemDataUtils.hasData(itemstack, "upgrades")) {
                 Map<Upgrade, Integer> upgrades = Upgrade.buildMap(ItemDataUtils.getDataMap(itemstack));
-                for (Map.Entry<Upgrade, Integer> entry : upgrades.entrySet()) {
+                for (Entry<Upgrade, Integer> entry : upgrades.entrySet()) {
                     list.add(entry.getKey().getColor() + "- " + entry.getKey().getName() + (entry.getKey().canMultiply() ? ": " + EnumColor.GREY + "x" + entry.getValue() : ""));
                 }
             }

--- a/src/main/java/mekanism/common/multiblock/MultiblockCache.java
+++ b/src/main/java/mekanism/common/multiblock/MultiblockCache.java
@@ -1,12 +1,13 @@
 package mekanism.common.multiblock;
 
 import java.util.HashSet;
+import java.util.Set;
 import mekanism.api.Coord4D;
 import net.minecraft.nbt.NBTTagCompound;
 
 public abstract class MultiblockCache<T extends SynchronizedData<T>> {
 
-    public HashSet<Coord4D> locations = new HashSet<>();
+    public Set<Coord4D> locations = new HashSet<>();
 
     public abstract void apply(T data);
 

--- a/src/main/java/mekanism/common/multiblock/MultiblockManager.java
+++ b/src/main/java/mekanism/common/multiblock/MultiblockManager.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
@@ -83,8 +84,8 @@ public class MultiblockManager<T extends SynchronizedData<T>> {
 
     public void tickSelf(World world) {
         ArrayList<String> idsToKill = new ArrayList<>();
-        HashMap<String, HashSet<Coord4D>> tilesToKill = new HashMap<>();
-        for (Map.Entry<String, MultiblockCache<T>> entry : inventories.entrySet()) {
+        Map<String, Set<Coord4D>> tilesToKill = new HashMap<>();
+        for (Entry<String, MultiblockCache<T>> entry : inventories.entrySet()) {
             String inventoryID = entry.getKey();
             for (Coord4D obj : entry.getValue().locations) {
                 if (obj.dimensionId == world.provider.getDimension() && obj.exists(world)) {
@@ -102,7 +103,7 @@ public class MultiblockManager<T extends SynchronizedData<T>> {
                 idsToKill.add(inventoryID);
             }
         }
-        for (Map.Entry<String, HashSet<Coord4D>> entry : tilesToKill.entrySet()) {
+        for (Entry<String, Set<Coord4D>> entry : tilesToKill.entrySet()) {
             for (Coord4D obj : entry.getValue()) {
                 inventories.get(entry.getKey()).locations.remove(obj);
             }

--- a/src/main/java/mekanism/common/recipe/ShapedMekanismRecipe.java
+++ b/src/main/java/mekanism/common/recipe/ShapedMekanismRecipe.java
@@ -7,6 +7,7 @@ import com.google.gson.JsonSyntaxException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import mekanism.common.Mekanism;
@@ -89,7 +90,7 @@ public class ShapedMekanismRecipe extends ShapedOreRecipe {
         //    group = context.getModId() + ":" + group;
 
         Map<Character, Ingredient> ingMap = new HashMap<>();
-        for (Map.Entry<String, JsonElement> entry : JsonUtils.getJsonObject(json, "key").entrySet()) {
+        for (Entry<String, JsonElement> entry : JsonUtils.getJsonObject(json, "key").entrySet()) {
             if (entry.getKey().length() != 1) {
                 throw new JsonSyntaxException("Invalid key entry: '" + entry.getKey() + "' is an invalid symbol (must be 1 character only).");
             }

--- a/src/main/java/mekanism/common/tile/TileEntityBin.java
+++ b/src/main/java/mekanism/common/tile/TileEntityBin.java
@@ -204,19 +204,16 @@ public class TileEntityBin extends TileEntityBasicBlock implements ISidedInvento
             if (delayTicks == 0) {
                 if (!bottomStack.isEmpty() && isActive) {
                     TileEntity tile = Coord4D.get(this).offset(EnumFacing.DOWN).getTileEntity(world);
-                    if (CapabilityUtils.hasCapability(tile, Capabilities.LOGISTICAL_TRANSPORTER_CAPABILITY, EnumFacing.UP)) {
-                        ILogisticalTransporter transporter = CapabilityUtils.getCapability(tile, Capabilities.LOGISTICAL_TRANSPORTER_CAPABILITY, EnumFacing.UP);
-                        TransitResponse response = TransporterUtils.insert(this, transporter, TransitRequest.getFromStack(bottomStack), null, true, 0);
-                        if (!response.isEmpty()) {
-                            bottomStack.shrink(response.getStack().getCount());
-                            setInventorySlotContents(0, bottomStack);
-                        }
+                    ILogisticalTransporter transporter = CapabilityUtils.getCapability(tile, Capabilities.LOGISTICAL_TRANSPORTER_CAPABILITY, EnumFacing.UP);
+                    TransitResponse response;
+                    if (transporter == null) {
+                        response = InventoryUtils.putStackInInventory(tile, TransitRequest.getFromStack(bottomStack), EnumFacing.DOWN, false);
                     } else {
-                        TransitResponse response = InventoryUtils.putStackInInventory(tile, TransitRequest.getFromStack(bottomStack), EnumFacing.DOWN, false);
-                        if (!response.isEmpty()) {
-                            bottomStack.shrink(response.getStack().getCount());
-                            setInventorySlotContents(0, bottomStack);
-                        }
+                        response = TransporterUtils.insert(this, transporter, TransitRequest.getFromStack(bottomStack), null, true, 0);
+                    }
+                    if (!response.isEmpty() && tier != BinTier.CREATIVE) {
+                        bottomStack.shrink(response.getStack().getCount());
+                        setInventorySlotContents(0, bottomStack);
                     }
                     delayTicks = 10;
                 }
@@ -561,18 +558,12 @@ public class TileEntityBin extends TileEntityBasicBlock implements ISidedInvento
         @Nonnull
         @Override
         public ItemStack insertItem(int slot, @Nonnull ItemStack stack, boolean simulate) {
-            if (slot != 0) {
-                return ItemStack.EMPTY;
-            }
-            return tileEntityBin.add(stack, simulate);
+            return slot != 0 ? ItemStack.EMPTY : tileEntityBin.add(stack, simulate);
         }
 
         @Nonnull
         public ItemStack extractItem(int slot, int amount, boolean simulate) {
-            if (slot != 0) {
-                return ItemStack.EMPTY;
-            }
-            return tileEntityBin.remove(amount, simulate);
+            return slot != 0 ? ItemStack.EMPTY : tileEntityBin.remove(amount, simulate);
         }
     }
 }

--- a/src/main/java/mekanism/common/tile/TileEntityBin.java
+++ b/src/main/java/mekanism/common/tile/TileEntityBin.java
@@ -212,7 +212,7 @@ public class TileEntityBin extends TileEntityBasicBlock implements ISidedInvento
                         response = TransporterUtils.insert(this, transporter, TransitRequest.getFromStack(bottomStack), null, true, 0);
                     }
                     if (!response.isEmpty() && tier != BinTier.CREATIVE) {
-                        bottomStack.shrink(response.getStack().getCount());
+                        bottomStack.shrink(response.getSendingAmount());
                         setInventorySlotContents(0, bottomStack);
                     }
                     delayTicks = 10;

--- a/src/main/java/mekanism/common/tile/TileEntityLogisticalSorter.java
+++ b/src/main/java/mekanism/common/tile/TileEntityLogisticalSorter.java
@@ -111,7 +111,7 @@ public class TileEntityLogisticalSorter extends TileEntityEffectsBlock implement
                             TransitRequest request = TransitRequest.getFromStack(itemStack);
                             TransitResponse response = emitItemToTransporter(front, request, filter.color, min);
                             if (!response.isEmpty()) {
-                                invStack.use(response.getStack().getCount());
+                                invStack.use(response.getSendingAmount());
                                 back.markDirty();
                                 setActive(true);
                                 sentItems = true;
@@ -125,7 +125,7 @@ public class TileEntityLogisticalSorter extends TileEntityEffectsBlock implement
                     TransitRequest request = TransitRequest.buildInventoryMap(back, facing.getOpposite(), singleItem ? 1 : 64, new StrictFilterFinder());
                     TransitResponse response = emitItemToTransporter(front, request, color, 0);
                     if (!response.isEmpty()) {
-                        response.getInvStack(back, facing).use(response.getStack().getCount());
+                        response.getInvStack(back, facing).use(response.getSendingAmount());
                         back.markDirty();
                         setActive(true);
                     }

--- a/src/main/java/mekanism/common/tile/TileEntityMetallurgicInfuser.java
+++ b/src/main/java/mekanism/common/tile/TileEntityMetallurgicInfuser.java
@@ -152,7 +152,7 @@ public class TileEntityMetallurgicInfuser extends TileEntityOperationalMachine i
         factory.upgradeComponent.setSupported(Upgrade.GAS, type.fuelEnergyUpgrades());
         factory.securityComponent.readFrom(securityComponent);
 
-        for (TransmissionType transmission : configComponent.transmissions) {
+        for (TransmissionType transmission : configComponent.getTransmissions()) {
             factory.configComponent.setConfig(transmission, configComponent.getConfig(transmission).asByteArray());
             factory.configComponent.setEjecting(transmission, configComponent.isEjecting(transmission));
         }

--- a/src/main/java/mekanism/common/tile/component/TileComponentConfig.java
+++ b/src/main/java/mekanism/common/tile/component/TileComponentConfig.java
@@ -2,8 +2,8 @@ package mekanism.common.tile.component;
 
 import io.netty.buffer.ByteBuf;
 import java.util.ArrayList;
+import java.util.EnumMap;
 import java.util.EnumSet;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -29,11 +29,11 @@ public class TileComponentConfig implements ITileComponent {
     public static SideData EMPTY = new SideData("Empty", EnumColor.BLACK, InventoryUtils.EMPTY);
 
     public TileEntityContainerBlock tileEntity;
-    public List<TransmissionType> transmissions = new ArrayList<>();
-    private Map<TransmissionType, SideConfig> sideConfigs = new HashMap<>();
-    private Map<TransmissionType, ArrayList<SideData>> sideOutputs = new HashMap<>();
-    private Map<TransmissionType, Boolean> ejecting = new HashMap<>();
-    private Map<TransmissionType, Boolean> canEject = new HashMap<>();
+    private List<TransmissionType> transmissions = new ArrayList<>();
+    private Map<TransmissionType, SideConfig> sideConfigs = new EnumMap<>(TransmissionType.class);
+    private Map<TransmissionType, ArrayList<SideData>> sideOutputs = new EnumMap<>(TransmissionType.class);
+    private Map<TransmissionType, Boolean> ejecting = new EnumMap<>(TransmissionType.class);
+    private Map<TransmissionType, Boolean> canEject = new EnumMap<>(TransmissionType.class);
 
     public TileComponentConfig(TileEntityContainerBlock tile, TransmissionType... types) {
         tileEntity = tile;
@@ -41,6 +41,10 @@ public class TileComponentConfig implements ITileComponent {
             addSupported(type);
         }
         tile.components.add(this);
+    }
+
+    public List<TransmissionType> getTransmissions() {
+        return transmissions;
     }
 
     public void readFrom(TileComponentConfig config) {

--- a/src/main/java/mekanism/common/tile/component/TileComponentEjector.java
+++ b/src/main/java/mekanism/common/tile/component/TileComponentEjector.java
@@ -154,10 +154,10 @@ public class TileComponentEjector implements ITileComponent {
                 ILogisticalTransporter capability = CapabilityUtils.getCapability(tile, Capabilities.LOGISTICAL_TRANSPORTER_CAPABILITY, side.getOpposite());
                 TransitRequest transitRequest = TransitRequest.getFromStack(stack.copy());
                 TransitResponse response;
-                if (capability != null) {
-                    response = TransporterUtils.insert(tileEntity, capability, transitRequest, outputColor, true, 0);
-                } else {
+                if (capability == null) {
                     response = InventoryUtils.putStackInInventory(tile, transitRequest, side, false);
+                } else {
+                    response = TransporterUtils.insert(tileEntity, capability, transitRequest, outputColor, true, 0);
                 }
                 if (!response.isEmpty()) {
                     stack.shrink(response.getStack().getCount());

--- a/src/main/java/mekanism/common/tile/component/TileComponentEjector.java
+++ b/src/main/java/mekanism/common/tile/component/TileComponentEjector.java
@@ -14,6 +14,7 @@ import mekanism.api.gas.GasStack;
 import mekanism.api.gas.GasTank;
 import mekanism.api.transmitters.TransmissionType;
 import mekanism.common.SideData;
+import mekanism.common.base.ILogisticalTransporter;
 import mekanism.common.base.ISideConfiguration;
 import mekanism.common.base.ITankManager;
 import mekanism.common.base.ITileComponent;
@@ -149,14 +150,15 @@ public class TileComponentEjector implements ITileComponent {
                 TileEntity tile = Coord4D.get(tileEntity).offset(side).getTileEntity(tileEntity.getWorld());
                 ItemStack prev = stack.copy();
 
-                if (CapabilityUtils.hasCapability(tile, Capabilities.LOGISTICAL_TRANSPORTER_CAPABILITY, side.getOpposite())) {
-                    TransitResponse response = TransporterUtils.insert(tileEntity, CapabilityUtils.getCapability(tile, Capabilities.LOGISTICAL_TRANSPORTER_CAPABILITY, side.getOpposite()),
-                          TransitRequest.getFromStack(stack.copy()), outputColor, true, 0);
+                ILogisticalTransporter capability = CapabilityUtils.getCapability(tile, Capabilities.LOGISTICAL_TRANSPORTER_CAPABILITY, side.getOpposite());
+                TransitRequest transitRequest = TransitRequest.getFromStack(stack.copy());
+                if (capability != null) {
+                    TransitResponse response = TransporterUtils.insert(tileEntity, capability, transitRequest, outputColor, true, 0);
                     if (!response.isEmpty()) {
                         stack.shrink(response.getStack().getCount());
                     }
                 } else {
-                    TransitResponse response = InventoryUtils.putStackInInventory(tile, TransitRequest.getFromStack(stack.copy()), side, false);
+                    TransitResponse response = InventoryUtils.putStackInInventory(tile, transitRequest, side, false);
                     if (!response.isEmpty()) {
                         stack.shrink(response.getStack().getCount());
                     }

--- a/src/main/java/mekanism/common/tile/component/TileComponentEjector.java
+++ b/src/main/java/mekanism/common/tile/component/TileComponentEjector.java
@@ -1,8 +1,8 @@
 package mekanism.common.tile.component;
 
 import io.netty.buffer.ByteBuf;
+import java.util.EnumMap;
 import java.util.EnumSet;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -44,8 +44,8 @@ public class TileComponentEjector implements ITileComponent {
     private EnumColor outputColor;
     private EnumColor[] inputColors = new EnumColor[]{null, null, null, null, null, null};
     private int tickDelay = 0;
-    private Map<TransmissionType, SideData> sideData = new HashMap<>();
-    public Map<TransmissionType, int[]> trackers = new HashMap<>();
+    private Map<TransmissionType, SideData> sideData = new EnumMap<>(TransmissionType.class);
+    public Map<TransmissionType, int[]> trackers = new EnumMap<>(TransmissionType.class);
 
     public TileComponentEjector(TileEntityContainerBlock tile) {
         tileEntity = tile;
@@ -138,8 +138,8 @@ public class TileComponentEjector implements ITileComponent {
 
         SideData data = sideData.get(TransmissionType.ITEM);
         Set<EnumFacing> outputSides = getOutputSides(TransmissionType.ITEM, data);
-        for (int index = 0; index < sideData.get(TransmissionType.ITEM).availableSlots.length; index++) {
-            int slotID = sideData.get(TransmissionType.ITEM).availableSlots[index];
+        for (int index = 0; index < data.availableSlots.length; index++) {
+            int slotID = data.availableSlots[index];
             if (tileEntity.getStackInSlot(slotID).isEmpty()) {
                 continue;
             }
@@ -160,7 +160,7 @@ public class TileComponentEjector implements ITileComponent {
                     response = TransporterUtils.insert(tileEntity, capability, transitRequest, outputColor, true, 0);
                 }
                 if (!response.isEmpty()) {
-                    stack.shrink(response.getStack().getCount());
+                    stack.shrink(response.getSendingAmount());
                 }
 
                 if (stack.isEmpty() || prevCount != stack.getCount()) {

--- a/src/main/java/mekanism/common/tile/component/TileComponentUpgrade.java
+++ b/src/main/java/mekanism/common/tile/component/TileComponentUpgrade.java
@@ -1,9 +1,10 @@
 package mekanism.common.tile.component;
 
 import io.netty.buffer.ByteBuf;
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.EnumMap;
+import java.util.EnumSet;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import mekanism.api.Coord4D;
 import mekanism.api.Range4D;
@@ -30,8 +31,8 @@ public class TileComponentUpgrade implements ITileComponent {
      * TileEntity implementing this component.
      */
     public TileEntityContainerBlock tileEntity;
-    private Map<Upgrade, Integer> upgrades = new HashMap<>();
-    private Set<Upgrade> supported = new HashSet<>();
+    private Map<Upgrade, Integer> upgrades = new EnumMap<>(Upgrade.class);
+    private Set<Upgrade> supported = EnumSet.noneOf(Upgrade.class);
     /**
      * The inventory slot the upgrade slot of this component occupies.
      */
@@ -156,7 +157,7 @@ public class TileComponentUpgrade implements ITileComponent {
     @Override
     public void write(TileNetworkList data) {
         data.add(upgrades.size());
-        for (Map.Entry<Upgrade, Integer> entry : upgrades.entrySet()) {
+        for (Entry<Upgrade, Integer> entry : upgrades.entrySet()) {
             data.add(entry.getKey().ordinal());
             data.add(entry.getValue());
         }

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityBasicBlock.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityBasicBlock.java
@@ -4,6 +4,7 @@ import io.netty.buffer.ByteBuf;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import javax.annotation.Nonnull;
 import mekanism.api.Coord4D;
 import mekanism.api.Range4D;
@@ -46,7 +47,7 @@ public abstract class TileEntityBasicBlock extends TileEntity implements ITileNe
     /**
      * The players currently using this block.
      */
-    public HashSet<EntityPlayer> playersUsing = new HashSet<>();
+    public Set<EntityPlayer> playersUsing = new HashSet<>();
 
     /**
      * A timer used to send packets to clients.

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityUpgradeableMachine.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityUpgradeableMachine.java
@@ -63,7 +63,7 @@ public abstract class TileEntityUpgradeableMachine<INPUT extends MachineInput<IN
         factory.upgradeComponent.setSupported(Upgrade.GAS, type.fuelEnergyUpgrades());
         factory.securityComponent.readFrom(securityComponent);
 
-        for (TransmissionType transmission : configComponent.transmissions) {
+        for (TransmissionType transmission : configComponent.getTransmissions()) {
             factory.configComponent.setConfig(transmission, configComponent.getConfig(transmission).asByteArray());
             factory.configComponent.setEjecting(transmission, configComponent.isEjecting(transmission));
         }

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityLogisticalTransporter.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityLogisticalTransporter.java
@@ -136,7 +136,7 @@ public class TileEntityLogisticalTransporter extends TileEntityTransmitter<TileE
 
                 // If the insert succeeded, remove the inserted count and try again for another 10 ticks
                 if (!response.isEmpty()) {
-                    response.getInvStack(tile, side.getOpposite()).use(response.getStack().getCount());
+                    response.getInvStack(tile, side.getOpposite()).use(response.getSendingAmount());
                     delay = 10;
                 } else {
                     // Insert failed; increment the backoff and calculate delay. Note that we cap retries

--- a/src/main/java/mekanism/common/transmitters/TransporterImpl.java
+++ b/src/main/java/mekanism/common/transmitters/TransporterImpl.java
@@ -98,14 +98,10 @@ public class TransporterImpl extends TransmitterImpl<TileEntity, InventoryNetwor
             for (TransporterStack stack : transit.values()) {
                 stack.progress = Math.min(100, stack.progress + getTileEntity().tier.getSpeed());
             }
-        } else {
-            if (getTransmitterNetwork() == null) {
-                return;
-            }
-
+        } else if (getTransmitterNetwork() != null) {
             Set<Integer> deletes = new HashSet<>();
             getTileEntity().pullItems();
-            for (Map.Entry<Integer, TransporterStack> entry : transit.entrySet()) {
+            for (Entry<Integer, TransporterStack> entry : transit.entrySet()) {
                 int stackId = entry.getKey();
                 TransporterStack stack = entry.getValue();
                 if (!stack.initiatedPath) {
@@ -138,8 +134,8 @@ public class TransporterImpl extends TransmitterImpl<TileEntity, InventoryNetwor
                         } else if (stack.pathType != Path.NONE) {
                             TileEntity tile = next.getTileEntity(world());
                             if (tile != null) {
-                                TransitResponse response = InventoryUtils.putStackInInventory(tile, TransitRequest.getFromTransport(stack),
-                                      stack.getSide(this), stack.pathType == Path.HOME);
+                                TransitResponse response = InventoryUtils.putStackInInventory(tile, TransitRequest.getFromTransport(stack), stack.getSide(this),
+                                      stack.pathType == Path.HOME);
                                 // Nothing was rejected; remove the stack from the prediction tracker and
                                 // schedule this stack for deletion. Continue the loop thereafter
                                 if (response.getRejected(stack.itemStack).isEmpty()) {
@@ -208,11 +204,9 @@ public class TransporterImpl extends TransmitterImpl<TileEntity, InventoryNetwor
     private boolean recalculate(int stackId, TransporterStack stack, Coord4D from) {
         if (stack.pathType != Path.NONE) {
             TransitResponse ret = stack.recalculatePath(TransitRequest.getFromTransport(stack), this, 0);
-            if (ret.isEmpty()) {
-                if (!stack.calculateIdle(this)) {
-                    TransporterUtils.drop(this, stack);
-                    return false;
-                }
+            if (ret.isEmpty() && !stack.calculateIdle(this)) {
+                TransporterUtils.drop(this, stack);
+                return false;
             }
         } else if (!stack.calculateIdle(this)) {
             TransporterUtils.drop(this, stack);
@@ -309,7 +303,6 @@ public class TransporterImpl extends TransmitterImpl<TileEntity, InventoryNetwor
         if (!getTileEntity().canConnect(side)) {
             return false;
         }
-
         return getTileEntity().getConnectionType(side) == ConnectionType.NORMAL || getTileEntity().getConnectionType(side) == ConnectionType.PUSH;
     }
 

--- a/src/main/java/mekanism/common/transmitters/TransporterImpl.java
+++ b/src/main/java/mekanism/common/transmitters/TransporterImpl.java
@@ -101,6 +101,7 @@ public class TransporterImpl extends TransmitterImpl<TileEntity, InventoryNetwor
         } else if (getTransmitterNetwork() != null) {
             Set<Integer> deletes = new HashSet<>();
             getTileEntity().pullItems();
+            Coord4D coord = coord();
             for (Entry<Integer, TransporterStack> entry : transit.entrySet()) {
                 int stackId = entry.getKey();
                 TransporterStack stack = entry.getValue();
@@ -115,7 +116,7 @@ public class TransporterImpl extends TransmitterImpl<TileEntity, InventoryNetwor
                 if (stack.progress >= 100) {
                     Coord4D prevSet = null;
                     if (stack.hasPath()) {
-                        int currentIndex = stack.getPath().indexOf(coord());
+                        int currentIndex = stack.getPath().indexOf(coord);
                         if (currentIndex == 0) { //Necessary for transition reasons, not sure why
                             deletes.add(stackId);
                             continue;
@@ -177,7 +178,7 @@ public class TransporterImpl extends TransmitterImpl<TileEntity, InventoryNetwor
             }
 
             if (deletes.size() > 0 || needsSync.size() > 0) {
-                TileEntityMessage msg = new TileEntityMessage(coord(), getTileEntity().makeBatchPacket(needsSync, deletes));
+                TileEntityMessage msg = new TileEntityMessage(coord, getTileEntity().makeBatchPacket(needsSync, deletes));
                 // Now remove any entries from transit that have been deleted
                 deletes.forEach(id -> transit.remove(id));
 
@@ -185,7 +186,7 @@ public class TransporterImpl extends TransmitterImpl<TileEntity, InventoryNetwor
                 needsSync.clear();
 
                 // Finally, notify clients and mark chunk for save
-                Mekanism.packetHandler.sendToReceivers(msg, new Range4D(coord()));
+                Mekanism.packetHandler.sendToReceivers(msg, new Range4D(coord));
                 MekanismUtils.saveChunk(getTileEntity());
             }
         }

--- a/src/main/java/mekanism/common/transmitters/TransporterImpl.java
+++ b/src/main/java/mekanism/common/transmitters/TransporterImpl.java
@@ -223,17 +223,12 @@ public class TransporterImpl extends TransmitterImpl<TileEntity, InventoryNetwor
 
     @Override
     public TransitResponse insert(Coord4D original, TransitRequest request, EnumColor color, boolean doEmit, int min) {
-        return insert_do(original, request, color, doEmit, min, false);
-    }
-
-    private TransitResponse insert_do(Coord4D original, TransitRequest request, EnumColor color, boolean doEmit, int min, boolean force) {
         EnumFacing from = coord().sideDifference(original).getOpposite();
         TransporterStack stack = new TransporterStack();
         stack.originalLocation = original;
         stack.homeLocation = original;
         stack.color = color;
-
-        if ((force && !canReceiveFrom(original.getTileEntity(world()), from)) || !stack.canInsertToTransporter(this, from)) {
+        if (!stack.canInsertToTransporter(this, from)) {
             return TransitResponse.EMPTY;
         }
         TransitResponse response = stack.recalculatePath(request, this, min);
@@ -247,7 +242,8 @@ public class TransporterImpl extends TransmitterImpl<TileEntity, InventoryNetwor
             if (doEmit) {
                 int stackId = nextId++;
                 transit.put(stackId, stack);
-                Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(coord(), getTileEntity().makeSyncPacket(stackId, stack)), new Range4D(coord()));
+                Coord4D coord = coord();
+                Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(coord, getTileEntity().makeSyncPacket(stackId, stack)), new Range4D(coord));
                 MekanismUtils.saveChunk(getTileEntity());
             }
             return response;

--- a/src/main/java/mekanism/common/transmitters/TransporterImpl.java
+++ b/src/main/java/mekanism/common/transmitters/TransporterImpl.java
@@ -132,11 +132,11 @@ public class TransporterImpl extends TransmitterImpl<TileEntity, InventoryNetwor
                             } else if (next != null) {
                                 prevSet = next;
                             }
-                        } else if (stack.pathType != Path.NONE) {
+                        } else if (stack.getPathType() != Path.NONE) {
                             TileEntity tile = next.getTileEntity(world());
                             if (tile != null) {
                                 TransitResponse response = InventoryUtils.putStackInInventory(tile, TransitRequest.getFromTransport(stack), stack.getSide(this),
-                                      stack.pathType == Path.HOME);
+                                      stack.getPathType() == Path.HOME);
                                 // Nothing was rejected; remove the stack from the prediction tracker and
                                 // schedule this stack for deletion. Continue the loop thereafter
                                 if (response.getRejected(stack.itemStack).isEmpty()) {
@@ -161,7 +161,7 @@ public class TransporterImpl extends TransmitterImpl<TileEntity, InventoryNetwor
                     }
                 } else if (stack.progress == 50) {
                     if (stack.isFinal(this)) {
-                        if (checkPath(stack, Path.DEST, false) || checkPath(stack, Path.HOME, true) || stack.pathType == Path.NONE) {
+                        if (checkPath(stack, Path.DEST, false) || checkPath(stack, Path.HOME, true) || stack.getPathType() == Path.NONE) {
                             if (!recalculate(stackId, stack, null)) {
                                 deletes.add(stackId);
                             }
@@ -193,7 +193,7 @@ public class TransporterImpl extends TransmitterImpl<TileEntity, InventoryNetwor
     }
 
     private boolean checkPath(TransporterStack stack, Path dest, boolean home) {
-        return stack.pathType == dest && (!checkSideForInsert(stack) || !InventoryUtils.canInsert(stack.getDest().getTileEntity(world()), stack.color, stack.itemStack,
+        return stack.getPathType() == dest && (!checkSideForInsert(stack) || !InventoryUtils.canInsert(stack.getDest().getTileEntity(world()), stack.color, stack.itemStack,
               stack.getSide(this), home));
     }
 
@@ -203,7 +203,7 @@ public class TransporterImpl extends TransmitterImpl<TileEntity, InventoryNetwor
     }
 
     private boolean recalculate(int stackId, TransporterStack stack, Coord4D from) {
-        if (stack.pathType != Path.NONE) {
+        if (stack.getPathType() != Path.NONE) {
             TransitResponse ret = stack.recalculatePath(TransitRequest.getFromTransport(stack), this, 0);
             if (ret.isEmpty() && !stack.calculateIdle(this)) {
                 TransporterUtils.drop(this, stack);

--- a/src/main/java/mekanism/common/transmitters/grid/InventoryNetwork.java
+++ b/src/main/java/mekanism/common/transmitters/grid/InventoryNetwork.java
@@ -54,7 +54,7 @@ public class InventoryNetwork extends DynamicNetwork<TileEntity, InventoryNetwor
                     if (data == null) {
                         toReturn.add(data = new AcceptorData(coord, response, opposite));
                     } else {
-                        data.sides.add(opposite);
+                        data.add(response, opposite);
                     }
                 }
             }
@@ -100,14 +100,34 @@ public class InventoryNetwork extends DynamicNetwork<TileEntity, InventoryNetwor
 
     public static class AcceptorData {
 
-        public Coord4D location;
-        public TransitResponse response;
-        public Set<EnumFacing> sides = EnumSet.noneOf(EnumFacing.class);
+        private Coord4D location;
+        private TransitResponse response;
+        private Set<EnumFacing> sides = EnumSet.noneOf(EnumFacing.class);
+        //private Map<EnumFacing, TransitResponse> sideResponses = new EnumMap<>(EnumFacing.class);
 
         public AcceptorData(Coord4D coord, TransitResponse ret, EnumFacing side) {
             location = coord;
+            //sideResponses.put(side, response);
             response = ret;
             sides.add(side);
+        }
+
+        public void add(TransitResponse toCombine, EnumFacing side) {
+            sides.add(side);
+            //System.out.println(response.getStack().getCount() + " " + toCombine.getStack().getCount());
+            //TODO: combine the two responses
+        }
+
+        public TransitResponse getResponse() {
+            return response;
+        }
+
+        public Coord4D getLocation() {
+            return location;
+        }
+
+        public Set<EnumFacing> getSides() {
+            return sides;
         }
     }
 }

--- a/src/main/java/mekanism/common/transmitters/grid/InventoryNetwork.java
+++ b/src/main/java/mekanism/common/transmitters/grid/InventoryNetwork.java
@@ -36,26 +36,26 @@ public class InventoryNetwork extends DynamicNetwork<TileEntity, InventoryNetwor
             if (coord == null || coord.equals(stack.homeLocation)) {
                 continue;
             }
-
             EnumSet<EnumFacing> sides = acceptorDirections.get(coord);
+            if (sides == null || sides.isEmpty()) {
+                continue;
+            }
             TileEntity acceptor = coord.getTileEntity(getWorld());
-            if (acceptor == null || sides == null || sides.isEmpty()) {
+            if (acceptor == null) {
                 continue;
             }
 
             AcceptorData data = null;
             for (EnumFacing side : sides) {
-                TransitResponse response = TransporterManager.getPredictedInsert(acceptor, stack.color, request, side.getOpposite());
+                EnumFacing opposite = side.getOpposite();
+                TransitResponse response = TransporterManager.getPredictedInsert(acceptor, stack.color, request, opposite);
                 if (!response.isEmpty()) {
                     if (data == null) {
-                        data = new AcceptorData(coord, response, side.getOpposite());
+                        toReturn.add(data = new AcceptorData(coord, response, opposite));
                     } else {
-                        data.sides.add(side.getOpposite());
+                        data.sides.add(opposite);
                     }
                 }
-            }
-            if (data != null) {
-                toReturn.add(data);
             }
         }
         return toReturn;

--- a/src/main/java/mekanism/common/transmitters/grid/InventoryNetwork.java
+++ b/src/main/java/mekanism/common/transmitters/grid/InventoryNetwork.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 import mekanism.api.Coord4D;
 import mekanism.api.transmitters.DynamicNetwork;
 import mekanism.api.transmitters.IGridTransmitter;
@@ -101,7 +102,7 @@ public class InventoryNetwork extends DynamicNetwork<TileEntity, InventoryNetwor
 
         public Coord4D location;
         public TransitResponse response;
-        public EnumSet<EnumFacing> sides = EnumSet.noneOf(EnumFacing.class);
+        public Set<EnumFacing> sides = EnumSet.noneOf(EnumFacing.class);
 
         public AcceptorData(Coord4D coord, TransitResponse ret, EnumFacing side) {
             location = coord;

--- a/src/main/java/mekanism/common/transmitters/grid/InventoryNetwork.java
+++ b/src/main/java/mekanism/common/transmitters/grid/InventoryNetwork.java
@@ -54,7 +54,7 @@ public class InventoryNetwork extends DynamicNetwork<TileEntity, InventoryNetwor
                     if (data == null) {
                         toReturn.add(data = new AcceptorData(coord, response, opposite));
                     } else {
-                        data.add(response, opposite);
+                        data.sides.add(opposite);
                     }
                 }
             }
@@ -102,20 +102,12 @@ public class InventoryNetwork extends DynamicNetwork<TileEntity, InventoryNetwor
 
         private Coord4D location;
         private TransitResponse response;
-        private Set<EnumFacing> sides = EnumSet.noneOf(EnumFacing.class);
-        //private Map<EnumFacing, TransitResponse> sideResponses = new EnumMap<>(EnumFacing.class);
+        private Set<EnumFacing> sides;
 
         public AcceptorData(Coord4D coord, TransitResponse ret, EnumFacing side) {
             location = coord;
-            //sideResponses.put(side, response);
             response = ret;
-            sides.add(side);
-        }
-
-        public void add(TransitResponse toCombine, EnumFacing side) {
-            sides.add(side);
-            //System.out.println(response.getStack().getCount() + " " + toCombine.getStack().getCount());
-            //TODO: combine the two responses
+            sides = EnumSet.of(side);
         }
 
         public TransitResponse getResponse() {

--- a/src/main/java/mekanism/common/util/InventoryUtils.java
+++ b/src/main/java/mekanism/common/util/InventoryUtils.java
@@ -1,6 +1,7 @@
 package mekanism.common.util;
 
 import java.util.Map;
+import java.util.Map.Entry;
 import mekanism.api.EnumColor;
 import mekanism.common.Mekanism;
 import mekanism.common.base.ISideConfiguration;
@@ -34,7 +35,7 @@ public final class InventoryUtils {
         if (force && tile instanceof TileEntityLogisticalSorter) {
             return ((TileEntityLogisticalSorter) tile).sendHome(request.getSingleStack());
         }
-        for (Map.Entry<HashedItem, Pair<Integer, Map<Integer, Integer>>> requestEntry : request.getItemMap().entrySet()) {
+        for (Entry<HashedItem, Pair<Integer, Map<Integer, Integer>>> requestEntry : request.getItemMap().entrySet()) {
             ItemStack origInsert = StackUtils.size(requestEntry.getKey().getStack(), requestEntry.getValue().getLeft());
             ItemStack toInsert = origInsert.copy();
             if (!isItemHandler(tile, side.getOpposite())) {
@@ -110,10 +111,12 @@ public final class InventoryUtils {
         }
         if (!force && tileEntity instanceof ISideConfiguration) {
             ISideConfiguration config = (ISideConfiguration) tileEntity;
-            EnumFacing tileSide = config.getOrientation();
-            EnumColor configColor = config.getEjector().getInputColor(MekanismUtils.getBaseOrientation(side, tileSide).getOpposite());
-            if (config.getEjector().hasStrictInput() && configColor != null && configColor != color) {
-                return false;
+            if (config.getEjector().hasStrictInput()) {
+                EnumFacing tileSide = config.getOrientation();
+                EnumColor configColor = config.getEjector().getInputColor(MekanismUtils.getBaseOrientation(side, tileSide).getOpposite());
+                if (configColor != null && configColor != color) {
+                    return false;
+                }
             }
         }
         if (!isItemHandler(tileEntity, side.getOpposite())) {
@@ -155,6 +158,7 @@ public final class InventoryUtils {
         return CapabilityUtils.getCapability(tile, CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, side);
     }
 
+    //TODO: Check what the difference between this method and areItemsStackable is
     public static boolean canStack(ItemStack stack1, ItemStack stack2) {
         return stack1.isEmpty() || stack2.isEmpty() ||
                stack1.getItem() == stack2.getItem() && (!stack2.getHasSubtypes() || stack2.getItemDamage() == stack1.getItemDamage())

--- a/src/main/java/mekanism/common/util/ItemRegistryUtils.java
+++ b/src/main/java/mekanism/common/util/ItemRegistryUtils.java
@@ -3,6 +3,7 @@ package mekanism.common.util;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Map.Entry;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
@@ -15,7 +16,7 @@ public final class ItemRegistryUtils {
     private static final Map<String, String> modIDMap = new HashMap<>();
 
     private static void populateMap() {
-        for (Map.Entry<String, ModContainer> entry : Loader.instance().getIndexedModList().entrySet()) {
+        for (Entry<String, ModContainer> entry : Loader.instance().getIndexedModList().entrySet()) {
             modIDMap.put(entry.getKey().toLowerCase(Locale.ROOT), entry.getValue().getName());
         }
     }

--- a/src/main/java/mekanism/common/util/RecipeUtils.java
+++ b/src/main/java/mekanism/common/util/RecipeUtils.java
@@ -1,7 +1,8 @@
 package mekanism.common.util;
 
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import mekanism.api.energy.IEnergizedItem;
 import mekanism.api.gas.GasStack;
 import mekanism.api.gas.IGasItem;
@@ -158,12 +159,12 @@ public class RecipeUtils {
         }
 
         if (MachineType.get(toReturn) != null && MachineType.get(toReturn).supportsUpgrades) {
-            Map<Upgrade, Integer> upgrades = new HashMap<>();
+            Map<Upgrade, Integer> upgrades = new EnumMap<>(Upgrade.class);
             for (int i = 0; i < invLength; i++) {
                 ItemStack itemstack = inv.getStackInSlot(i);
                 if (!itemstack.isEmpty() && MachineType.get(itemstack) != null && MachineType.get(itemstack).supportsUpgrades) {
                     Map<Upgrade, Integer> stackMap = Upgrade.buildMap(ItemDataUtils.getDataMapIfPresent(itemstack));
-                    for (Map.Entry<Upgrade, Integer> entry : stackMap.entrySet()) {
+                    for (Entry<Upgrade, Integer> entry : stackMap.entrySet()) {
                         if (entry != null && entry.getKey() != null && entry.getValue() != null) {
                             Integer val = upgrades.get(entry.getKey());
                             upgrades.put(entry.getKey(), Math.min(entry.getKey().getMax(), (val != null ? val : 0) + entry.getValue()));

--- a/src/main/java/mekanism/common/util/TransporterUtils.java
+++ b/src/main/java/mekanism/common/util/TransporterUtils.java
@@ -75,12 +75,11 @@ public final class TransporterUtils {
     public static void incrementColor(ILogisticalTransporter tileEntity) {
         if (tileEntity.getColor() == null) {
             tileEntity.setColor(colors.get(0));
-            return;
         } else if (colors.indexOf(tileEntity.getColor()) == colors.size() - 1) {
             tileEntity.setColor(null);
-            return;
+        } else {
+            int index = colors.indexOf(tileEntity.getColor());
+            tileEntity.setColor(colors.get(index + 1));
         }
-        int index = colors.indexOf(tileEntity.getColor());
-        tileEntity.setColor(colors.get(index + 1));
     }
 }

--- a/src/main/java/mekanism/generators/client/render/RenderBioGenerator.java
+++ b/src/main/java/mekanism/generators/client/render/RenderBioGenerator.java
@@ -1,6 +1,6 @@
 package mekanism.generators.client.render;
 
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.Map;
 import mekanism.client.render.MekanismRenderer;
 import mekanism.client.render.MekanismRenderer.DisplayInteger;
@@ -22,7 +22,7 @@ public class RenderBioGenerator extends TileEntitySpecialRenderer<TileEntityBioG
 
     private static final int stages = 40;
     private ModelBioGenerator model = new ModelBioGenerator();
-    private Map<EnumFacing, DisplayInteger[]> energyDisplays = new HashMap<>();
+    private Map<EnumFacing, DisplayInteger[]> energyDisplays = new EnumMap<>(EnumFacing.class);
 
     @Override
     public void render(TileEntityBioGenerator tileEntity, double x, double y, double z, float partialTick, int destroyStage, float alpha) {

--- a/src/main/java/mekanism/generators/client/render/item/RenderGeneratorItem.java
+++ b/src/main/java/mekanism/generators/client/render/item/RenderGeneratorItem.java
@@ -1,6 +1,6 @@
 package mekanism.generators.client.render.item;
 
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -15,7 +15,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 @SideOnly(Side.CLIENT)
 public class RenderGeneratorItem extends SubTypeItemRenderer<GeneratorType> {
 
-    public static Map<GeneratorType, ItemLayerWrapper> modelMap = new HashMap<>();
+    public static Map<GeneratorType, ItemLayerWrapper> modelMap = new EnumMap<>(GeneratorType.class);
 
     @Override
     protected boolean earlyExit() {

--- a/src/main/java/mekanism/tools/common/MekanismTools.java
+++ b/src/main/java/mekanism/tools/common/MekanismTools.java
@@ -76,6 +76,7 @@ public class MekanismTools implements IModule {
     public static ArmorMaterial armorGLOWSTONE;
     public static ArmorMaterial armorSTEEL;
 
+    //Can't use EnumMap as the custom ToolMaterial's do not exist yet
     public static Map<ToolMaterial, Float> AXE_DAMAGE = new HashMap<>();
     public static Map<ToolMaterial, Float> AXE_SPEED = new HashMap<>();
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Fixed creative bin auto eject actually lowering the item count from "infinite"
- Changed internal implementations of Maps with Enum keys to EnumMap from HashMap.
- Changed various Transporter related stuff from being public to private with getters/setters where appropriate.
- Improve readability of some parts of transporter code (lambda's, helpers for getters, etc)
- Inline `TransporterManager#getStacksToDest` to allow `getPredictedInsert` to bail sooner
- Keep track of the inventory size rather than making a copy for predicting insertion.
- Pass actual stack to simulate inserting rather than a copy as it is not modified due to just being simulated.

These last two changes improve the performance a lot due to the large overhead of copying itemstacks, when you have a lot of them to copy and are making a lot of copies.