### PR TITLE
Use Recipe Generics in more places, and some general readability improvements

### DIFF
--- a/src/main/java/mekanism/client/ClientProxy.java
+++ b/src/main/java/mekanism/client/ClientProxy.java
@@ -143,6 +143,13 @@ import mekanism.common.item.ItemPortableTeleporter;
 import mekanism.common.item.ItemSeismicReader;
 import mekanism.common.item.ItemWalkieTalkie;
 import mekanism.common.network.PacketPortableTeleporter.PortableTeleporterMessage;
+import mekanism.common.recipe.machines.CombinerRecipe;
+import mekanism.common.recipe.machines.CrusherRecipe;
+import mekanism.common.recipe.machines.EnrichmentRecipe;
+import mekanism.common.recipe.machines.InjectionRecipe;
+import mekanism.common.recipe.machines.OsmiumCompressorRecipe;
+import mekanism.common.recipe.machines.PurificationRecipe;
+import mekanism.common.recipe.machines.SmeltingRecipe;
 import mekanism.common.tier.BaseTier;
 import mekanism.common.tier.GasTankTier;
 import mekanism.common.tile.TileEntityAdvancedFactory;
@@ -678,6 +685,7 @@ public class ClientProxy extends CommonProxy {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public GuiScreen getClientGui(int ID, EntityPlayer player, World world, BlockPos pos) {
         TileEntity tileEntity = world.getTileEntity(pos);
 
@@ -689,13 +697,13 @@ public class ClientProxy extends CommonProxy {
             case 2:
                 return new GuiDigitalMiner(player.inventory, (TileEntityDigitalMiner) tileEntity);
             case 3:
-                return new GuiEnrichmentChamber(player.inventory, (TileEntityElectricMachine) tileEntity);
+                return new GuiEnrichmentChamber(player.inventory, (TileEntityElectricMachine<EnrichmentRecipe>) tileEntity);
             case 4:
-                return new GuiOsmiumCompressor(player.inventory, (TileEntityAdvancedElectricMachine) tileEntity);
+                return new GuiOsmiumCompressor(player.inventory, (TileEntityAdvancedElectricMachine<OsmiumCompressorRecipe>) tileEntity);
             case 5:
-                return new GuiCombiner(player.inventory, (TileEntityDoubleElectricMachine) tileEntity);
+                return new GuiCombiner(player.inventory, (TileEntityDoubleElectricMachine<CombinerRecipe>) tileEntity);
             case 6:
-                return new GuiCrusher(player.inventory, (TileEntityElectricMachine) tileEntity);
+                return new GuiCrusher(player.inventory, (TileEntityElectricMachine<CrusherRecipe>) tileEntity);
             case 7:
                 return new GuiRotaryCondensentrator(player.inventory, (TileEntityRotaryCondensentrator) tileEntity);
             case 8:
@@ -717,9 +725,9 @@ public class ClientProxy extends CommonProxy {
                 }
                 return null;
             case 15:
-                return new GuiPurificationChamber(player.inventory, (TileEntityAdvancedElectricMachine) tileEntity);
+                return new GuiPurificationChamber(player.inventory, (TileEntityAdvancedElectricMachine<PurificationRecipe>) tileEntity);
             case 16:
-                return new GuiEnergizedSmelter(player.inventory, (TileEntityElectricMachine) tileEntity);
+                return new GuiEnergizedSmelter(player.inventory, (TileEntityElectricMachine<SmeltingRecipe>) tileEntity);
             case 17:
                 return new GuiElectricPump(player.inventory, (TileEntityElectricPump) tileEntity);
             case 18:
@@ -760,7 +768,7 @@ public class ClientProxy extends CommonProxy {
             case 30:
                 return new GuiChemicalInfuser(player.inventory, (TileEntityChemicalInfuser) tileEntity);
             case 31:
-                return new GuiChemicalInjectionChamber(player.inventory, (TileEntityAdvancedElectricMachine) tileEntity);
+                return new GuiChemicalInjectionChamber(player.inventory, (TileEntityAdvancedElectricMachine<InjectionRecipe>) tileEntity);
             case 32:
                 return new GuiElectrolyticSeparator(player.inventory, (TileEntityElectrolyticSeparator) tileEntity);
             case 33:

--- a/src/main/java/mekanism/client/gui/GuiAdvancedElectricMachine.java
+++ b/src/main/java/mekanism/client/gui/GuiAdvancedElectricMachine.java
@@ -17,6 +17,7 @@ import mekanism.client.gui.element.GuiTransporterConfigTab;
 import mekanism.client.gui.element.GuiUpgradeTab;
 import mekanism.client.render.MekanismRenderer;
 import mekanism.common.inventory.container.ContainerAdvancedElectricMachine;
+import mekanism.common.recipe.machines.AdvancedMachineRecipe;
 import mekanism.common.tile.prefab.TileEntityAdvancedElectricMachine;
 import mekanism.common.util.LangUtils;
 import mekanism.common.util.MekanismUtils;
@@ -27,10 +28,10 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import org.lwjgl.opengl.GL11;
 
 @SideOnly(Side.CLIENT)
-public class GuiAdvancedElectricMachine extends GuiMekanismTile<TileEntityAdvancedElectricMachine> {
+public class GuiAdvancedElectricMachine<RECIPE extends AdvancedMachineRecipe<RECIPE>> extends GuiMekanismTile<TileEntityAdvancedElectricMachine<RECIPE>> {
 
-    public GuiAdvancedElectricMachine(InventoryPlayer inventory, TileEntityAdvancedElectricMachine tile) {
-        super(tile, new ContainerAdvancedElectricMachine(inventory, tile));
+    public GuiAdvancedElectricMachine(InventoryPlayer inventory, TileEntityAdvancedElectricMachine<RECIPE> tile) {
+        super(tile, new ContainerAdvancedElectricMachine<>(inventory, tile));
         ResourceLocation resource = getGuiLocation();
         addGuiElement(new GuiRedstoneControl(this, tileEntity, resource));
         addGuiElement(new GuiUpgradeTab(this, tileEntity, resource));

--- a/src/main/java/mekanism/client/gui/GuiChanceMachine.java
+++ b/src/main/java/mekanism/client/gui/GuiChanceMachine.java
@@ -15,6 +15,7 @@ import mekanism.client.gui.element.GuiSlot.SlotType;
 import mekanism.client.gui.element.GuiTransporterConfigTab;
 import mekanism.client.gui.element.GuiUpgradeTab;
 import mekanism.common.inventory.container.ContainerChanceMachine;
+import mekanism.common.recipe.machines.ChanceMachineRecipe;
 import mekanism.common.tile.TileEntityChanceMachine;
 import mekanism.common.util.LangUtils;
 import mekanism.common.util.MekanismUtils;
@@ -25,10 +26,10 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import org.lwjgl.opengl.GL11;
 
 @SideOnly(Side.CLIENT)
-public class GuiChanceMachine extends GuiMekanismTile<TileEntityChanceMachine> {
+public class GuiChanceMachine<RECIPE extends ChanceMachineRecipe<RECIPE>> extends GuiMekanismTile<TileEntityChanceMachine<RECIPE>> {
 
-    public GuiChanceMachine(InventoryPlayer inventory, TileEntityChanceMachine tile) {
-        super(tile, new ContainerChanceMachine(inventory, tile));
+    public GuiChanceMachine(InventoryPlayer inventory, TileEntityChanceMachine<RECIPE> tile) {
+        super(tile, new ContainerChanceMachine<>(inventory, tile));
         ResourceLocation resource = getGuiLocation();
         addGuiElement(new GuiRedstoneControl(this, tileEntity, resource));
         addGuiElement(new GuiUpgradeTab(this, tileEntity, resource));

--- a/src/main/java/mekanism/client/gui/GuiCombiner.java
+++ b/src/main/java/mekanism/client/gui/GuiCombiner.java
@@ -1,15 +1,16 @@
 package mekanism.client.gui;
 
 import mekanism.client.gui.element.GuiProgress.ProgressBar;
+import mekanism.common.recipe.machines.CombinerRecipe;
 import mekanism.common.tile.prefab.TileEntityDoubleElectricMachine;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 @SideOnly(Side.CLIENT)
-public class GuiCombiner extends GuiDoubleElectricMachine {
+public class GuiCombiner extends GuiDoubleElectricMachine<CombinerRecipe> {
 
-    public GuiCombiner(InventoryPlayer inventory, TileEntityDoubleElectricMachine tile) {
+    public GuiCombiner(InventoryPlayer inventory, TileEntityDoubleElectricMachine<CombinerRecipe> tile) {
         super(inventory, tile);
     }
 

--- a/src/main/java/mekanism/client/gui/GuiCrusher.java
+++ b/src/main/java/mekanism/client/gui/GuiCrusher.java
@@ -1,15 +1,16 @@
 package mekanism.client.gui;
 
 import mekanism.client.gui.element.GuiProgress.ProgressBar;
+import mekanism.common.recipe.machines.CrusherRecipe;
 import mekanism.common.tile.prefab.TileEntityElectricMachine;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 @SideOnly(Side.CLIENT)
-public class GuiCrusher extends GuiElectricMachine {
+public class GuiCrusher extends GuiElectricMachine<CrusherRecipe> {
 
-    public GuiCrusher(InventoryPlayer inventory, TileEntityElectricMachine tile) {
+    public GuiCrusher(InventoryPlayer inventory, TileEntityElectricMachine<CrusherRecipe> tile) {
         super(inventory, tile);
     }
 

--- a/src/main/java/mekanism/client/gui/GuiDoubleElectricMachine.java
+++ b/src/main/java/mekanism/client/gui/GuiDoubleElectricMachine.java
@@ -15,6 +15,7 @@ import mekanism.client.gui.element.GuiSlot.SlotType;
 import mekanism.client.gui.element.GuiTransporterConfigTab;
 import mekanism.client.gui.element.GuiUpgradeTab;
 import mekanism.common.inventory.container.ContainerDoubleElectricMachine;
+import mekanism.common.recipe.machines.DoubleMachineRecipe;
 import mekanism.common.tile.prefab.TileEntityDoubleElectricMachine;
 import mekanism.common.util.LangUtils;
 import mekanism.common.util.MekanismUtils;
@@ -25,10 +26,10 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import org.lwjgl.opengl.GL11;
 
 @SideOnly(Side.CLIENT)
-public class GuiDoubleElectricMachine extends GuiMekanismTile<TileEntityDoubleElectricMachine> {
+public class GuiDoubleElectricMachine<RECIPE extends DoubleMachineRecipe<RECIPE>> extends GuiMekanismTile<TileEntityDoubleElectricMachine<RECIPE>> {
 
-    public GuiDoubleElectricMachine(InventoryPlayer inventory, TileEntityDoubleElectricMachine tile) {
-        super(tile, new ContainerDoubleElectricMachine(inventory, tile));
+    public GuiDoubleElectricMachine(InventoryPlayer inventory, TileEntityDoubleElectricMachine<RECIPE> tile) {
+        super(tile, new ContainerDoubleElectricMachine<>(inventory, tile));
         ResourceLocation resource = tileEntity.guiLocation;
         addGuiElement(new GuiRedstoneControl(this, tileEntity, resource));
         addGuiElement(new GuiUpgradeTab(this, tileEntity, resource));

--- a/src/main/java/mekanism/client/gui/GuiElectricMachine.java
+++ b/src/main/java/mekanism/client/gui/GuiElectricMachine.java
@@ -15,6 +15,7 @@ import mekanism.client.gui.element.GuiSlot.SlotType;
 import mekanism.client.gui.element.GuiTransporterConfigTab;
 import mekanism.client.gui.element.GuiUpgradeTab;
 import mekanism.common.inventory.container.ContainerElectricMachine;
+import mekanism.common.recipe.machines.BasicMachineRecipe;
 import mekanism.common.tile.prefab.TileEntityElectricMachine;
 import mekanism.common.util.LangUtils;
 import mekanism.common.util.MekanismUtils;
@@ -25,10 +26,10 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import org.lwjgl.opengl.GL11;
 
 @SideOnly(Side.CLIENT)
-public class GuiElectricMachine extends GuiMekanismTile<TileEntityElectricMachine> {
+public class GuiElectricMachine<RECIPE extends BasicMachineRecipe<RECIPE>> extends GuiMekanismTile<TileEntityElectricMachine<RECIPE>> {
 
-    public GuiElectricMachine(InventoryPlayer inventory, TileEntityElectricMachine tile) {
-        super(tile, new ContainerElectricMachine(inventory, tile));
+    public GuiElectricMachine(InventoryPlayer inventory, TileEntityElectricMachine<RECIPE> tile) {
+        super(tile, new ContainerElectricMachine<>(inventory, tile));
         ResourceLocation resource = tileEntity.guiLocation;
         addGuiElement(new GuiRedstoneControl(this, tileEntity, resource));
         addGuiElement(new GuiUpgradeTab(this, tileEntity, resource));

--- a/src/main/java/mekanism/client/gui/GuiEnergizedSmelter.java
+++ b/src/main/java/mekanism/client/gui/GuiEnergizedSmelter.java
@@ -1,15 +1,16 @@
 package mekanism.client.gui;
 
 import mekanism.client.gui.element.GuiProgress.ProgressBar;
+import mekanism.common.recipe.machines.SmeltingRecipe;
 import mekanism.common.tile.prefab.TileEntityElectricMachine;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 @SideOnly(Side.CLIENT)
-public class GuiEnergizedSmelter extends GuiElectricMachine {
+public class GuiEnergizedSmelter extends GuiElectricMachine<SmeltingRecipe> {
 
-    public GuiEnergizedSmelter(InventoryPlayer inventory, TileEntityElectricMachine tile) {
+    public GuiEnergizedSmelter(InventoryPlayer inventory, TileEntityElectricMachine<SmeltingRecipe> tile) {
         super(inventory, tile);
     }
 

--- a/src/main/java/mekanism/client/gui/GuiEnrichmentChamber.java
+++ b/src/main/java/mekanism/client/gui/GuiEnrichmentChamber.java
@@ -1,15 +1,16 @@
 package mekanism.client.gui;
 
 import mekanism.client.gui.element.GuiProgress.ProgressBar;
+import mekanism.common.recipe.machines.EnrichmentRecipe;
 import mekanism.common.tile.prefab.TileEntityElectricMachine;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 @SideOnly(Side.CLIENT)
-public class GuiEnrichmentChamber extends GuiElectricMachine {
+public class GuiEnrichmentChamber extends GuiElectricMachine<EnrichmentRecipe> {
 
-    public GuiEnrichmentChamber(InventoryPlayer inventory, TileEntityElectricMachine tile) {
+    public GuiEnrichmentChamber(InventoryPlayer inventory, TileEntityElectricMachine<EnrichmentRecipe> tile) {
         super(inventory, tile);
     }
 

--- a/src/main/java/mekanism/client/gui/GuiOsmiumCompressor.java
+++ b/src/main/java/mekanism/client/gui/GuiOsmiumCompressor.java
@@ -1,15 +1,16 @@
 package mekanism.client.gui;
 
 import mekanism.client.gui.element.GuiProgress.ProgressBar;
+import mekanism.common.recipe.machines.OsmiumCompressorRecipe;
 import mekanism.common.tile.prefab.TileEntityAdvancedElectricMachine;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 @SideOnly(Side.CLIENT)
-public class GuiOsmiumCompressor extends GuiAdvancedElectricMachine {
+public class GuiOsmiumCompressor extends GuiAdvancedElectricMachine<OsmiumCompressorRecipe> {
 
-    public GuiOsmiumCompressor(InventoryPlayer inventory, TileEntityAdvancedElectricMachine tile) {
+    public GuiOsmiumCompressor(InventoryPlayer inventory, TileEntityAdvancedElectricMachine<OsmiumCompressorRecipe> tile) {
         super(inventory, tile);
     }
 

--- a/src/main/java/mekanism/client/gui/GuiPrecisionSawmill.java
+++ b/src/main/java/mekanism/client/gui/GuiPrecisionSawmill.java
@@ -1,15 +1,16 @@
 package mekanism.client.gui;
 
 import mekanism.client.gui.element.GuiProgress.ProgressBar;
+import mekanism.common.recipe.machines.SawmillRecipe;
 import mekanism.common.tile.TileEntityChanceMachine;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 @SideOnly(Side.CLIENT)
-public class GuiPrecisionSawmill extends GuiChanceMachine {
+public class GuiPrecisionSawmill extends GuiChanceMachine<SawmillRecipe> {
 
-    public GuiPrecisionSawmill(InventoryPlayer inventory, TileEntityChanceMachine tile) {
+    public GuiPrecisionSawmill(InventoryPlayer inventory, TileEntityChanceMachine<SawmillRecipe> tile) {
         super(inventory, tile);
     }
 

--- a/src/main/java/mekanism/client/gui/GuiPurificationChamber.java
+++ b/src/main/java/mekanism/client/gui/GuiPurificationChamber.java
@@ -1,15 +1,16 @@
 package mekanism.client.gui;
 
 import mekanism.client.gui.element.GuiProgress.ProgressBar;
+import mekanism.common.recipe.machines.PurificationRecipe;
 import mekanism.common.tile.prefab.TileEntityAdvancedElectricMachine;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 @SideOnly(Side.CLIENT)
-public class GuiPurificationChamber extends GuiAdvancedElectricMachine {
+public class GuiPurificationChamber extends GuiAdvancedElectricMachine<PurificationRecipe> {
 
-    public GuiPurificationChamber(InventoryPlayer inventory, TileEntityAdvancedElectricMachine tile) {
+    public GuiPurificationChamber(InventoryPlayer inventory, TileEntityAdvancedElectricMachine<PurificationRecipe> tile) {
         super(inventory, tile);
     }
 

--- a/src/main/java/mekanism/client/gui/chemical/GuiChemicalInjectionChamber.java
+++ b/src/main/java/mekanism/client/gui/chemical/GuiChemicalInjectionChamber.java
@@ -2,15 +2,16 @@ package mekanism.client.gui.chemical;
 
 import mekanism.client.gui.GuiAdvancedElectricMachine;
 import mekanism.client.gui.element.GuiProgress.ProgressBar;
+import mekanism.common.recipe.machines.InjectionRecipe;
 import mekanism.common.tile.prefab.TileEntityAdvancedElectricMachine;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 @SideOnly(Side.CLIENT)
-public class GuiChemicalInjectionChamber extends GuiAdvancedElectricMachine {
+public class GuiChemicalInjectionChamber extends GuiAdvancedElectricMachine<InjectionRecipe> {
 
-    public GuiChemicalInjectionChamber(InventoryPlayer inventory, TileEntityAdvancedElectricMachine tile) {
+    public GuiChemicalInjectionChamber(InventoryPlayer inventory, TileEntityAdvancedElectricMachine<InjectionRecipe> tile) {
         super(inventory, tile);
     }
 

--- a/src/main/java/mekanism/client/jei/BaseRecipeCategory.java
+++ b/src/main/java/mekanism/client/jei/BaseRecipeCategory.java
@@ -28,7 +28,7 @@ import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.util.ResourceLocation;
 import org.lwjgl.opengl.GL11;
 
-public abstract class BaseRecipeCategory implements IRecipeCategory<IRecipeWrapper>, IGuiWrapper {
+public abstract class BaseRecipeCategory<WRAPPER extends IRecipeWrapper> implements IRecipeCategory<WRAPPER>, IGuiWrapper {
 
     private static final GuiDummy gui = new GuiDummy();
 

--- a/src/main/java/mekanism/client/jei/RecipeRegistryHelper.java
+++ b/src/main/java/mekanism/client/jei/RecipeRegistryHelper.java
@@ -49,24 +49,10 @@ import mekanism.common.integration.crafttweaker.handlers.EnergizedSmelter;
 import mekanism.common.inventory.container.ContainerFormulaicAssemblicator;
 import mekanism.common.recipe.RecipeHandler.Recipe;
 import mekanism.common.recipe.inputs.ItemStackInput;
-import mekanism.common.recipe.machines.ChemicalInfuserRecipe;
-import mekanism.common.recipe.machines.CombinerRecipe;
-import mekanism.common.recipe.machines.CrusherRecipe;
-import mekanism.common.recipe.machines.CrystallizerRecipe;
-import mekanism.common.recipe.machines.DissolutionRecipe;
-import mekanism.common.recipe.machines.EnrichmentRecipe;
-import mekanism.common.recipe.machines.InjectionRecipe;
-import mekanism.common.recipe.machines.MetallurgicInfuserRecipe;
-import mekanism.common.recipe.machines.OsmiumCompressorRecipe;
-import mekanism.common.recipe.machines.OxidationRecipe;
-import mekanism.common.recipe.machines.PressurizedRecipe;
-import mekanism.common.recipe.machines.PurificationRecipe;
-import mekanism.common.recipe.machines.SawmillRecipe;
-import mekanism.common.recipe.machines.SeparatorRecipe;
+import mekanism.common.recipe.inputs.MachineInput;
+import mekanism.common.recipe.machines.MachineRecipe;
 import mekanism.common.recipe.machines.SmeltingRecipe;
-import mekanism.common.recipe.machines.SolarNeutronRecipe;
-import mekanism.common.recipe.machines.ThermalEvaporationRecipe;
-import mekanism.common.recipe.machines.WasherRecipe;
+import mekanism.common.recipe.outputs.MachineOutput;
 import mekanism.common.tier.FactoryTier;
 import mekanism.common.util.MekanismUtils;
 import mezz.jei.api.IModRegistry;
@@ -80,7 +66,7 @@ public class RecipeRegistryHelper {
         if (!MachineType.ENRICHMENT_CHAMBER.isEnabled()) {
             return;
         }
-        addRecipes(registry, Recipe.ENRICHMENT_CHAMBER, EnrichmentRecipe.class, MachineRecipeWrapper::new);
+        addRecipes(registry, Recipe.ENRICHMENT_CHAMBER, MachineRecipeWrapper::new);
         registry.addRecipeClickArea(GuiEnrichmentChamber.class, 79, 40, 24, 7, Recipe.ENRICHMENT_CHAMBER.getJEICategory());
         registerRecipeItem(registry, MachineType.ENRICHMENT_CHAMBER, Recipe.ENRICHMENT_CHAMBER);
     }
@@ -89,7 +75,7 @@ public class RecipeRegistryHelper {
         if (!MachineType.CRUSHER.isEnabled()) {
             return;
         }
-        addRecipes(registry, Recipe.CRUSHER, CrusherRecipe.class, MachineRecipeWrapper::new);
+        addRecipes(registry, Recipe.CRUSHER, MachineRecipeWrapper::new);
         registry.addRecipeClickArea(GuiCrusher.class, 79, 40, 24, 7, Recipe.CRUSHER.getJEICategory());
         registerRecipeItem(registry, MachineType.CRUSHER, Recipe.CRUSHER);
     }
@@ -98,7 +84,7 @@ public class RecipeRegistryHelper {
         if (!MachineType.COMBINER.isEnabled()) {
             return;
         }
-        addRecipes(registry, Recipe.COMBINER, CombinerRecipe.class, DoubleMachineRecipeWrapper::new);
+        addRecipes(registry, Recipe.COMBINER, DoubleMachineRecipeWrapper::new);
         registry.addRecipeClickArea(GuiCombiner.class, 79, 40, 24, 7, Recipe.COMBINER.getJEICategory());
         registerRecipeItem(registry, MachineType.COMBINER, Recipe.COMBINER);
     }
@@ -107,7 +93,7 @@ public class RecipeRegistryHelper {
         if (!MachineType.PURIFICATION_CHAMBER.isEnabled()) {
             return;
         }
-        addRecipes(registry, Recipe.PURIFICATION_CHAMBER, PurificationRecipe.class, AdvancedMachineRecipeWrapper::new);
+        addRecipes(registry, Recipe.PURIFICATION_CHAMBER, AdvancedMachineRecipeWrapper::new);
         registry.addRecipeClickArea(GuiPurificationChamber.class, 79, 40, 24, 7, Recipe.PURIFICATION_CHAMBER.getJEICategory());
         registerRecipeItem(registry, MachineType.PURIFICATION_CHAMBER, Recipe.PURIFICATION_CHAMBER);
     }
@@ -116,7 +102,7 @@ public class RecipeRegistryHelper {
         if (!MachineType.OSMIUM_COMPRESSOR.isEnabled()) {
             return;
         }
-        addRecipes(registry, Recipe.OSMIUM_COMPRESSOR, OsmiumCompressorRecipe.class, AdvancedMachineRecipeWrapper::new);
+        addRecipes(registry, Recipe.OSMIUM_COMPRESSOR, AdvancedMachineRecipeWrapper::new);
         registry.addRecipeClickArea(GuiOsmiumCompressor.class, 79, 40, 24, 7, Recipe.OSMIUM_COMPRESSOR.getJEICategory());
         registerRecipeItem(registry, MachineType.OSMIUM_COMPRESSOR, Recipe.OSMIUM_COMPRESSOR);
     }
@@ -125,7 +111,7 @@ public class RecipeRegistryHelper {
         if (!MachineType.CHEMICAL_INJECTION_CHAMBER.isEnabled()) {
             return;
         }
-        addRecipes(registry, Recipe.CHEMICAL_INJECTION_CHAMBER, InjectionRecipe.class, AdvancedMachineRecipeWrapper::new);
+        addRecipes(registry, Recipe.CHEMICAL_INJECTION_CHAMBER, AdvancedMachineRecipeWrapper::new);
         registry.addRecipeClickArea(GuiChemicalInjectionChamber.class, 79, 40, 24, 7, Recipe.CHEMICAL_INJECTION_CHAMBER.getJEICategory());
         registerRecipeItem(registry, MachineType.CHEMICAL_INJECTION_CHAMBER, Recipe.CHEMICAL_INJECTION_CHAMBER);
     }
@@ -134,7 +120,7 @@ public class RecipeRegistryHelper {
         if (!MachineType.PRECISION_SAWMILL.isEnabled()) {
             return;
         }
-        addRecipes(registry, Recipe.PRECISION_SAWMILL, SawmillRecipe.class, ChanceMachineRecipeWrapper::new);
+        addRecipes(registry, Recipe.PRECISION_SAWMILL, ChanceMachineRecipeWrapper::new);
         registry.addRecipeClickArea(GuiPrecisionSawmill.class, 79, 40, 24, 7, Recipe.PRECISION_SAWMILL.getJEICategory());
         registerRecipeItem(registry, MachineType.PRECISION_SAWMILL, Recipe.PRECISION_SAWMILL);
     }
@@ -143,7 +129,7 @@ public class RecipeRegistryHelper {
         if (!MachineType.METALLURGIC_INFUSER.isEnabled()) {
             return;
         }
-        addRecipes(registry, Recipe.METALLURGIC_INFUSER, MetallurgicInfuserRecipe.class, MetallurgicInfuserRecipeWrapper::new);
+        addRecipes(registry, Recipe.METALLURGIC_INFUSER, MetallurgicInfuserRecipeWrapper::new);
         registry.addRecipeClickArea(GuiMetallurgicInfuser.class, 72, 47, 32, 8, Recipe.METALLURGIC_INFUSER.getJEICategory());
         registerRecipeItem(registry, MachineType.METALLURGIC_INFUSER, Recipe.METALLURGIC_INFUSER);
     }
@@ -152,7 +138,7 @@ public class RecipeRegistryHelper {
         if (!MachineType.CHEMICAL_CRYSTALLIZER.isEnabled()) {
             return;
         }
-        addRecipes(registry, Recipe.CHEMICAL_CRYSTALLIZER, CrystallizerRecipe.class, ChemicalCrystallizerRecipeWrapper::new);
+        addRecipes(registry, Recipe.CHEMICAL_CRYSTALLIZER, ChemicalCrystallizerRecipeWrapper::new);
         registry.addRecipeClickArea(GuiChemicalCrystallizer.class, 53, 62, 48, 8, Recipe.CHEMICAL_CRYSTALLIZER.getJEICategory());
         registerRecipeItem(registry, MachineType.CHEMICAL_CRYSTALLIZER, Recipe.CHEMICAL_CRYSTALLIZER);
     }
@@ -161,7 +147,7 @@ public class RecipeRegistryHelper {
         if (!MachineType.CHEMICAL_DISSOLUTION_CHAMBER.isEnabled()) {
             return;
         }
-        addRecipes(registry, Recipe.CHEMICAL_DISSOLUTION_CHAMBER, DissolutionRecipe.class, ChemicalDissolutionChamberRecipeWrapper::new);
+        addRecipes(registry, Recipe.CHEMICAL_DISSOLUTION_CHAMBER, ChemicalDissolutionChamberRecipeWrapper::new);
         registry.addRecipeClickArea(GuiChemicalDissolutionChamber.class, 64, 40, 48, 8, Recipe.CHEMICAL_DISSOLUTION_CHAMBER.getJEICategory());
         registerRecipeItem(registry, MachineType.CHEMICAL_DISSOLUTION_CHAMBER, Recipe.CHEMICAL_DISSOLUTION_CHAMBER);
     }
@@ -170,7 +156,7 @@ public class RecipeRegistryHelper {
         if (!MachineType.CHEMICAL_INFUSER.isEnabled()) {
             return;
         }
-        addRecipes(registry, Recipe.CHEMICAL_INFUSER, ChemicalInfuserRecipe.class, ChemicalInfuserRecipeWrapper::new);
+        addRecipes(registry, Recipe.CHEMICAL_INFUSER, ChemicalInfuserRecipeWrapper::new);
         registry.addRecipeClickArea(GuiChemicalInfuser.class, 47, 39, 28, 8, Recipe.CHEMICAL_INFUSER.getJEICategory());
         registry.addRecipeClickArea(GuiChemicalInfuser.class, 101, 39, 28, 8, Recipe.CHEMICAL_INFUSER.getJEICategory());
         registerRecipeItem(registry, MachineType.CHEMICAL_INFUSER, Recipe.CHEMICAL_INFUSER);
@@ -180,7 +166,7 @@ public class RecipeRegistryHelper {
         if (!MachineType.CHEMICAL_OXIDIZER.isEnabled()) {
             return;
         }
-        addRecipes(registry, Recipe.CHEMICAL_OXIDIZER, OxidationRecipe.class, ChemicalOxidizerRecipeWrapper::new);
+        addRecipes(registry, Recipe.CHEMICAL_OXIDIZER, ChemicalOxidizerRecipeWrapper::new);
         registry.addRecipeClickArea(GuiChemicalOxidizer.class, 64, 40, 48, 8, Recipe.CHEMICAL_OXIDIZER.getJEICategory());
         registerRecipeItem(registry, MachineType.CHEMICAL_OXIDIZER, Recipe.CHEMICAL_OXIDIZER);
     }
@@ -189,7 +175,7 @@ public class RecipeRegistryHelper {
         if (!MachineType.CHEMICAL_WASHER.isEnabled()) {
             return;
         }
-        addRecipes(registry, Recipe.CHEMICAL_WASHER, WasherRecipe.class, ChemicalWasherRecipeWrapper::new);
+        addRecipes(registry, Recipe.CHEMICAL_WASHER, ChemicalWasherRecipeWrapper::new);
         registry.addRecipeClickArea(GuiChemicalWasher.class, 61, 39, 55, 8, Recipe.CHEMICAL_WASHER.getJEICategory());
         registerRecipeItem(registry, MachineType.CHEMICAL_WASHER, Recipe.CHEMICAL_WASHER);
     }
@@ -198,7 +184,7 @@ public class RecipeRegistryHelper {
         if (!MachineType.SOLAR_NEUTRON_ACTIVATOR.isEnabled()) {
             return;
         }
-        addRecipes(registry, Recipe.SOLAR_NEUTRON_ACTIVATOR, SolarNeutronRecipe.class, SolarNeutronRecipeWrapper::new);
+        addRecipes(registry, Recipe.SOLAR_NEUTRON_ACTIVATOR, SolarNeutronRecipeWrapper::new);
         registry.addRecipeClickArea(GuiSolarNeutronActivator.class, 64, 39, 48, 8, Recipe.SOLAR_NEUTRON_ACTIVATOR.getJEICategory());
         registerRecipeItem(registry, MachineType.SOLAR_NEUTRON_ACTIVATOR, Recipe.SOLAR_NEUTRON_ACTIVATOR);
     }
@@ -207,13 +193,13 @@ public class RecipeRegistryHelper {
         if (!MachineType.ELECTROLYTIC_SEPARATOR.isEnabled()) {
             return;
         }
-        addRecipes(registry, Recipe.ELECTROLYTIC_SEPARATOR, SeparatorRecipe.class, ElectrolyticSeparatorRecipeWrapper::new);
+        addRecipes(registry, Recipe.ELECTROLYTIC_SEPARATOR, ElectrolyticSeparatorRecipeWrapper::new);
         registry.addRecipeClickArea(GuiElectrolyticSeparator.class, 80, 30, 16, 6, Recipe.ELECTROLYTIC_SEPARATOR.getJEICategory());
         registerRecipeItem(registry, MachineType.ELECTROLYTIC_SEPARATOR, Recipe.ELECTROLYTIC_SEPARATOR);
     }
 
     public static void registerEvaporationPlant(IModRegistry registry) {
-        addRecipes(registry, Recipe.THERMAL_EVAPORATION_PLANT, ThermalEvaporationRecipe.class, ThermalEvaporationRecipeWrapper::new);
+        addRecipes(registry, Recipe.THERMAL_EVAPORATION_PLANT, ThermalEvaporationRecipeWrapper::new);
         registry.addRecipeClickArea(GuiThermalEvaporationController.class, 49, 20, 78, 38, Recipe.THERMAL_EVAPORATION_PLANT.getJEICategory());
         registry.addRecipeCatalyst(BasicBlockType.THERMAL_EVAPORATION_CONTROLLER.getStack(1), Recipe.THERMAL_EVAPORATION_PLANT.getJEICategory());
     }
@@ -222,7 +208,7 @@ public class RecipeRegistryHelper {
         if (!MachineType.PRESSURIZED_REACTION_CHAMBER.isEnabled()) {
             return;
         }
-        addRecipes(registry, Recipe.PRESSURIZED_REACTION_CHAMBER, PressurizedRecipe.class, PRCRecipeWrapper::new);
+        addRecipes(registry, Recipe.PRESSURIZED_REACTION_CHAMBER, PRCRecipeWrapper::new);
         registry.addRecipeClickArea(GuiPRC.class, 75, 37, 36, 10, Recipe.PRESSURIZED_REACTION_CHAMBER.getJEICategory());
         registerRecipeItem(registry, MachineType.PRESSURIZED_REACTION_CHAMBER, Recipe.PRESSURIZED_REACTION_CHAMBER);
     }
@@ -266,7 +252,7 @@ public class RecipeRegistryHelper {
             Map<ItemStackInput, SmeltingRecipe> smeltingRecipes = Recipe.ENERGIZED_SMELTER.get();
             List<MachineRecipeWrapper> smeltingWrapper = smeltingRecipes.entrySet().stream().filter(entry ->
                   !FurnaceRecipes.instance().getSmeltingList().keySet().contains(entry.getKey().ingredient)).map(entry ->
-                  new MachineRecipeWrapper(entry.getValue())).collect(Collectors.toList());
+                  new MachineRecipeWrapper<>(entry.getValue())).collect(Collectors.toList());
             registry.addRecipes(smeltingWrapper, Recipe.ENERGIZED_SMELTER.getJEICategory());
 
             registry.addRecipeClickArea(GuiEnergizedSmelter.class, 79, 40, 24, 7, VanillaRecipeCategoryUid.SMELTING, Recipe.ENERGIZED_SMELTER.getJEICategory());
@@ -293,12 +279,11 @@ public class RecipeRegistryHelper {
         FactoryTier.forEnabled(tier -> registry.addRecipeCatalyst(MekanismUtils.getFactory(tier, RecipeType.SMELTING), VanillaRecipeCategoryUid.SMELTING));
     }
 
-    private static <T> void addRecipes(IModRegistry registry, Recipe type, Class<T> recipeClass,
-          IRecipeWrapperFactory<T> factory) {
+    private static <INPUT extends MachineInput<INPUT>, OUTPUT extends MachineOutput<OUTPUT>, RECIPE extends MachineRecipe<INPUT, OUTPUT, RECIPE>>
+    void addRecipes(IModRegistry registry, Recipe<INPUT, OUTPUT, RECIPE> type, IRecipeWrapperFactory<RECIPE> factory) {
         String recipeCategoryUid = type.getJEICategory();
-        registry.handleRecipes(recipeClass, factory, recipeCategoryUid);
-        Collection<T> recipeList = type.get().values();
-        registry.addRecipes(recipeList.stream().map(factory::getRecipeWrapper).collect(Collectors.toList()), recipeCategoryUid);
+        registry.handleRecipes(type.getRecipeClass(), factory, recipeCategoryUid);
+        registry.addRecipes(type.get().values().stream().map(factory::getRecipeWrapper).collect(Collectors.toList()), recipeCategoryUid);
     }
 
     private static void registerRecipeItem(IModRegistry registry, MachineType type, Recipe recipe) {

--- a/src/main/java/mekanism/client/jei/machine/AdvancedMachineRecipeCategory.java
+++ b/src/main/java/mekanism/client/jei/machine/AdvancedMachineRecipeCategory.java
@@ -11,9 +11,7 @@ import mekanism.client.gui.element.GuiSlot.SlotOverlay;
 import mekanism.client.gui.element.GuiSlot.SlotType;
 import mekanism.client.jei.BaseRecipeCategory;
 import mekanism.client.jei.MekanismJEI;
-import mekanism.common.recipe.inputs.AdvancedMachineInput;
 import mekanism.common.recipe.machines.AdvancedMachineRecipe;
-import mekanism.common.recipe.outputs.ItemStackOutput;
 import mekanism.common.tile.prefab.TileEntityAdvancedElectricMachine;
 import mezz.jei.api.IGuiHelper;
 import mezz.jei.api.gui.IGuiIngredientGroup;
@@ -49,17 +47,16 @@ public class AdvancedMachineRecipeCategory<RECIPE extends AdvancedMachineRecipe<
 
     @Override
     public void setRecipe(IRecipeLayout recipeLayout, WRAPPER recipeWrapper, IIngredients ingredients) {
-        AdvancedMachineRecipe tempRecipe = recipeWrapper.getRecipe();
-        AdvancedMachineInput input = (AdvancedMachineInput) tempRecipe.recipeInput;
+        AdvancedMachineRecipe<?> tempRecipe = recipeWrapper.getRecipe();
         IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
         itemStacks.init(0, true, 27, 0);
         itemStacks.init(1, false, 87, 18);
         itemStacks.init(2, false, 27, 36);
-        itemStacks.set(0, input.itemStack);
-        itemStacks.set(1, ((ItemStackOutput) tempRecipe.recipeOutput).output);
-        itemStacks.set(2, recipeWrapper.getFuelStacks(input.gasType));
+        itemStacks.set(0, tempRecipe.recipeInput.itemStack);
+        itemStacks.set(1, tempRecipe.recipeOutput.output);
+        itemStacks.set(2, recipeWrapper.getFuelStacks(tempRecipe.recipeInput.gasType));
         IGuiIngredientGroup<GasStack> gasStacks = recipeLayout.getIngredientsGroup(MekanismJEI.TYPE_GAS);
-        initGas(gasStacks, 0, true, 33, 21, 6, 12, new GasStack(input.gasType, TileEntityAdvancedElectricMachine.BASE_TICKS_REQUIRED
+        initGas(gasStacks, 0, true, 33, 21, 6, 12, new GasStack(tempRecipe.recipeInput.gasType, TileEntityAdvancedElectricMachine.BASE_TICKS_REQUIRED
                                                                                * TileEntityAdvancedElectricMachine.BASE_GAS_PER_TICK), false);
     }
 }

--- a/src/main/java/mekanism/client/jei/machine/AdvancedMachineRecipeCategory.java
+++ b/src/main/java/mekanism/client/jei/machine/AdvancedMachineRecipeCategory.java
@@ -20,9 +20,8 @@ import mezz.jei.api.gui.IGuiIngredientGroup;
 import mezz.jei.api.gui.IGuiItemStackGroup;
 import mezz.jei.api.gui.IRecipeLayout;
 import mezz.jei.api.ingredients.IIngredients;
-import mezz.jei.api.recipe.IRecipeWrapper;
 
-public class AdvancedMachineRecipeCategory extends BaseRecipeCategory {
+public class AdvancedMachineRecipeCategory<RECIPE extends AdvancedMachineRecipe<RECIPE>, WRAPPER extends AdvancedMachineRecipeWrapper<RECIPE>> extends BaseRecipeCategory<WRAPPER> {
 
     public AdvancedMachineRecipeCategory(IGuiHelper helper, String name, String unlocalized, ProgressBar progress) {
         super(helper, "mekanism:gui/GuiAdvancedMachine.png", name, unlocalized, progress, 28, 16, 144, 54);
@@ -49,20 +48,18 @@ public class AdvancedMachineRecipeCategory extends BaseRecipeCategory {
     }
 
     @Override
-    public void setRecipe(IRecipeLayout recipeLayout, IRecipeWrapper recipeWrapper, IIngredients ingredients) {
-        if (recipeWrapper instanceof AdvancedMachineRecipeWrapper) {
-            AdvancedMachineRecipe tempRecipe = ((AdvancedMachineRecipeWrapper) recipeWrapper).getRecipe();
-            AdvancedMachineInput input = (AdvancedMachineInput) tempRecipe.recipeInput;
-            IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
-            itemStacks.init(0, true, 27, 0);
-            itemStacks.init(1, false, 87, 18);
-            itemStacks.init(2, false, 27, 36);
-            itemStacks.set(0, input.itemStack);
-            itemStacks.set(1, ((ItemStackOutput) tempRecipe.recipeOutput).output);
-            itemStacks.set(2, ((AdvancedMachineRecipeWrapper) recipeWrapper).getFuelStacks(input.gasType));
-            IGuiIngredientGroup<GasStack> gasStacks = recipeLayout.getIngredientsGroup(MekanismJEI.TYPE_GAS);
-            initGas(gasStacks, 0, true, 33, 21, 6, 12, new GasStack(input.gasType, TileEntityAdvancedElectricMachine.BASE_TICKS_REQUIRED
-                                                                                   * TileEntityAdvancedElectricMachine.BASE_GAS_PER_TICK), false);
-        }
+    public void setRecipe(IRecipeLayout recipeLayout, WRAPPER recipeWrapper, IIngredients ingredients) {
+        AdvancedMachineRecipe tempRecipe = recipeWrapper.getRecipe();
+        AdvancedMachineInput input = (AdvancedMachineInput) tempRecipe.recipeInput;
+        IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
+        itemStacks.init(0, true, 27, 0);
+        itemStacks.init(1, false, 87, 18);
+        itemStacks.init(2, false, 27, 36);
+        itemStacks.set(0, input.itemStack);
+        itemStacks.set(1, ((ItemStackOutput) tempRecipe.recipeOutput).output);
+        itemStacks.set(2, recipeWrapper.getFuelStacks(input.gasType));
+        IGuiIngredientGroup<GasStack> gasStacks = recipeLayout.getIngredientsGroup(MekanismJEI.TYPE_GAS);
+        initGas(gasStacks, 0, true, 33, 21, 6, 12, new GasStack(input.gasType, TileEntityAdvancedElectricMachine.BASE_TICKS_REQUIRED
+                                                                               * TileEntityAdvancedElectricMachine.BASE_GAS_PER_TICK), false);
     }
 }

--- a/src/main/java/mekanism/client/jei/machine/AdvancedMachineRecipeWrapper.java
+++ b/src/main/java/mekanism/client/jei/machine/AdvancedMachineRecipeWrapper.java
@@ -5,36 +5,27 @@ import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasStack;
 import mekanism.client.jei.MekanismJEI;
 import mekanism.common.recipe.GasConversionHandler;
-import mekanism.common.recipe.inputs.AdvancedMachineInput;
 import mekanism.common.recipe.machines.AdvancedMachineRecipe;
-import mekanism.common.recipe.outputs.ItemStackOutput;
 import mekanism.common.tile.prefab.TileEntityAdvancedElectricMachine;
 import mezz.jei.api.ingredients.IIngredients;
 import mezz.jei.api.ingredients.VanillaTypes;
-import mezz.jei.api.recipe.IRecipeWrapper;
 import net.minecraft.item.ItemStack;
 
-public class AdvancedMachineRecipeWrapper implements IRecipeWrapper {
+public class AdvancedMachineRecipeWrapper<RECIPE extends AdvancedMachineRecipe<RECIPE>> extends MekanismRecipeWrapper<RECIPE> {
 
-    private final AdvancedMachineRecipe recipe;
-
-    public AdvancedMachineRecipeWrapper(AdvancedMachineRecipe r) {
-        recipe = r;
+    public AdvancedMachineRecipeWrapper(RECIPE recipe) {
+        super(recipe);
     }
 
     @Override
     public void getIngredients(IIngredients ingredients) {
-        ingredients.setInput(VanillaTypes.ITEM, ((AdvancedMachineInput) recipe.getInput()).itemStack);
-        ingredients.setInput(MekanismJEI.TYPE_GAS, new GasStack(((AdvancedMachineInput) recipe.getInput()).gasType,
+        ingredients.setInput(VanillaTypes.ITEM, recipe.getInput().itemStack);
+        ingredients.setInput(MekanismJEI.TYPE_GAS, new GasStack(recipe.getInput().gasType,
               TileEntityAdvancedElectricMachine.BASE_TICKS_REQUIRED * TileEntityAdvancedElectricMachine.BASE_GAS_PER_TICK));
-        ingredients.setOutput(VanillaTypes.ITEM, ((ItemStackOutput) recipe.getOutput()).output);
+        ingredients.setOutput(VanillaTypes.ITEM, recipe.getOutput().output);
     }
 
     public List<ItemStack> getFuelStacks(Gas gasType) {
         return GasConversionHandler.getStacksForGas(gasType);
-    }
-
-    public AdvancedMachineRecipe getRecipe() {
-        return recipe;
     }
 }

--- a/src/main/java/mekanism/client/jei/machine/ChanceMachineRecipeCategory.java
+++ b/src/main/java/mekanism/client/jei/machine/ChanceMachineRecipeCategory.java
@@ -16,9 +16,8 @@ import mezz.jei.api.IGuiHelper;
 import mezz.jei.api.gui.IGuiItemStackGroup;
 import mezz.jei.api.gui.IRecipeLayout;
 import mezz.jei.api.ingredients.IIngredients;
-import mezz.jei.api.recipe.IRecipeWrapper;
 
-public class ChanceMachineRecipeCategory extends BaseRecipeCategory {
+public class ChanceMachineRecipeCategory<RECIPE extends ChanceMachineRecipe<RECIPE>, WRAPPER extends ChanceMachineRecipeWrapper<RECIPE>> extends BaseRecipeCategory<WRAPPER> {
 
     public ChanceMachineRecipeCategory(IGuiHelper helper, String name, String unlocalized, ProgressBar progress) {
         super(helper, "mekanism:gui/GuiBasicMachine.png", name, unlocalized, progress, 28, 16, 144, 54);
@@ -44,21 +43,19 @@ public class ChanceMachineRecipeCategory extends BaseRecipeCategory {
     }
 
     @Override
-    public void setRecipe(IRecipeLayout recipeLayout, IRecipeWrapper recipeWrapper, IIngredients ingredients) {
-        if (recipeWrapper instanceof ChanceMachineRecipeWrapper) {
-            ChanceMachineRecipe tempRecipe = ((ChanceMachineRecipeWrapper) recipeWrapper).getRecipe();
-            IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
-            itemStacks.init(0, true, 27, 0);
-            itemStacks.init(1, false, 87, 18);
-            itemStacks.init(2, false, 103, 18);
-            itemStacks.set(0, ((ItemStackInput) tempRecipe.recipeInput).ingredient);
-            ChanceOutput output = (ChanceOutput) tempRecipe.getOutput();
-            if (output.hasPrimary()) {
-                itemStacks.set(1, output.primaryOutput);
-            }
-            if (output.hasSecondary()) {
-                itemStacks.set(2, output.secondaryOutput);
-            }
+    public void setRecipe(IRecipeLayout recipeLayout, WRAPPER recipeWrapper, IIngredients ingredients) {
+        ChanceMachineRecipe tempRecipe = recipeWrapper.getRecipe();
+        IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
+        itemStacks.init(0, true, 27, 0);
+        itemStacks.init(1, false, 87, 18);
+        itemStacks.init(2, false, 103, 18);
+        itemStacks.set(0, ((ItemStackInput) tempRecipe.recipeInput).ingredient);
+        ChanceOutput output = (ChanceOutput) tempRecipe.getOutput();
+        if (output.hasPrimary()) {
+            itemStacks.set(1, output.primaryOutput);
+        }
+        if (output.hasSecondary()) {
+            itemStacks.set(2, output.secondaryOutput);
         }
     }
 }

--- a/src/main/java/mekanism/client/jei/machine/ChanceMachineRecipeCategory.java
+++ b/src/main/java/mekanism/client/jei/machine/ChanceMachineRecipeCategory.java
@@ -9,7 +9,6 @@ import mekanism.client.gui.element.GuiSlot;
 import mekanism.client.gui.element.GuiSlot.SlotOverlay;
 import mekanism.client.gui.element.GuiSlot.SlotType;
 import mekanism.client.jei.BaseRecipeCategory;
-import mekanism.common.recipe.inputs.ItemStackInput;
 import mekanism.common.recipe.machines.ChanceMachineRecipe;
 import mekanism.common.recipe.outputs.ChanceOutput;
 import mezz.jei.api.IGuiHelper;
@@ -44,13 +43,13 @@ public class ChanceMachineRecipeCategory<RECIPE extends ChanceMachineRecipe<RECI
 
     @Override
     public void setRecipe(IRecipeLayout recipeLayout, WRAPPER recipeWrapper, IIngredients ingredients) {
-        ChanceMachineRecipe tempRecipe = recipeWrapper.getRecipe();
+        ChanceMachineRecipe<?> tempRecipe = recipeWrapper.getRecipe();
         IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
         itemStacks.init(0, true, 27, 0);
         itemStacks.init(1, false, 87, 18);
         itemStacks.init(2, false, 103, 18);
-        itemStacks.set(0, ((ItemStackInput) tempRecipe.recipeInput).ingredient);
-        ChanceOutput output = (ChanceOutput) tempRecipe.getOutput();
+        itemStacks.set(0, tempRecipe.recipeInput.ingredient);
+        ChanceOutput output = tempRecipe.getOutput();
         if (output.hasPrimary()) {
             itemStacks.set(1, output.primaryOutput);
         }

--- a/src/main/java/mekanism/client/jei/machine/ChanceMachineRecipeWrapper.java
+++ b/src/main/java/mekanism/client/jei/machine/ChanceMachineRecipeWrapper.java
@@ -2,40 +2,32 @@ package mekanism.client.jei.machine;
 
 import java.util.Arrays;
 import javax.annotation.Nonnull;
-import mekanism.common.recipe.inputs.ItemStackInput;
 import mekanism.common.recipe.machines.ChanceMachineRecipe;
 import mekanism.common.recipe.outputs.ChanceOutput;
 import mezz.jei.api.ingredients.IIngredients;
 import mezz.jei.api.ingredients.VanillaTypes;
-import mezz.jei.api.recipe.IRecipeWrapper;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 
-public class ChanceMachineRecipeWrapper implements IRecipeWrapper {
+public class ChanceMachineRecipeWrapper<RECIPE extends ChanceMachineRecipe<RECIPE>> extends MekanismRecipeWrapper<RECIPE> {
 
-    private final ChanceMachineRecipe recipe;
-
-    public ChanceMachineRecipeWrapper(ChanceMachineRecipe r) {
-        recipe = r;
+    public ChanceMachineRecipeWrapper(RECIPE recipe) {
+        super(recipe);
     }
 
     @Override
     public void getIngredients(IIngredients ingredients) {
-        ChanceOutput output = (ChanceOutput) recipe.getOutput();
-        ingredients.setInput(VanillaTypes.ITEM, ((ItemStackInput) recipe.getInput()).ingredient);
+        ChanceOutput output = recipe.getOutput();
+        ingredients.setInput(VanillaTypes.ITEM, recipe.getInput().ingredient);
         ingredients.setOutputs(VanillaTypes.ITEM, Arrays.asList(output.primaryOutput, output.secondaryOutput));
     }
 
     @Override
     public void drawInfo(@Nonnull Minecraft minecraft, int recipeWidth, int recipeHeight, int mouseX, int mouseY) {
-        ChanceOutput output = (ChanceOutput) recipe.getOutput();
+        ChanceOutput output = recipe.getOutput();
         if (output.hasSecondary()) {
             FontRenderer fontRendererObj = minecraft.fontRenderer;
             fontRendererObj.drawString(Math.round(output.secondaryChance * 100) + "%", 104, 41, 0x404040, false);
         }
-    }
-
-    public ChanceMachineRecipe getRecipe() {
-        return recipe;
     }
 }

--- a/src/main/java/mekanism/client/jei/machine/DoubleMachineRecipeCategory.java
+++ b/src/main/java/mekanism/client/jei/machine/DoubleMachineRecipeCategory.java
@@ -9,9 +9,7 @@ import mekanism.client.gui.element.GuiSlot;
 import mekanism.client.gui.element.GuiSlot.SlotOverlay;
 import mekanism.client.gui.element.GuiSlot.SlotType;
 import mekanism.client.jei.BaseRecipeCategory;
-import mekanism.common.recipe.inputs.DoubleMachineInput;
 import mekanism.common.recipe.machines.DoubleMachineRecipe;
-import mekanism.common.recipe.outputs.ItemStackOutput;
 import mezz.jei.api.IGuiHelper;
 import mezz.jei.api.gui.IGuiItemStackGroup;
 import mezz.jei.api.gui.IRecipeLayout;
@@ -45,14 +43,13 @@ public class DoubleMachineRecipeCategory<RECIPE extends DoubleMachineRecipe<RECI
 
     @Override
     public void setRecipe(IRecipeLayout recipeLayout, WRAPPER recipeWrapper, IIngredients ingredients) {
-        DoubleMachineRecipe tempRecipe = recipeWrapper.getRecipe();
-        DoubleMachineInput input = (DoubleMachineInput) tempRecipe.recipeInput;
+        DoubleMachineRecipe<?> tempRecipe = recipeWrapper.getRecipe();
         IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
         itemStacks.init(0, true, 27, 0);
         itemStacks.init(1, false, 87, 18);
         itemStacks.init(2, false, 27, 36);
-        itemStacks.set(0, input.itemStack);
-        itemStacks.set(1, ((ItemStackOutput) tempRecipe.recipeOutput).output);
-        itemStacks.set(2, input.extraStack);
+        itemStacks.set(0, tempRecipe.recipeInput.itemStack);
+        itemStacks.set(1, tempRecipe.recipeOutput.output);
+        itemStacks.set(2, tempRecipe.recipeInput.extraStack);
     }
 }

--- a/src/main/java/mekanism/client/jei/machine/DoubleMachineRecipeCategory.java
+++ b/src/main/java/mekanism/client/jei/machine/DoubleMachineRecipeCategory.java
@@ -16,9 +16,8 @@ import mezz.jei.api.IGuiHelper;
 import mezz.jei.api.gui.IGuiItemStackGroup;
 import mezz.jei.api.gui.IRecipeLayout;
 import mezz.jei.api.ingredients.IIngredients;
-import mezz.jei.api.recipe.IRecipeWrapper;
 
-public class DoubleMachineRecipeCategory extends BaseRecipeCategory {
+public class DoubleMachineRecipeCategory<RECIPE extends DoubleMachineRecipe<RECIPE>, WRAPPER extends DoubleMachineRecipeWrapper<RECIPE>> extends BaseRecipeCategory<WRAPPER> {
 
     public DoubleMachineRecipeCategory(IGuiHelper helper, String name, String unlocalized, ProgressBar progress) {
         super(helper, "mekanism:gui/guibasicmachine.png", name, unlocalized, progress, 28, 16, 144, 54);
@@ -45,17 +44,15 @@ public class DoubleMachineRecipeCategory extends BaseRecipeCategory {
     }
 
     @Override
-    public void setRecipe(IRecipeLayout recipeLayout, IRecipeWrapper recipeWrapper, IIngredients ingredients) {
-        if (recipeWrapper instanceof DoubleMachineRecipeWrapper) {
-            DoubleMachineRecipe tempRecipe = ((DoubleMachineRecipeWrapper) recipeWrapper).getRecipe();
-            DoubleMachineInput input = (DoubleMachineInput) tempRecipe.recipeInput;
-            IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
-            itemStacks.init(0, true, 27, 0);
-            itemStacks.init(1, false, 87, 18);
-            itemStacks.init(2, false, 27, 36);
-            itemStacks.set(0, input.itemStack);
-            itemStacks.set(1, ((ItemStackOutput) tempRecipe.recipeOutput).output);
-            itemStacks.set(2, input.extraStack);
-        }
+    public void setRecipe(IRecipeLayout recipeLayout, WRAPPER recipeWrapper, IIngredients ingredients) {
+        DoubleMachineRecipe tempRecipe = recipeWrapper.getRecipe();
+        DoubleMachineInput input = (DoubleMachineInput) tempRecipe.recipeInput;
+        IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
+        itemStacks.init(0, true, 27, 0);
+        itemStacks.init(1, false, 87, 18);
+        itemStacks.init(2, false, 27, 36);
+        itemStacks.set(0, input.itemStack);
+        itemStacks.set(1, ((ItemStackOutput) tempRecipe.recipeOutput).output);
+        itemStacks.set(2, input.extraStack);
     }
 }

--- a/src/main/java/mekanism/client/jei/machine/DoubleMachineRecipeWrapper.java
+++ b/src/main/java/mekanism/client/jei/machine/DoubleMachineRecipeWrapper.java
@@ -3,27 +3,19 @@ package mekanism.client.jei.machine;
 import java.util.Arrays;
 import mekanism.common.recipe.inputs.DoubleMachineInput;
 import mekanism.common.recipe.machines.DoubleMachineRecipe;
-import mekanism.common.recipe.outputs.ItemStackOutput;
 import mezz.jei.api.ingredients.IIngredients;
 import mezz.jei.api.ingredients.VanillaTypes;
-import mezz.jei.api.recipe.IRecipeWrapper;
 
-public class DoubleMachineRecipeWrapper implements IRecipeWrapper {
+public class DoubleMachineRecipeWrapper<RECIPE extends DoubleMachineRecipe<RECIPE>> extends MekanismRecipeWrapper<RECIPE> {
 
-    private final DoubleMachineRecipe recipe;
-
-    public DoubleMachineRecipeWrapper(DoubleMachineRecipe r) {
-        recipe = r;
+    public DoubleMachineRecipeWrapper(RECIPE recipe) {
+        super(recipe);
     }
 
     @Override
     public void getIngredients(IIngredients ingredients) {
-        DoubleMachineInput input = (DoubleMachineInput) recipe.getInput();
+        DoubleMachineInput input = recipe.getInput();
         ingredients.setInputs(VanillaTypes.ITEM, Arrays.asList(input.itemStack, input.extraStack));
-        ingredients.setOutput(VanillaTypes.ITEM, ((ItemStackOutput) recipe.getOutput()).output);
-    }
-
-    public DoubleMachineRecipe getRecipe() {
-        return recipe;
+        ingredients.setOutput(VanillaTypes.ITEM, recipe.getOutput().output);
     }
 }

--- a/src/main/java/mekanism/client/jei/machine/MachineRecipeCategory.java
+++ b/src/main/java/mekanism/client/jei/machine/MachineRecipeCategory.java
@@ -13,9 +13,8 @@ import mezz.jei.api.IGuiHelper;
 import mezz.jei.api.gui.IGuiItemStackGroup;
 import mezz.jei.api.gui.IRecipeLayout;
 import mezz.jei.api.ingredients.IIngredients;
-import mezz.jei.api.recipe.IRecipeWrapper;
 
-public class MachineRecipeCategory extends BaseRecipeCategory {
+public class MachineRecipeCategory<WRAPPER extends MachineRecipeWrapper> extends BaseRecipeCategory<WRAPPER> {
 
     public MachineRecipeCategory(IGuiHelper helper, String name, String unlocalized, ProgressBar progress) {
         super(helper, "mekanism:gui/GuiBasicMachine.png", name, unlocalized, progress, 28, 16, 144, 54);
@@ -41,12 +40,10 @@ public class MachineRecipeCategory extends BaseRecipeCategory {
     }
 
     @Override
-    public void setRecipe(IRecipeLayout recipeLayout, IRecipeWrapper recipeWrapper, IIngredients ingredients) {
-        if (recipeWrapper instanceof MachineRecipeWrapper) {
-            IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
-            itemStacks.init(0, true, 27, 0);
-            itemStacks.init(1, false, 87, 18);
-            itemStacks.set(ingredients);
-        }
+    public void setRecipe(IRecipeLayout recipeLayout, WRAPPER recipeWrapper, IIngredients ingredients) {
+        IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
+        itemStacks.init(0, true, 27, 0);
+        itemStacks.init(1, false, 87, 18);
+        itemStacks.set(ingredients);
     }
 }

--- a/src/main/java/mekanism/client/jei/machine/MachineRecipeWrapper.java
+++ b/src/main/java/mekanism/client/jei/machine/MachineRecipeWrapper.java
@@ -1,27 +1,18 @@
 package mekanism.client.jei.machine;
 
-import mekanism.common.recipe.inputs.ItemStackInput;
 import mekanism.common.recipe.machines.BasicMachineRecipe;
-import mekanism.common.recipe.outputs.ItemStackOutput;
 import mezz.jei.api.ingredients.IIngredients;
 import mezz.jei.api.ingredients.VanillaTypes;
-import mezz.jei.api.recipe.IRecipeWrapper;
 
-public class MachineRecipeWrapper implements IRecipeWrapper {
+public class MachineRecipeWrapper<RECIPE extends BasicMachineRecipe<RECIPE>> extends MekanismRecipeWrapper<RECIPE> {
 
-    private final BasicMachineRecipe recipe;
-
-    public MachineRecipeWrapper(BasicMachineRecipe r) {
-        recipe = r;
+    public MachineRecipeWrapper(RECIPE recipe) {
+        super(recipe);
     }
 
     @Override
     public void getIngredients(IIngredients ingredients) {
-        ingredients.setInput(VanillaTypes.ITEM, ((ItemStackInput) recipe.getInput()).ingredient);
-        ingredients.setOutput(VanillaTypes.ITEM, ((ItemStackOutput) recipe.getOutput()).output);
-    }
-
-    public BasicMachineRecipe getRecipe() {
-        return recipe;
+        ingredients.setInput(VanillaTypes.ITEM, recipe.getInput().ingredient);
+        ingredients.setOutput(VanillaTypes.ITEM, recipe.getOutput().output);
     }
 }

--- a/src/main/java/mekanism/client/jei/machine/MekanismRecipeWrapper.java
+++ b/src/main/java/mekanism/client/jei/machine/MekanismRecipeWrapper.java
@@ -1,0 +1,17 @@
+package mekanism.client.jei.machine;
+
+import mekanism.common.recipe.machines.MachineRecipe;
+import mezz.jei.api.recipe.IRecipeWrapper;
+
+public abstract class MekanismRecipeWrapper<RECIPE extends MachineRecipe> implements IRecipeWrapper {
+
+    protected final RECIPE recipe;
+
+    protected MekanismRecipeWrapper(RECIPE recipe) {
+        this.recipe = recipe;
+    }
+
+    public RECIPE getRecipe() {
+        return recipe;
+    }
+}

--- a/src/main/java/mekanism/client/jei/machine/chemical/ChemicalCrystallizerRecipeCategory.java
+++ b/src/main/java/mekanism/client/jei/machine/chemical/ChemicalCrystallizerRecipeCategory.java
@@ -10,10 +10,9 @@ import mezz.jei.api.gui.IGuiIngredientGroup;
 import mezz.jei.api.gui.IGuiItemStackGroup;
 import mezz.jei.api.gui.IRecipeLayout;
 import mezz.jei.api.ingredients.IIngredients;
-import mezz.jei.api.recipe.IRecipeWrapper;
 import net.minecraft.client.Minecraft;
 
-public class ChemicalCrystallizerRecipeCategory extends BaseRecipeCategory {
+public class ChemicalCrystallizerRecipeCategory<WRAPPER extends ChemicalCrystallizerRecipeWrapper<CrystallizerRecipe>> extends BaseRecipeCategory<WRAPPER> {
 
     public ChemicalCrystallizerRecipeCategory(IGuiHelper helper) {
         super(helper, "mekanism:gui/nei/GuiChemicalCrystallizer.png", Recipe.CHEMICAL_CRYSTALLIZER.getJEICategory(),
@@ -27,14 +26,12 @@ public class ChemicalCrystallizerRecipeCategory extends BaseRecipeCategory {
     }
 
     @Override
-    public void setRecipe(IRecipeLayout recipeLayout, IRecipeWrapper recipeWrapper, IIngredients ingredients) {
-        if (recipeWrapper instanceof ChemicalCrystallizerRecipeWrapper) {
-            CrystallizerRecipe tempRecipe = ((ChemicalCrystallizerRecipeWrapper) recipeWrapper).getRecipe();
-            IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
-            itemStacks.init(0, false, 130 - xOffset, 56 - yOffset);
-            itemStacks.set(0, tempRecipe.getOutput().output);
-            IGuiIngredientGroup<GasStack> gasStacks = recipeLayout.getIngredientsGroup(MekanismJEI.TYPE_GAS);
-            initGas(gasStacks, 0, true, 6 - xOffset, 5 - yOffset, 16, 58, tempRecipe.getInput().ingredient, true);
-        }
+    public void setRecipe(IRecipeLayout recipeLayout, WRAPPER recipeWrapper, IIngredients ingredients) {
+        CrystallizerRecipe tempRecipe = recipeWrapper.getRecipe();
+        IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
+        itemStacks.init(0, false, 130 - xOffset, 56 - yOffset);
+        itemStacks.set(0, tempRecipe.getOutput().output);
+        IGuiIngredientGroup<GasStack> gasStacks = recipeLayout.getIngredientsGroup(MekanismJEI.TYPE_GAS);
+        initGas(gasStacks, 0, true, 6 - xOffset, 5 - yOffset, 16, 58, tempRecipe.getInput().ingredient, true);
     }
 }

--- a/src/main/java/mekanism/client/jei/machine/chemical/ChemicalCrystallizerRecipeWrapper.java
+++ b/src/main/java/mekanism/client/jei/machine/chemical/ChemicalCrystallizerRecipeWrapper.java
@@ -1,26 +1,20 @@
 package mekanism.client.jei.machine.chemical;
 
 import mekanism.client.jei.MekanismJEI;
+import mekanism.client.jei.machine.MekanismRecipeWrapper;
 import mekanism.common.recipe.machines.CrystallizerRecipe;
 import mezz.jei.api.ingredients.IIngredients;
 import mezz.jei.api.ingredients.VanillaTypes;
-import mezz.jei.api.recipe.IRecipeWrapper;
 
-public class ChemicalCrystallizerRecipeWrapper implements IRecipeWrapper {
+public class ChemicalCrystallizerRecipeWrapper<RECIPE extends CrystallizerRecipe> extends MekanismRecipeWrapper<RECIPE> {
 
-    private final CrystallizerRecipe recipe;
-
-    public ChemicalCrystallizerRecipeWrapper(CrystallizerRecipe r) {
-        recipe = r;
+    public ChemicalCrystallizerRecipeWrapper(RECIPE recipe) {
+        super(recipe);
     }
 
     @Override
     public void getIngredients(IIngredients ingredients) {
         ingredients.setInput(MekanismJEI.TYPE_GAS, recipe.recipeInput.ingredient);
         ingredients.setOutput(VanillaTypes.ITEM, recipe.recipeOutput.output);
-    }
-
-    public CrystallizerRecipe getRecipe() {
-        return recipe;
     }
 }

--- a/src/main/java/mekanism/client/jei/machine/chemical/ChemicalDissolutionChamberRecipeCategory.java
+++ b/src/main/java/mekanism/client/jei/machine/chemical/ChemicalDissolutionChamberRecipeCategory.java
@@ -12,10 +12,9 @@ import mezz.jei.api.gui.IGuiIngredientGroup;
 import mezz.jei.api.gui.IGuiItemStackGroup;
 import mezz.jei.api.gui.IRecipeLayout;
 import mezz.jei.api.ingredients.IIngredients;
-import mezz.jei.api.recipe.IRecipeWrapper;
 import net.minecraft.client.Minecraft;
 
-public class ChemicalDissolutionChamberRecipeCategory extends BaseRecipeCategory {
+public class ChemicalDissolutionChamberRecipeCategory<WRAPPER extends ChemicalDissolutionChamberRecipeWrapper<DissolutionRecipe>> extends BaseRecipeCategory<WRAPPER> {
 
     public ChemicalDissolutionChamberRecipeCategory(IGuiHelper helper) {
         super(helper, "mekanism:gui/nei/GuiChemicalDissolutionChamber.png",
@@ -29,17 +28,15 @@ public class ChemicalDissolutionChamberRecipeCategory extends BaseRecipeCategory
     }
 
     @Override
-    public void setRecipe(IRecipeLayout recipeLayout, IRecipeWrapper recipeWrapper, IIngredients ingredients) {
-        if (recipeWrapper instanceof ChemicalDissolutionChamberRecipeWrapper) {
-            DissolutionRecipe tempRecipe = ((ChemicalDissolutionChamberRecipeWrapper) recipeWrapper).getRecipe();
-            IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
-            itemStacks.init(0, true, 25 - xOffset, 35 - yOffset);
-            itemStacks.set(0, tempRecipe.getInput().ingredient);
-            IGuiIngredientGroup<GasStack> gasStacks = recipeLayout.getIngredientsGroup(MekanismJEI.TYPE_GAS);
-            initGas(gasStacks, 0, true, 6 - xOffset, 5 - yOffset, 16, 58,
-                  new GasStack(MekanismFluids.SulfuricAcid, TileEntityChemicalDissolutionChamber.BASE_INJECT_USAGE * TileEntityChemicalDissolutionChamber.BASE_TICKS_REQUIRED),
-                  true);
-            initGas(gasStacks, 1, false, 134 - xOffset, 14 - yOffset, 16, 58, tempRecipe.getOutput().output, true);
-        }
+    public void setRecipe(IRecipeLayout recipeLayout, WRAPPER recipeWrapper, IIngredients ingredients) {
+        DissolutionRecipe tempRecipe = recipeWrapper.getRecipe();
+        IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
+        itemStacks.init(0, true, 25 - xOffset, 35 - yOffset);
+        itemStacks.set(0, tempRecipe.getInput().ingredient);
+        IGuiIngredientGroup<GasStack> gasStacks = recipeLayout.getIngredientsGroup(MekanismJEI.TYPE_GAS);
+        initGas(gasStacks, 0, true, 6 - xOffset, 5 - yOffset, 16, 58,
+              new GasStack(MekanismFluids.SulfuricAcid, TileEntityChemicalDissolutionChamber.BASE_INJECT_USAGE * TileEntityChemicalDissolutionChamber.BASE_TICKS_REQUIRED),
+              true);
+        initGas(gasStacks, 1, false, 134 - xOffset, 14 - yOffset, 16, 58, tempRecipe.getOutput().output, true);
     }
 }

--- a/src/main/java/mekanism/client/jei/machine/chemical/ChemicalDissolutionChamberRecipeWrapper.java
+++ b/src/main/java/mekanism/client/jei/machine/chemical/ChemicalDissolutionChamberRecipeWrapper.java
@@ -2,19 +2,17 @@ package mekanism.client.jei.machine.chemical;
 
 import mekanism.api.gas.GasStack;
 import mekanism.client.jei.MekanismJEI;
+import mekanism.client.jei.machine.MekanismRecipeWrapper;
 import mekanism.common.MekanismFluids;
 import mekanism.common.recipe.machines.DissolutionRecipe;
 import mekanism.common.tile.TileEntityChemicalDissolutionChamber;
 import mezz.jei.api.ingredients.IIngredients;
 import mezz.jei.api.ingredients.VanillaTypes;
-import mezz.jei.api.recipe.IRecipeWrapper;
 
-public class ChemicalDissolutionChamberRecipeWrapper implements IRecipeWrapper {
+public class ChemicalDissolutionChamberRecipeWrapper<RECIPE extends DissolutionRecipe> extends MekanismRecipeWrapper<RECIPE> {
 
-    private final DissolutionRecipe recipe;
-
-    public ChemicalDissolutionChamberRecipeWrapper(DissolutionRecipe r) {
-        recipe = r;
+    public ChemicalDissolutionChamberRecipeWrapper(RECIPE recipe) {
+        super(recipe);
     }
 
     @Override
@@ -22,9 +20,5 @@ public class ChemicalDissolutionChamberRecipeWrapper implements IRecipeWrapper {
         ingredients.setInput(MekanismJEI.TYPE_GAS, new GasStack(MekanismFluids.SulfuricAcid, TileEntityChemicalDissolutionChamber.BASE_INJECT_USAGE * TileEntityChemicalDissolutionChamber.BASE_TICKS_REQUIRED));
         ingredients.setInput(VanillaTypes.ITEM, recipe.recipeInput.ingredient);
         ingredients.setOutput(MekanismJEI.TYPE_GAS, recipe.recipeOutput.output);
-    }
-
-    public DissolutionRecipe getRecipe() {
-        return recipe;
     }
 }

--- a/src/main/java/mekanism/client/jei/machine/chemical/ChemicalInfuserRecipeCategory.java
+++ b/src/main/java/mekanism/client/jei/machine/chemical/ChemicalInfuserRecipeCategory.java
@@ -9,10 +9,9 @@ import mezz.jei.api.IGuiHelper;
 import mezz.jei.api.gui.IGuiIngredientGroup;
 import mezz.jei.api.gui.IRecipeLayout;
 import mezz.jei.api.ingredients.IIngredients;
-import mezz.jei.api.recipe.IRecipeWrapper;
 import net.minecraft.client.Minecraft;
 
-public class ChemicalInfuserRecipeCategory extends BaseRecipeCategory {
+public class ChemicalInfuserRecipeCategory<WRAPPER extends ChemicalInfuserRecipeWrapper<ChemicalInfuserRecipe>> extends BaseRecipeCategory<WRAPPER> {
 
     public ChemicalInfuserRecipeCategory(IGuiHelper helper) {
         super(helper, "mekanism:gui/nei/GuiChemicalInfuser.png", Recipe.CHEMICAL_INFUSER.getJEICategory(),
@@ -27,13 +26,11 @@ public class ChemicalInfuserRecipeCategory extends BaseRecipeCategory {
     }
 
     @Override
-    public void setRecipe(IRecipeLayout recipeLayout, IRecipeWrapper recipeWrapper, IIngredients ingredients) {
-        if (recipeWrapper instanceof ChemicalInfuserRecipeWrapper) {
-            ChemicalInfuserRecipe tempRecipe = ((ChemicalInfuserRecipeWrapper) recipeWrapper).getRecipe();
-            IGuiIngredientGroup<GasStack> gasStacks = recipeLayout.getIngredientsGroup(MekanismJEI.TYPE_GAS);
-            initGas(gasStacks, 0, true, 26 - xOffset, 14 - yOffset, 16, 58, tempRecipe.getInput().leftGas, true);
-            initGas(gasStacks, 1, true, 134 - xOffset, 14 - yOffset, 16, 58, tempRecipe.getInput().rightGas, true);
-            initGas(gasStacks, 2, false, 80 - xOffset, 5 - yOffset, 16, 58, tempRecipe.getOutput().output, true);
-        }
+    public void setRecipe(IRecipeLayout recipeLayout, WRAPPER recipeWrapper, IIngredients ingredients) {
+        ChemicalInfuserRecipe tempRecipe = recipeWrapper.getRecipe();
+        IGuiIngredientGroup<GasStack> gasStacks = recipeLayout.getIngredientsGroup(MekanismJEI.TYPE_GAS);
+        initGas(gasStacks, 0, true, 26 - xOffset, 14 - yOffset, 16, 58, tempRecipe.getInput().leftGas, true);
+        initGas(gasStacks, 1, true, 134 - xOffset, 14 - yOffset, 16, 58, tempRecipe.getInput().rightGas, true);
+        initGas(gasStacks, 2, false, 80 - xOffset, 5 - yOffset, 16, 58, tempRecipe.getOutput().output, true);
     }
 }

--- a/src/main/java/mekanism/client/jei/machine/chemical/ChemicalInfuserRecipeWrapper.java
+++ b/src/main/java/mekanism/client/jei/machine/chemical/ChemicalInfuserRecipeWrapper.java
@@ -2,25 +2,19 @@ package mekanism.client.jei.machine.chemical;
 
 import java.util.Arrays;
 import mekanism.client.jei.MekanismJEI;
+import mekanism.client.jei.machine.MekanismRecipeWrapper;
 import mekanism.common.recipe.machines.ChemicalInfuserRecipe;
 import mezz.jei.api.ingredients.IIngredients;
-import mezz.jei.api.recipe.IRecipeWrapper;
 
-public class ChemicalInfuserRecipeWrapper implements IRecipeWrapper {
+public class ChemicalInfuserRecipeWrapper<RECIPE extends ChemicalInfuserRecipe> extends MekanismRecipeWrapper<RECIPE> {
 
-    private final ChemicalInfuserRecipe recipe;
-
-    public ChemicalInfuserRecipeWrapper(ChemicalInfuserRecipe r) {
-        recipe = r;
+    public ChemicalInfuserRecipeWrapper(RECIPE recipe) {
+        super(recipe);
     }
 
     @Override
     public void getIngredients(IIngredients ingredients) {
         ingredients.setInputs(MekanismJEI.TYPE_GAS, Arrays.asList(recipe.recipeInput.leftGas, recipe.recipeInput.rightGas));
         ingredients.setOutput(MekanismJEI.TYPE_GAS, recipe.recipeOutput.output);
-    }
-
-    public ChemicalInfuserRecipe getRecipe() {
-        return recipe;
     }
 }

--- a/src/main/java/mekanism/client/jei/machine/chemical/ChemicalOxidizerRecipeCategory.java
+++ b/src/main/java/mekanism/client/jei/machine/chemical/ChemicalOxidizerRecipeCategory.java
@@ -17,9 +17,8 @@ import mezz.jei.api.gui.IGuiIngredientGroup;
 import mezz.jei.api.gui.IGuiItemStackGroup;
 import mezz.jei.api.gui.IRecipeLayout;
 import mezz.jei.api.ingredients.IIngredients;
-import mezz.jei.api.recipe.IRecipeWrapper;
 
-public class ChemicalOxidizerRecipeCategory extends BaseRecipeCategory {
+public class ChemicalOxidizerRecipeCategory<WRAPPER extends ChemicalOxidizerRecipeWrapper<OxidationRecipe>> extends BaseRecipeCategory<WRAPPER> {
 
     public ChemicalOxidizerRecipeCategory(IGuiHelper helper) {
         super(helper, "mekanism:gui/GuiChemicalOxidizer.png", Recipe.CHEMICAL_OXIDIZER.getJEICategory(),
@@ -39,14 +38,12 @@ public class ChemicalOxidizerRecipeCategory extends BaseRecipeCategory {
     }
 
     @Override
-    public void setRecipe(IRecipeLayout recipeLayout, IRecipeWrapper recipeWrapper, IIngredients ingredients) {
-        if (recipeWrapper instanceof ChemicalOxidizerRecipeWrapper) {
-            OxidationRecipe tempRecipe = ((ChemicalOxidizerRecipeWrapper) recipeWrapper).getRecipe();
-            IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
-            itemStacks.init(0, true, 25 - xOffset, 35 - yOffset);
-            itemStacks.set(0, tempRecipe.getInput().ingredient);
-            IGuiIngredientGroup<GasStack> gasStacks = recipeLayout.getIngredientsGroup(MekanismJEI.TYPE_GAS);
-            initGas(gasStacks, 0, false, 134 - xOffset, 14 - yOffset, 16, 58, tempRecipe.recipeOutput.output, true);
-        }
+    public void setRecipe(IRecipeLayout recipeLayout, WRAPPER recipeWrapper, IIngredients ingredients) {
+        OxidationRecipe tempRecipe = recipeWrapper.getRecipe();
+        IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
+        itemStacks.init(0, true, 25 - xOffset, 35 - yOffset);
+        itemStacks.set(0, tempRecipe.getInput().ingredient);
+        IGuiIngredientGroup<GasStack> gasStacks = recipeLayout.getIngredientsGroup(MekanismJEI.TYPE_GAS);
+        initGas(gasStacks, 0, false, 134 - xOffset, 14 - yOffset, 16, 58, tempRecipe.recipeOutput.output, true);
     }
 }

--- a/src/main/java/mekanism/client/jei/machine/chemical/ChemicalOxidizerRecipeWrapper.java
+++ b/src/main/java/mekanism/client/jei/machine/chemical/ChemicalOxidizerRecipeWrapper.java
@@ -1,26 +1,20 @@
 package mekanism.client.jei.machine.chemical;
 
 import mekanism.client.jei.MekanismJEI;
+import mekanism.client.jei.machine.MekanismRecipeWrapper;
 import mekanism.common.recipe.machines.OxidationRecipe;
 import mezz.jei.api.ingredients.IIngredients;
 import mezz.jei.api.ingredients.VanillaTypes;
-import mezz.jei.api.recipe.IRecipeWrapper;
 
-public class ChemicalOxidizerRecipeWrapper implements IRecipeWrapper {
+public class ChemicalOxidizerRecipeWrapper<RECIPE extends OxidationRecipe> extends MekanismRecipeWrapper<RECIPE> {
 
-    private final OxidationRecipe recipe;
-
-    public ChemicalOxidizerRecipeWrapper(OxidationRecipe r) {
-        recipe = r;
+    public ChemicalOxidizerRecipeWrapper(RECIPE recipe) {
+        super(recipe);
     }
 
     @Override
     public void getIngredients(IIngredients ingredients) {
         ingredients.setInput(VanillaTypes.ITEM, recipe.recipeInput.ingredient);
         ingredients.setOutput(MekanismJEI.TYPE_GAS, recipe.recipeOutput.output);
-    }
-
-    public OxidationRecipe getRecipe() {
-        return recipe;
     }
 }

--- a/src/main/java/mekanism/client/jei/machine/chemical/ChemicalWasherRecipeCategory.java
+++ b/src/main/java/mekanism/client/jei/machine/chemical/ChemicalWasherRecipeCategory.java
@@ -12,10 +12,9 @@ import mezz.jei.api.gui.IGuiIngredientGroup;
 import mezz.jei.api.gui.IRecipeLayout;
 import mezz.jei.api.ingredients.IIngredients;
 import mezz.jei.api.ingredients.VanillaTypes;
-import mezz.jei.api.recipe.IRecipeWrapper;
 import net.minecraft.client.Minecraft;
 
-public class ChemicalWasherRecipeCategory extends BaseRecipeCategory {
+public class ChemicalWasherRecipeCategory<WRAPPER extends ChemicalWasherRecipeWrapper<WasherRecipe>> extends BaseRecipeCategory<WRAPPER> {
 
     public ChemicalWasherRecipeCategory(IGuiHelper helper) {
         super(helper, "mekanism:gui/nei/GuiChemicalWasher.png", Recipe.CHEMICAL_WASHER.getJEICategory(),
@@ -29,16 +28,14 @@ public class ChemicalWasherRecipeCategory extends BaseRecipeCategory {
     }
 
     @Override
-    public void setRecipe(IRecipeLayout recipeLayout, IRecipeWrapper recipeWrapper, IIngredients ingredients) {
-        if (recipeWrapper instanceof ChemicalWasherRecipeWrapper) {
-            WasherRecipe tempRecipe = ((ChemicalWasherRecipeWrapper) recipeWrapper).getRecipe();
-            IGuiFluidStackGroup fluidStacks = recipeLayout.getFluidStacks();
-            fluidStacks.init(0, true, 6 - xOffset, 5 - yOffset, 16, 58, TileEntityChemicalWasher.WATER_USAGE, false,
-                  fluidOverlayLarge);
-            fluidStacks.set(0, ingredients.getInputs(VanillaTypes.FLUID).get(0));
-            IGuiIngredientGroup<GasStack> gasStacks = recipeLayout.getIngredientsGroup(MekanismJEI.TYPE_GAS);
-            initGas(gasStacks, 0, true, 27 - xOffset, 14 - yOffset, 16, 58, tempRecipe.getInput().ingredient, true);
-            initGas(gasStacks, 1, false, 134 - xOffset, 14 - yOffset, 16, 58, tempRecipe.getOutput().output, true);
-        }
+    public void setRecipe(IRecipeLayout recipeLayout, WRAPPER recipeWrapper, IIngredients ingredients) {
+        WasherRecipe tempRecipe = recipeWrapper.getRecipe();
+        IGuiFluidStackGroup fluidStacks = recipeLayout.getFluidStacks();
+        fluidStacks.init(0, true, 6 - xOffset, 5 - yOffset, 16, 58, TileEntityChemicalWasher.WATER_USAGE, false,
+              fluidOverlayLarge);
+        fluidStacks.set(0, ingredients.getInputs(VanillaTypes.FLUID).get(0));
+        IGuiIngredientGroup<GasStack> gasStacks = recipeLayout.getIngredientsGroup(MekanismJEI.TYPE_GAS);
+        initGas(gasStacks, 0, true, 27 - xOffset, 14 - yOffset, 16, 58, tempRecipe.getInput().ingredient, true);
+        initGas(gasStacks, 1, false, 134 - xOffset, 14 - yOffset, 16, 58, tempRecipe.getOutput().output, true);
     }
 }

--- a/src/main/java/mekanism/client/jei/machine/chemical/ChemicalWasherRecipeWrapper.java
+++ b/src/main/java/mekanism/client/jei/machine/chemical/ChemicalWasherRecipeWrapper.java
@@ -1,20 +1,18 @@
 package mekanism.client.jei.machine.chemical;
 
 import mekanism.client.jei.MekanismJEI;
+import mekanism.client.jei.machine.MekanismRecipeWrapper;
 import mekanism.common.recipe.machines.WasherRecipe;
 import mekanism.common.tile.TileEntityChemicalWasher;
 import mezz.jei.api.ingredients.IIngredients;
 import mezz.jei.api.ingredients.VanillaTypes;
-import mezz.jei.api.recipe.IRecipeWrapper;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 
-public class ChemicalWasherRecipeWrapper implements IRecipeWrapper {
+public class ChemicalWasherRecipeWrapper<RECIPE extends WasherRecipe> extends MekanismRecipeWrapper<RECIPE> {
 
-    private final WasherRecipe recipe;
-
-    public ChemicalWasherRecipeWrapper(WasherRecipe r) {
-        recipe = r;
+    public ChemicalWasherRecipeWrapper(RECIPE recipe) {
+        super(recipe);
     }
 
     @Override
@@ -22,9 +20,5 @@ public class ChemicalWasherRecipeWrapper implements IRecipeWrapper {
         ingredients.setInput(VanillaTypes.FLUID, new FluidStack(FluidRegistry.WATER, TileEntityChemicalWasher.WATER_USAGE));
         ingredients.setInput(MekanismJEI.TYPE_GAS, recipe.recipeInput.ingredient);
         ingredients.setOutput(MekanismJEI.TYPE_GAS, recipe.recipeOutput.output);
-    }
-
-    public WasherRecipe getRecipe() {
-        return recipe;
     }
 }

--- a/src/main/java/mekanism/client/jei/machine/other/ElectrolyticSeparatorRecipeCategory.java
+++ b/src/main/java/mekanism/client/jei/machine/other/ElectrolyticSeparatorRecipeCategory.java
@@ -22,9 +22,8 @@ import mezz.jei.api.gui.IGuiIngredientGroup;
 import mezz.jei.api.gui.IRecipeLayout;
 import mezz.jei.api.ingredients.IIngredients;
 import mezz.jei.api.ingredients.VanillaTypes;
-import mezz.jei.api.recipe.IRecipeWrapper;
 
-public class ElectrolyticSeparatorRecipeCategory extends BaseRecipeCategory {
+public class ElectrolyticSeparatorRecipeCategory<WRAPPER extends ElectrolyticSeparatorRecipeWrapper<SeparatorRecipe>> extends BaseRecipeCategory<WRAPPER> {
 
     public ElectrolyticSeparatorRecipeCategory(IGuiHelper helper) {
         super(helper, "mekanism:gui/GuiElectrolyticSeparator.png", Recipe.ELECTROLYTIC_SEPARATOR.getJEICategory(),
@@ -55,15 +54,13 @@ public class ElectrolyticSeparatorRecipeCategory extends BaseRecipeCategory {
     }
 
     @Override
-    public void setRecipe(IRecipeLayout recipeLayout, IRecipeWrapper recipeWrapper, IIngredients ingredients) {
-        if (recipeWrapper instanceof ElectrolyticSeparatorRecipeWrapper) {
-            SeparatorRecipe tempRecipe = ((ElectrolyticSeparatorRecipeWrapper) recipeWrapper).getRecipe();
-            IGuiFluidStackGroup fluidStacks = recipeLayout.getFluidStacks();
-            fluidStacks.init(0, true, 2, 2, 16, 58, tempRecipe.getInput().ingredient.amount, false, fluidOverlayLarge);
-            fluidStacks.set(0, ingredients.getInputs(VanillaTypes.FLUID).get(0));
-            IGuiIngredientGroup<GasStack> gasStacks = recipeLayout.getIngredientsGroup(MekanismJEI.TYPE_GAS);
-            initGas(gasStacks, 0, false, 59 - xOffset, 19 - yOffset, 16, 28, tempRecipe.recipeOutput.leftGas, true);
-            initGas(gasStacks, 1, false, 101 - xOffset, 19 - yOffset, 16, 28, tempRecipe.recipeOutput.rightGas, true);
-        }
+    public void setRecipe(IRecipeLayout recipeLayout, WRAPPER recipeWrapper, IIngredients ingredients) {
+        SeparatorRecipe tempRecipe = recipeWrapper.getRecipe();
+        IGuiFluidStackGroup fluidStacks = recipeLayout.getFluidStacks();
+        fluidStacks.init(0, true, 2, 2, 16, 58, tempRecipe.getInput().ingredient.amount, false, fluidOverlayLarge);
+        fluidStacks.set(0, ingredients.getInputs(VanillaTypes.FLUID).get(0));
+        IGuiIngredientGroup<GasStack> gasStacks = recipeLayout.getIngredientsGroup(MekanismJEI.TYPE_GAS);
+        initGas(gasStacks, 0, false, 59 - xOffset, 19 - yOffset, 16, 28, tempRecipe.recipeOutput.leftGas, true);
+        initGas(gasStacks, 1, false, 101 - xOffset, 19 - yOffset, 16, 28, tempRecipe.recipeOutput.rightGas, true);
     }
 }

--- a/src/main/java/mekanism/client/jei/machine/other/ElectrolyticSeparatorRecipeWrapper.java
+++ b/src/main/java/mekanism/client/jei/machine/other/ElectrolyticSeparatorRecipeWrapper.java
@@ -2,26 +2,20 @@ package mekanism.client.jei.machine.other;
 
 import java.util.Arrays;
 import mekanism.client.jei.MekanismJEI;
+import mekanism.client.jei.machine.MekanismRecipeWrapper;
 import mekanism.common.recipe.machines.SeparatorRecipe;
 import mezz.jei.api.ingredients.IIngredients;
 import mezz.jei.api.ingredients.VanillaTypes;
-import mezz.jei.api.recipe.IRecipeWrapper;
 
-public class ElectrolyticSeparatorRecipeWrapper implements IRecipeWrapper {
+public class ElectrolyticSeparatorRecipeWrapper<RECIPE extends SeparatorRecipe> extends MekanismRecipeWrapper<RECIPE> {
 
-    private final SeparatorRecipe recipe;
-
-    public ElectrolyticSeparatorRecipeWrapper(SeparatorRecipe r) {
-        recipe = r;
+    public ElectrolyticSeparatorRecipeWrapper(RECIPE recipe) {
+        super(recipe);
     }
 
     @Override
     public void getIngredients(IIngredients ingredients) {
         ingredients.setInput(VanillaTypes.FLUID, recipe.recipeInput.ingredient);
         ingredients.setOutputs(MekanismJEI.TYPE_GAS, Arrays.asList(recipe.recipeOutput.leftGas, recipe.recipeOutput.rightGas));
-    }
-
-    public SeparatorRecipe getRecipe() {
-        return recipe;
     }
 }

--- a/src/main/java/mekanism/client/jei/machine/other/MetallurgicInfuserRecipeCategory.java
+++ b/src/main/java/mekanism/client/jei/machine/other/MetallurgicInfuserRecipeCategory.java
@@ -20,10 +20,9 @@ import mezz.jei.api.IGuiHelper;
 import mezz.jei.api.gui.IGuiItemStackGroup;
 import mezz.jei.api.gui.IRecipeLayout;
 import mezz.jei.api.ingredients.IIngredients;
-import mezz.jei.api.recipe.IRecipeWrapper;
 import net.minecraft.item.ItemStack;
 
-public class MetallurgicInfuserRecipeCategory extends BaseRecipeCategory {
+public class MetallurgicInfuserRecipeCategory<WRAPPER extends MetallurgicInfuserRecipeWrapper<MetallurgicInfuserRecipe>> extends BaseRecipeCategory<WRAPPER> {
 
     public MetallurgicInfuserRecipeCategory(IGuiHelper helper) {
         super(helper, "mekanism:gui/GuiMetallurgicInfuser.png", Recipe.METALLURGIC_INFUSER.getJEICategory(),
@@ -55,16 +54,14 @@ public class MetallurgicInfuserRecipeCategory extends BaseRecipeCategory {
     }
 
     @Override
-    public void setRecipe(IRecipeLayout recipeLayout, IRecipeWrapper recipeWrapper, IIngredients ingredients) {
-        if (recipeWrapper instanceof MetallurgicInfuserRecipeWrapper) {
-            MetallurgicInfuserRecipe tempRecipe = ((MetallurgicInfuserRecipeWrapper) recipeWrapper).getRecipe();
-            IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
-            itemStacks.init(0, true, 45, 26);
-            itemStacks.init(1, false, 103, 26);
-            itemStacks.init(2, true, 11, 18);
-            itemStacks.set(0, tempRecipe.getInput().inputStack);
-            itemStacks.set(1, tempRecipe.getOutput().output);
-            itemStacks.set(2, getInfuseStacks(tempRecipe.getInput().infuse.getType()));
-        }
+    public void setRecipe(IRecipeLayout recipeLayout, WRAPPER recipeWrapper, IIngredients ingredients) {
+        MetallurgicInfuserRecipe tempRecipe = recipeWrapper.getRecipe();
+        IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
+        itemStacks.init(0, true, 45, 26);
+        itemStacks.init(1, false, 103, 26);
+        itemStacks.init(2, true, 11, 18);
+        itemStacks.set(0, tempRecipe.getInput().inputStack);
+        itemStacks.set(1, tempRecipe.getOutput().output);
+        itemStacks.set(2, getInfuseStacks(tempRecipe.getInput().infuse.getType()));
     }
 }

--- a/src/main/java/mekanism/client/jei/machine/other/MetallurgicInfuserRecipeWrapper.java
+++ b/src/main/java/mekanism/client/jei/machine/other/MetallurgicInfuserRecipeWrapper.java
@@ -3,21 +3,19 @@ package mekanism.client.jei.machine.other;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import mekanism.client.jei.machine.MekanismRecipeWrapper;
 import mekanism.client.render.MekanismRenderer;
 import mekanism.common.InfuseStorage;
 import mekanism.common.recipe.machines.MetallurgicInfuserRecipe;
 import mezz.jei.api.ingredients.IIngredients;
 import mezz.jei.api.ingredients.VanillaTypes;
-import mezz.jei.api.recipe.IRecipeWrapper;
 import net.minecraft.client.Minecraft;
 import net.minecraft.item.ItemStack;
 
-public class MetallurgicInfuserRecipeWrapper implements IRecipeWrapper {
+public class MetallurgicInfuserRecipeWrapper<RECIPE extends MetallurgicInfuserRecipe> extends MekanismRecipeWrapper<RECIPE> {
 
-    private final MetallurgicInfuserRecipe recipe;
-
-    public MetallurgicInfuserRecipeWrapper(MetallurgicInfuserRecipe r) {
-        recipe = r;
+    public MetallurgicInfuserRecipeWrapper(RECIPE recipe) {
+        super(recipe);
     }
 
     @Override
@@ -27,10 +25,6 @@ public class MetallurgicInfuserRecipeWrapper implements IRecipeWrapper {
         ingredients.setInput(VanillaTypes.ITEM, recipe.recipeInput.inputStack);
         ingredients.setInputLists(VanillaTypes.ITEM, Arrays.asList(inputStacks, infuseStacks));
         ingredients.setOutput(VanillaTypes.ITEM, recipe.recipeOutput.output);
-    }
-
-    public MetallurgicInfuserRecipe getRecipe() {
-        return recipe;
     }
 
     @Override

--- a/src/main/java/mekanism/client/jei/machine/other/PRCRecipeCategory.java
+++ b/src/main/java/mekanism/client/jei/machine/other/PRCRecipeCategory.java
@@ -22,9 +22,8 @@ import mezz.jei.api.gui.IGuiIngredientGroup;
 import mezz.jei.api.gui.IGuiItemStackGroup;
 import mezz.jei.api.gui.IRecipeLayout;
 import mezz.jei.api.ingredients.IIngredients;
-import mezz.jei.api.recipe.IRecipeWrapper;
 
-public class PRCRecipeCategory extends BaseRecipeCategory {
+public class PRCRecipeCategory<WRAPPER extends PRCRecipeWrapper<PressurizedRecipe>> extends BaseRecipeCategory<WRAPPER> {
 
     public PRCRecipeCategory(IGuiHelper helper) {
         super(helper, "mekanism:gui/nei/GuiPRC.png", Recipe.PRESSURIZED_REACTION_CHAMBER.getJEICategory(),
@@ -54,20 +53,18 @@ public class PRCRecipeCategory extends BaseRecipeCategory {
     }
 
     @Override
-    public void setRecipe(IRecipeLayout recipeLayout, IRecipeWrapper recipeWrapper, IIngredients ingredients) {
-        if (recipeWrapper instanceof PRCRecipeWrapper) {
-            PressurizedRecipe tempRecipe = ((PRCRecipeWrapper) recipeWrapper).getRecipe();
-            IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
-            itemStacks.init(0, true, 53 - xOffset, 34 - yOffset);
-            itemStacks.init(1, false, 115 - xOffset, 34 - yOffset);
-            itemStacks.set(0, tempRecipe.recipeInput.getSolid());
-            itemStacks.set(1, tempRecipe.recipeOutput.getItemOutput());
-            IGuiFluidStackGroup fluidStacks = recipeLayout.getFluidStacks();
-            fluidStacks.init(0, true, 3, 0, 16, 58, tempRecipe.getInput().getFluid().amount, false, fluidOverlayLarge);
-            fluidStacks.set(0, tempRecipe.recipeInput.getFluid());
-            IGuiIngredientGroup<GasStack> gasStacks = recipeLayout.getIngredientsGroup(MekanismJEI.TYPE_GAS);
-            initGas(gasStacks, 0, true, 29 - xOffset, 11 - yOffset, 16, 58, tempRecipe.recipeInput.getGas(), true);
-            initGas(gasStacks, 1, false, 141 - xOffset, 41 - yOffset, 16, 28, tempRecipe.recipeOutput.getGasOutput(), true);
-        }
+    public void setRecipe(IRecipeLayout recipeLayout, WRAPPER recipeWrapper, IIngredients ingredients) {
+        PressurizedRecipe tempRecipe = recipeWrapper.getRecipe();
+        IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
+        itemStacks.init(0, true, 53 - xOffset, 34 - yOffset);
+        itemStacks.init(1, false, 115 - xOffset, 34 - yOffset);
+        itemStacks.set(0, tempRecipe.recipeInput.getSolid());
+        itemStacks.set(1, tempRecipe.recipeOutput.getItemOutput());
+        IGuiFluidStackGroup fluidStacks = recipeLayout.getFluidStacks();
+        fluidStacks.init(0, true, 3, 0, 16, 58, tempRecipe.getInput().getFluid().amount, false, fluidOverlayLarge);
+        fluidStacks.set(0, tempRecipe.recipeInput.getFluid());
+        IGuiIngredientGroup<GasStack> gasStacks = recipeLayout.getIngredientsGroup(MekanismJEI.TYPE_GAS);
+        initGas(gasStacks, 0, true, 29 - xOffset, 11 - yOffset, 16, 58, tempRecipe.recipeInput.getGas(), true);
+        initGas(gasStacks, 1, false, 141 - xOffset, 41 - yOffset, 16, 28, tempRecipe.recipeOutput.getGasOutput(), true);
     }
 }

--- a/src/main/java/mekanism/client/jei/machine/other/PRCRecipeWrapper.java
+++ b/src/main/java/mekanism/client/jei/machine/other/PRCRecipeWrapper.java
@@ -1,17 +1,15 @@
 package mekanism.client.jei.machine.other;
 
 import mekanism.client.jei.MekanismJEI;
+import mekanism.client.jei.machine.MekanismRecipeWrapper;
 import mekanism.common.recipe.machines.PressurizedRecipe;
 import mezz.jei.api.ingredients.IIngredients;
 import mezz.jei.api.ingredients.VanillaTypes;
-import mezz.jei.api.recipe.IRecipeWrapper;
 
-public class PRCRecipeWrapper implements IRecipeWrapper {
+public class PRCRecipeWrapper<RECIPE extends PressurizedRecipe> extends MekanismRecipeWrapper<RECIPE> {
 
-    private final PressurizedRecipe recipe;
-
-    public PRCRecipeWrapper(PressurizedRecipe r) {
-        recipe = r;
+    public PRCRecipeWrapper(RECIPE recipe) {
+        super(recipe);
     }
 
     @Override
@@ -21,9 +19,5 @@ public class PRCRecipeWrapper implements IRecipeWrapper {
         ingredients.setInput(MekanismJEI.TYPE_GAS, recipe.recipeInput.getGas());
         ingredients.setOutput(VanillaTypes.ITEM, recipe.recipeOutput.getItemOutput());
         ingredients.setOutput(MekanismJEI.TYPE_GAS, recipe.recipeOutput.getGasOutput());
-    }
-
-    public PressurizedRecipe getRecipe() {
-        return recipe;
     }
 }

--- a/src/main/java/mekanism/client/jei/machine/other/RotaryCondensentratorRecipeCategory.java
+++ b/src/main/java/mekanism/client/jei/machine/other/RotaryCondensentratorRecipeCategory.java
@@ -9,10 +9,9 @@ import mezz.jei.api.gui.IGuiIngredientGroup;
 import mezz.jei.api.gui.IRecipeLayout;
 import mezz.jei.api.ingredients.IIngredients;
 import mezz.jei.api.ingredients.VanillaTypes;
-import mezz.jei.api.recipe.IRecipeWrapper;
 import net.minecraft.client.Minecraft;
 
-public class RotaryCondensentratorRecipeCategory extends BaseRecipeCategory {
+public class RotaryCondensentratorRecipeCategory extends BaseRecipeCategory<RotaryCondensentratorRecipeWrapper> {
 
     private final boolean condensentrating;
 
@@ -30,19 +29,16 @@ public class RotaryCondensentratorRecipeCategory extends BaseRecipeCategory {
     }
 
     @Override
-    public void setRecipe(IRecipeLayout recipeLayout, IRecipeWrapper recipeWrapper, IIngredients ingredients) {
-        if (recipeWrapper instanceof RotaryCondensentratorRecipeWrapper) {
-            RotaryCondensentratorRecipeWrapper tempRecipe = (RotaryCondensentratorRecipeWrapper) recipeWrapper;
-            IGuiFluidStackGroup fluidStacks = recipeLayout.getFluidStacks();
-            IGuiIngredientGroup<GasStack> gasStacks = recipeLayout.getIngredientsGroup(MekanismJEI.TYPE_GAS);
-            fluidStacks.init(0, !condensentrating, 134 - xOffset, 14 - yOffset, 16, 58, tempRecipe.FLUID_AMOUNT, false, fluidOverlayLarge);
-            if (condensentrating) {
-                initGas(gasStacks, 0, true, 26 - xOffset, 14 - yOffset, 16, 58, new GasStack(tempRecipe.getGasType(), tempRecipe.GAS_AMOUNT), true);
-                fluidStacks.set(0, ingredients.getOutputs(VanillaTypes.FLUID).get(0));
-            } else {
-                initGas(gasStacks, 0, false, 26 - xOffset, 14 - yOffset, 16, 58, new GasStack(tempRecipe.getGasType(), tempRecipe.GAS_AMOUNT), true);
-                fluidStacks.set(0, ingredients.getInputs(VanillaTypes.FLUID).get(0));
-            }
+    public void setRecipe(IRecipeLayout recipeLayout, RotaryCondensentratorRecipeWrapper recipeWrapper, IIngredients ingredients) {
+        IGuiFluidStackGroup fluidStacks = recipeLayout.getFluidStacks();
+        IGuiIngredientGroup<GasStack> gasStacks = recipeLayout.getIngredientsGroup(MekanismJEI.TYPE_GAS);
+        fluidStacks.init(0, !condensentrating, 134 - xOffset, 14 - yOffset, 16, 58, RotaryCondensentratorRecipeWrapper.FLUID_AMOUNT, false, fluidOverlayLarge);
+        if (condensentrating) {
+            initGas(gasStacks, 0, true, 26 - xOffset, 14 - yOffset, 16, 58, new GasStack(recipeWrapper.getGasType(), RotaryCondensentratorRecipeWrapper.GAS_AMOUNT), true);
+            fluidStacks.set(0, ingredients.getOutputs(VanillaTypes.FLUID).get(0));
+        } else {
+            initGas(gasStacks, 0, false, 26 - xOffset, 14 - yOffset, 16, 58, new GasStack(recipeWrapper.getGasType(), RotaryCondensentratorRecipeWrapper.GAS_AMOUNT), true);
+            fluidStacks.set(0, ingredients.getInputs(VanillaTypes.FLUID).get(0));
         }
     }
 }

--- a/src/main/java/mekanism/client/jei/machine/other/SolarNeutronRecipeCategory.java
+++ b/src/main/java/mekanism/client/jei/machine/other/SolarNeutronRecipeCategory.java
@@ -9,10 +9,9 @@ import mezz.jei.api.IGuiHelper;
 import mezz.jei.api.gui.IGuiIngredientGroup;
 import mezz.jei.api.gui.IRecipeLayout;
 import mezz.jei.api.ingredients.IIngredients;
-import mezz.jei.api.recipe.IRecipeWrapper;
 import net.minecraft.client.Minecraft;
 
-public class SolarNeutronRecipeCategory extends BaseRecipeCategory {
+public class SolarNeutronRecipeCategory<WRAPPER extends SolarNeutronRecipeWrapper<SolarNeutronRecipe>> extends BaseRecipeCategory<WRAPPER> {
 
     public SolarNeutronRecipeCategory(IGuiHelper helper) {
         super(helper, "mekanism:gui/nei/GuiSolarNeutronActivator.png", Recipe.SOLAR_NEUTRON_ACTIVATOR.getJEICategory(),
@@ -26,12 +25,10 @@ public class SolarNeutronRecipeCategory extends BaseRecipeCategory {
     }
 
     @Override
-    public void setRecipe(IRecipeLayout recipeLayout, IRecipeWrapper recipeWrapper, IIngredients ingredients) {
-        if (recipeWrapper instanceof SolarNeutronRecipeWrapper) {
-            SolarNeutronRecipe tempRecipe = ((SolarNeutronRecipeWrapper) recipeWrapper).getRecipe();
-            IGuiIngredientGroup<GasStack> gasStacks = recipeLayout.getIngredientsGroup(MekanismJEI.TYPE_GAS);
-            initGas(gasStacks, 0, true, 26 - xOffset, 14 - yOffset, 16, 58, tempRecipe.recipeInput.ingredient, true);
-            initGas(gasStacks, 1, false, 134 - xOffset, 14 - yOffset, 16, 58, tempRecipe.recipeOutput.output, true);
-        }
+    public void setRecipe(IRecipeLayout recipeLayout, WRAPPER recipeWrapper, IIngredients ingredients) {
+        SolarNeutronRecipe tempRecipe = recipeWrapper.getRecipe();
+        IGuiIngredientGroup<GasStack> gasStacks = recipeLayout.getIngredientsGroup(MekanismJEI.TYPE_GAS);
+        initGas(gasStacks, 0, true, 26 - xOffset, 14 - yOffset, 16, 58, tempRecipe.recipeInput.ingredient, true);
+        initGas(gasStacks, 1, false, 134 - xOffset, 14 - yOffset, 16, 58, tempRecipe.recipeOutput.output, true);
     }
 }

--- a/src/main/java/mekanism/client/jei/machine/other/SolarNeutronRecipeWrapper.java
+++ b/src/main/java/mekanism/client/jei/machine/other/SolarNeutronRecipeWrapper.java
@@ -1,25 +1,19 @@
 package mekanism.client.jei.machine.other;
 
 import mekanism.client.jei.MekanismJEI;
+import mekanism.client.jei.machine.MekanismRecipeWrapper;
 import mekanism.common.recipe.machines.SolarNeutronRecipe;
 import mezz.jei.api.ingredients.IIngredients;
-import mezz.jei.api.recipe.IRecipeWrapper;
 
-public class SolarNeutronRecipeWrapper implements IRecipeWrapper {
+public class SolarNeutronRecipeWrapper<RECIPE extends SolarNeutronRecipe> extends MekanismRecipeWrapper<RECIPE> {
 
-    private final SolarNeutronRecipe recipe;
-
-    public SolarNeutronRecipeWrapper(SolarNeutronRecipe r) {
-        recipe = r;
+    public SolarNeutronRecipeWrapper(RECIPE recipe) {
+        super(recipe);
     }
 
     @Override
     public void getIngredients(IIngredients ingredients) {
         ingredients.setInput(MekanismJEI.TYPE_GAS, recipe.getInput().ingredient);
         ingredients.setOutput(MekanismJEI.TYPE_GAS, recipe.getOutput().output);
-    }
-
-    public SolarNeutronRecipe getRecipe() {
-        return recipe;
     }
 }

--- a/src/main/java/mekanism/client/jei/machine/other/ThermalEvaporationRecipeCategory.java
+++ b/src/main/java/mekanism/client/jei/machine/other/ThermalEvaporationRecipeCategory.java
@@ -7,10 +7,9 @@ import mezz.jei.api.IGuiHelper;
 import mezz.jei.api.gui.IGuiFluidStackGroup;
 import mezz.jei.api.gui.IRecipeLayout;
 import mezz.jei.api.ingredients.IIngredients;
-import mezz.jei.api.recipe.IRecipeWrapper;
 import net.minecraft.client.Minecraft;
 
-public class ThermalEvaporationRecipeCategory extends BaseRecipeCategory {
+public class ThermalEvaporationRecipeCategory<WRAPPER extends ThermalEvaporationRecipeWrapper<ThermalEvaporationRecipe>> extends BaseRecipeCategory<WRAPPER> {
 
     public ThermalEvaporationRecipeCategory(IGuiHelper helper) {
         super(helper, "mekanism:gui/nei/GuiThermalEvaporationController.png",
@@ -24,16 +23,14 @@ public class ThermalEvaporationRecipeCategory extends BaseRecipeCategory {
     }
 
     @Override
-    public void setRecipe(IRecipeLayout recipeLayout, IRecipeWrapper recipeWrapper, IIngredients ingredients) {
-        if (recipeWrapper instanceof ThermalEvaporationRecipeWrapper) {
-            ThermalEvaporationRecipe tempRecipe = ((ThermalEvaporationRecipeWrapper) recipeWrapper).getRecipe();
-            IGuiFluidStackGroup fluidStacks = recipeLayout.getFluidStacks();
-            fluidStacks.init(0, true, 7 - xOffset, 14 - yOffset, 16, 58, tempRecipe.getInput().ingredient.amount, false,
-                  fluidOverlayLarge);
-            fluidStacks.init(1, false, 153 - xOffset, 14 - yOffset, 16, 58, tempRecipe.getOutput().output.amount, false,
-                  fluidOverlayLarge);
-            fluidStacks.set(0, tempRecipe.recipeInput.ingredient);
-            fluidStacks.set(1, tempRecipe.recipeOutput.output);
-        }
+    public void setRecipe(IRecipeLayout recipeLayout, WRAPPER recipeWrapper, IIngredients ingredients) {
+        ThermalEvaporationRecipe tempRecipe = recipeWrapper.getRecipe();
+        IGuiFluidStackGroup fluidStacks = recipeLayout.getFluidStacks();
+        fluidStacks.init(0, true, 7 - xOffset, 14 - yOffset, 16, 58, tempRecipe.getInput().ingredient.amount, false,
+              fluidOverlayLarge);
+        fluidStacks.init(1, false, 153 - xOffset, 14 - yOffset, 16, 58, tempRecipe.getOutput().output.amount, false,
+              fluidOverlayLarge);
+        fluidStacks.set(0, tempRecipe.recipeInput.ingredient);
+        fluidStacks.set(1, tempRecipe.recipeOutput.output);
     }
 }

--- a/src/main/java/mekanism/client/jei/machine/other/ThermalEvaporationRecipeWrapper.java
+++ b/src/main/java/mekanism/client/jei/machine/other/ThermalEvaporationRecipeWrapper.java
@@ -1,25 +1,19 @@
 package mekanism.client.jei.machine.other;
 
+import mekanism.client.jei.machine.MekanismRecipeWrapper;
 import mekanism.common.recipe.machines.ThermalEvaporationRecipe;
 import mezz.jei.api.ingredients.IIngredients;
 import mezz.jei.api.ingredients.VanillaTypes;
-import mezz.jei.api.recipe.IRecipeWrapper;
 
-public class ThermalEvaporationRecipeWrapper implements IRecipeWrapper {
+public class ThermalEvaporationRecipeWrapper<RECIPE extends ThermalEvaporationRecipe> extends MekanismRecipeWrapper<RECIPE> {
 
-    private final ThermalEvaporationRecipe recipe;
-
-    public ThermalEvaporationRecipeWrapper(ThermalEvaporationRecipe r) {
-        recipe = r;
+    public ThermalEvaporationRecipeWrapper(RECIPE recipe) {
+        super(recipe);
     }
 
     @Override
     public void getIngredients(IIngredients ingredients) {
         ingredients.setInput(VanillaTypes.FLUID, recipe.getInput().ingredient);
         ingredients.setOutput(VanillaTypes.FLUID, recipe.getOutput().output);
-    }
-
-    public ThermalEvaporationRecipe getRecipe() {
-        return recipe;
     }
 }

--- a/src/main/java/mekanism/common/CommonProxy.java
+++ b/src/main/java/mekanism/common/CommonProxy.java
@@ -203,6 +203,7 @@ public class CommonProxy implements IGuiProvider {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public Container getServerGui(int ID, EntityPlayer player, World world, BlockPos pos) {
         TileEntity tileEntity = world.getTileEntity(pos);
         switch (ID) {
@@ -211,13 +212,13 @@ public class CommonProxy implements IGuiProvider {
             case 2:
                 return new ContainerDigitalMiner(player.inventory, (TileEntityDigitalMiner) tileEntity);
             case 3:
-                return new ContainerElectricMachine(player.inventory, (TileEntityElectricMachine) tileEntity);
+                return new ContainerElectricMachine<>(player.inventory, (TileEntityElectricMachine) tileEntity);
             case 4:
-                return new ContainerAdvancedElectricMachine(player.inventory, (TileEntityAdvancedElectricMachine) tileEntity);
+                return new ContainerAdvancedElectricMachine<>(player.inventory, (TileEntityAdvancedElectricMachine) tileEntity);
             case 5:
-                return new ContainerDoubleElectricMachine(player.inventory, (TileEntityDoubleElectricMachine) tileEntity);
+                return new ContainerDoubleElectricMachine<>(player.inventory, (TileEntityDoubleElectricMachine) tileEntity);
             case 6:
-                return new ContainerElectricMachine(player.inventory, (TileEntityElectricMachine) tileEntity);
+                return new ContainerElectricMachine<>(player.inventory, (TileEntityElectricMachine) tileEntity);
             case 7:
                 return new ContainerRotaryCondensentrator(player.inventory, (TileEntityRotaryCondensentrator) tileEntity);
             case 8:
@@ -239,9 +240,9 @@ public class CommonProxy implements IGuiProvider {
                 }
                 return null;
             case 15:
-                return new ContainerAdvancedElectricMachine(player.inventory, (TileEntityAdvancedElectricMachine) tileEntity);
+                return new ContainerAdvancedElectricMachine<>(player.inventory, (TileEntityAdvancedElectricMachine) tileEntity);
             case 16:
-                return new ContainerElectricMachine(player.inventory, (TileEntityElectricMachine) tileEntity);
+                return new ContainerElectricMachine<>(player.inventory, (TileEntityElectricMachine) tileEntity);
             case 17:
                 return new ContainerElectricPump(player.inventory, (TileEntityElectricPump) tileEntity);
             case 18:
@@ -287,13 +288,13 @@ public class CommonProxy implements IGuiProvider {
             case 30:
                 return new ContainerChemicalInfuser(player.inventory, (TileEntityChemicalInfuser) tileEntity);
             case 31:
-                return new ContainerAdvancedElectricMachine(player.inventory, (TileEntityAdvancedElectricMachine) tileEntity);
+                return new ContainerAdvancedElectricMachine<>(player.inventory, (TileEntityAdvancedElectricMachine) tileEntity);
             case 32:
                 return new ContainerElectrolyticSeparator(player.inventory, (TileEntityElectrolyticSeparator) tileEntity);
             case 33:
                 return new ContainerThermalEvaporationController(player.inventory, (TileEntityThermalEvaporationController) tileEntity);
             case 34:
-                return new ContainerChanceMachine(player.inventory, (TileEntityChanceMachine) tileEntity);
+                return new ContainerChanceMachine<>(player.inventory, (TileEntityChanceMachine) tileEntity);
             case 35:
                 return new ContainerChemicalDissolutionChamber(player.inventory, (TileEntityChemicalDissolutionChamber) tileEntity);
             case 36:

--- a/src/main/java/mekanism/common/base/IFactory.java
+++ b/src/main/java/mekanism/common/base/IFactory.java
@@ -91,12 +91,12 @@ public interface IFactory {
         private Recipe recipe;
         private TileEntityAdvancedElectricMachine cacheTile;
 
-        RecipeType(String s, String s1, MachineType t, MachineFuelType ft, boolean b1, Recipe r) {
+        RecipeType(String s, String s1, MachineType t, MachineFuelType ft, boolean speed, Recipe r) {
             name = s;
             sound = new SoundEvent(new ResourceLocation(Mekanism.MODID, "tile.machine." + s1));
             type = t;
             fuelType = ft;
-            fuelSpeed = b1;
+            fuelSpeed = speed;
             recipe = r;
         }
 
@@ -113,7 +113,7 @@ public interface IFactory {
         }
 
         public BasicMachineRecipe getRecipe(ItemStackInput input) {
-            return RecipeHandler.getRecipe(input, recipe.get());
+            return (BasicMachineRecipe) RecipeHandler.getRecipe(input, recipe);
         }
 
         public BasicMachineRecipe getRecipe(ItemStack input) {
@@ -121,7 +121,7 @@ public interface IFactory {
         }
 
         public AdvancedMachineRecipe getRecipe(AdvancedMachineInput input) {
-            return RecipeHandler.getRecipe(input, recipe.get());
+            return (AdvancedMachineRecipe) RecipeHandler.getRecipe(input, recipe);
         }
 
         public AdvancedMachineRecipe getRecipe(ItemStack input, Gas gas) {
@@ -129,7 +129,7 @@ public interface IFactory {
         }
 
         public DoubleMachineRecipe getRecipe(DoubleMachineInput input) {
-            return RecipeHandler.getRecipe(input, recipe.get());
+            return (DoubleMachineRecipe) RecipeHandler.getRecipe(input, recipe);
         }
 
         public DoubleMachineRecipe getRecipe(ItemStack input, ItemStack extra) {
@@ -137,7 +137,7 @@ public interface IFactory {
         }
 
         public ChanceMachineRecipe getChanceRecipe(ItemStackInput input) {
-            return RecipeHandler.getChanceRecipe(input, recipe.get());
+            return (ChanceMachineRecipe) RecipeHandler.getRecipe(input, recipe);
         }
 
         public ChanceMachineRecipe getChanceRecipe(ItemStack input) {

--- a/src/main/java/mekanism/common/block/BlockBasic.java
+++ b/src/main/java/mekanism/common/block/BlockBasic.java
@@ -201,7 +201,7 @@ public abstract class BlockBasic extends BlockTileDrops {
     @Override
     @Deprecated
     public IBlockState getStateFromMeta(int meta) {
-        BlockStateBasic.BasicBlockType type = BlockStateBasic.BasicBlockType.get(getBasicBlock(), meta & 0xF);
+        BasicBlockType type = BasicBlockType.get(getBasicBlock(), meta & 0xF);
         return getDefaultState().withProperty(getTypeProperty(), type);
     }
 

--- a/src/main/java/mekanism/common/block/states/BlockStateMachine.java
+++ b/src/main/java/mekanism/common/block/states/BlockStateMachine.java
@@ -162,17 +162,17 @@ public class BlockStateMachine extends ExtendedBlockState {
         public boolean activable;
         public FactoryTier factoryTier;
 
-        MachineType(MachineBlock block, int i, String s, int j, Supplier<TileEntity> tileClass, boolean electric, boolean model, boolean upgrades,
+        MachineType(MachineBlock block, int m, String name, int gui, Supplier<TileEntity> tileClass, boolean electric, boolean model, boolean upgrades,
               Predicate<EnumFacing> predicate, boolean hasActiveTexture) {
-            this(block, i, s, j, tileClass, electric, model, upgrades, predicate, hasActiveTexture, null);
+            this(block, m, name, gui, tileClass, electric, model, upgrades, predicate, hasActiveTexture, null);
         }
 
-        MachineType(MachineBlock block, int i, String s, int j, Supplier<TileEntity> tileClass, boolean electric, boolean model, boolean upgrades,
+        MachineType(MachineBlock block, int m, String name, int gui, Supplier<TileEntity> tileClass, boolean electric, boolean model, boolean upgrades,
               Predicate<EnumFacing> predicate, boolean hasActiveTexture, FactoryTier factoryTier) {
             typeBlock = block;
-            meta = i;
-            blockName = s;
-            guiId = j;
+            meta = m;
+            blockName = name;
+            guiId = gui;
             tileEntitySupplier = tileClass;
             isElectric = electric;
             hasModel = model;

--- a/src/main/java/mekanism/common/config/GeneralConfig.java
+++ b/src/main/java/mekanism/common/config/GeneralConfig.java
@@ -227,7 +227,7 @@ public class GeneralConfig extends BaseConfig {
     public final DoubleOption sawdustChanceLog = new DoubleOption(this, "general", "SawdustChanceLog", 1D,
           "Chance of producing sawdust per operation in the precision sawmill when turning logs into planks.").setRequiresGameRestart(true);
 
-    public final TypeConfigManager<MachineType> machinesManager = new TypeConfigManager<>(this, "machines", MachineType.class, MachineType::getValidMachines, t -> t.blockName);
+    public final TypeConfigManager<MachineType> machinesManager = new TypeConfigManager<>(this, "machines", MachineType.class, MachineType::getValidMachines, MachineType::getBlockName);
 
     public final EnumMap<BaseTier, TierConfig> tiers = TierConfig.create(this);
 }

--- a/src/main/java/mekanism/common/config/GeneratorsConfig.java
+++ b/src/main/java/mekanism/common/config/GeneratorsConfig.java
@@ -5,6 +5,7 @@ import mekanism.common.config.options.DoubleOption;
 import mekanism.common.config.options.IntOption;
 import mekanism.common.config.options.IntSetOption;
 import mekanism.generators.common.block.states.BlockStateGenerator;
+import mekanism.generators.common.block.states.BlockStateGenerator.GeneratorType;
 import net.minecraftforge.common.config.Configuration;
 
 /**
@@ -61,7 +62,7 @@ public class GeneratorsConfig extends BaseConfig {
           "The list of dimension ids that the Wind Generator will not generate power in.");
 
     public TypeConfigManager<BlockStateGenerator.GeneratorType> generatorsManager = new TypeConfigManager<>(this, "generators", BlockStateGenerator.GeneratorType.class,
-          BlockStateGenerator.GeneratorType::getGeneratorsForConfig, t -> t.blockName);
+          BlockStateGenerator.GeneratorType::getGeneratorsForConfig, GeneratorType::getBlockName);
 
     @Override
     public void load(Configuration config) {

--- a/src/main/java/mekanism/common/config/GeneratorsConfig.java
+++ b/src/main/java/mekanism/common/config/GeneratorsConfig.java
@@ -4,7 +4,6 @@ import io.netty.buffer.ByteBuf;
 import mekanism.common.config.options.DoubleOption;
 import mekanism.common.config.options.IntOption;
 import mekanism.common.config.options.IntSetOption;
-import mekanism.generators.common.block.states.BlockStateGenerator;
 import mekanism.generators.common.block.states.BlockStateGenerator.GeneratorType;
 import net.minecraftforge.common.config.Configuration;
 
@@ -61,8 +60,8 @@ public class GeneratorsConfig extends BaseConfig {
     public final IntSetOption windGenerationDimBlacklist = new IntSetOption(this, "generation", "WindGenerationDimBlacklist", new int[0],
           "The list of dimension ids that the Wind Generator will not generate power in.");
 
-    public TypeConfigManager<BlockStateGenerator.GeneratorType> generatorsManager = new TypeConfigManager<>(this, "generators", BlockStateGenerator.GeneratorType.class,
-          BlockStateGenerator.GeneratorType::getGeneratorsForConfig, GeneratorType::getBlockName);
+    public TypeConfigManager<GeneratorType> generatorsManager = new TypeConfigManager<>(this, "generators", GeneratorType.class,
+          GeneratorType::getGeneratorsForConfig, GeneratorType::getBlockName);
 
     @Override
     public void load(Configuration config) {

--- a/src/main/java/mekanism/common/integration/IMCHandler.java
+++ b/src/main/java/mekanism/common/integration/IMCHandler.java
@@ -31,8 +31,7 @@ public class IMCHandler {
                 }
 
                 for (Recipe<?, ?, ?> type : Recipe.values()) {
-                    if (message.equalsIgnoreCase(type.getRecipeName() + "Recipe") ||
-                        message.equalsIgnoreCase(type.getOldRecipeName() + "Recipe")) {
+                    if (message.equalsIgnoreCase(type.getRecipeName() + "Recipe")) {
                         handleRecipe(type, msg, delete);
                         found = true;
                         break;

--- a/src/main/java/mekanism/common/integration/MekanismHooks.java
+++ b/src/main/java/mekanism/common/integration/MekanismHooks.java
@@ -24,6 +24,7 @@ import mekanism.common.integration.computer.OCDriver;
 import mekanism.common.integration.crafttweaker.CrafttweakerIntegration;
 import mekanism.common.integration.wrenches.Wrenches;
 import mekanism.common.recipe.RecipeHandler;
+import mekanism.common.recipe.RecipeHandler.Recipe;
 import mekanism.common.recipe.inputs.MachineInput;
 import mekanism.common.util.StackUtils;
 import net.minecraft.block.Block;
@@ -162,7 +163,7 @@ public final class MekanismHooks {
     private void hookIC2Recipes() {
         for (MachineRecipe<IRecipeInput, Collection<ItemStack>> entry : Recipes.macerator.getRecipes()) {
             if (!entry.getInput().getInputs().isEmpty()) {
-                if (!RecipeHandler.Recipe.CRUSHER.containsRecipe(entry.getInput().getInputs().get(0))) {
+                if (!Recipe.CRUSHER.containsRecipe(entry.getInput().getInputs().get(0))) {
                     List<String> names = OreDictCache.getOreDictName(entry.getInput().getInputs().get(0));
                     for (String name : names) {
                         if (name.startsWith("ingot") || name.startsWith("crystal")) {

--- a/src/main/java/mekanism/common/inventory/container/ContainerAdvancedElectricMachine.java
+++ b/src/main/java/mekanism/common/inventory/container/ContainerAdvancedElectricMachine.java
@@ -3,6 +3,7 @@ package mekanism.common.inventory.container;
 import javax.annotation.Nonnull;
 import mekanism.common.inventory.slot.SlotEnergy.SlotDischarge;
 import mekanism.common.inventory.slot.SlotOutput;
+import mekanism.common.recipe.inputs.AdvancedMachineInput;
 import mekanism.common.recipe.machines.AdvancedMachineRecipe;
 import mekanism.common.tile.prefab.TileEntityAdvancedElectricMachine;
 import mekanism.common.util.ChargeUtils;
@@ -10,6 +11,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.items.ItemHandlerHelper;
 
 public class ContainerAdvancedElectricMachine<RECIPE extends AdvancedMachineRecipe<RECIPE>> extends ContainerMekanism<TileEntityAdvancedElectricMachine<RECIPE>> {
 
@@ -78,7 +80,12 @@ public class ContainerAdvancedElectricMachine<RECIPE extends AdvancedMachineReci
     }
 
     private boolean isInputItem(ItemStack itemstack) {
-        return tileEntity.getRecipes().keySet().stream().anyMatch(input -> input.itemStack.isItemEqual(itemstack));
+        for (AdvancedMachineInput input : tileEntity.getRecipes().keySet()) {
+            if (ItemHandlerHelper.canItemStacksStack(input.itemStack, itemstack)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/mekanism/common/inventory/container/ContainerAdvancedElectricMachine.java
+++ b/src/main/java/mekanism/common/inventory/container/ContainerAdvancedElectricMachine.java
@@ -1,11 +1,9 @@
 package mekanism.common.inventory.container;
 
-import java.util.Map;
-import java.util.Map.Entry;
 import javax.annotation.Nonnull;
 import mekanism.common.inventory.slot.SlotEnergy.SlotDischarge;
 import mekanism.common.inventory.slot.SlotOutput;
-import mekanism.common.recipe.inputs.AdvancedMachineInput;
+import mekanism.common.recipe.machines.AdvancedMachineRecipe;
 import mekanism.common.tile.prefab.TileEntityAdvancedElectricMachine;
 import mekanism.common.util.ChargeUtils;
 import net.minecraft.entity.player.EntityPlayer;
@@ -13,9 +11,9 @@ import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 
-public class ContainerAdvancedElectricMachine extends ContainerMekanism<TileEntityAdvancedElectricMachine> {
+public class ContainerAdvancedElectricMachine<RECIPE extends AdvancedMachineRecipe<RECIPE>> extends ContainerMekanism<TileEntityAdvancedElectricMachine<RECIPE>> {
 
-    public ContainerAdvancedElectricMachine(InventoryPlayer inventory, TileEntityAdvancedElectricMachine tile) {
+    public ContainerAdvancedElectricMachine(InventoryPlayer inventory, TileEntityAdvancedElectricMachine<RECIPE> tile) {
         super(tile, inventory);
     }
 
@@ -80,12 +78,7 @@ public class ContainerAdvancedElectricMachine extends ContainerMekanism<TileEnti
     }
 
     private boolean isInputItem(ItemStack itemstack) {
-        for (Entry<AdvancedMachineInput, ItemStack> entry : ((Map<AdvancedMachineInput, ItemStack>) tileEntity.getRecipes()).entrySet()) {
-            if (entry.getKey().itemStack.isItemEqual(itemstack)) {
-                return true;
-            }
-        }
-        return false;
+        return tileEntity.getRecipes().keySet().stream().anyMatch(input -> input.itemStack.isItemEqual(itemstack));
     }
 
     @Override

--- a/src/main/java/mekanism/common/inventory/container/ContainerChanceMachine.java
+++ b/src/main/java/mekanism/common/inventory/container/ContainerChanceMachine.java
@@ -5,6 +5,7 @@ import mekanism.common.inventory.slot.SlotEnergy.SlotDischarge;
 import mekanism.common.inventory.slot.SlotOutput;
 import mekanism.common.recipe.RecipeHandler;
 import mekanism.common.recipe.inputs.ItemStackInput;
+import mekanism.common.recipe.machines.ChanceMachineRecipe;
 import mekanism.common.tile.TileEntityChanceMachine;
 import mekanism.common.util.ChargeUtils;
 import net.minecraft.entity.player.EntityPlayer;
@@ -12,9 +13,9 @@ import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 
-public class ContainerChanceMachine extends ContainerMekanism<TileEntityChanceMachine> {
+public class ContainerChanceMachine<RECIPE extends ChanceMachineRecipe<RECIPE>> extends ContainerMekanism<TileEntityChanceMachine<RECIPE>> {
 
-    public ContainerChanceMachine(InventoryPlayer inventory, TileEntityChanceMachine tile) {
+    public ContainerChanceMachine(InventoryPlayer inventory, TileEntityChanceMachine<RECIPE> tile) {
         super(tile, inventory);
     }
 

--- a/src/main/java/mekanism/common/inventory/container/ContainerDoubleElectricMachine.java
+++ b/src/main/java/mekanism/common/inventory/container/ContainerDoubleElectricMachine.java
@@ -1,10 +1,9 @@
 package mekanism.common.inventory.container;
 
-import java.util.Map;
 import javax.annotation.Nonnull;
 import mekanism.common.inventory.slot.SlotEnergy.SlotDischarge;
 import mekanism.common.inventory.slot.SlotOutput;
-import mekanism.common.recipe.inputs.DoubleMachineInput;
+import mekanism.common.recipe.machines.DoubleMachineRecipe;
 import mekanism.common.tile.prefab.TileEntityDoubleElectricMachine;
 import mekanism.common.util.ChargeUtils;
 import net.minecraft.entity.player.EntityPlayer;
@@ -12,9 +11,9 @@ import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 
-public class ContainerDoubleElectricMachine extends ContainerMekanism<TileEntityDoubleElectricMachine> {
+public class ContainerDoubleElectricMachine<RECIPE extends DoubleMachineRecipe<RECIPE>> extends ContainerMekanism<TileEntityDoubleElectricMachine<RECIPE>> {
 
-    public ContainerDoubleElectricMachine(InventoryPlayer inventory, TileEntityDoubleElectricMachine tile) {
+    public ContainerDoubleElectricMachine(InventoryPlayer inventory, TileEntityDoubleElectricMachine<RECIPE> tile) {
         super(tile, inventory);
     }
 
@@ -79,21 +78,11 @@ public class ContainerDoubleElectricMachine extends ContainerMekanism<TileEntity
     }
 
     private boolean isInputItem(ItemStack itemstack) {
-        for (Map.Entry<DoubleMachineInput, ItemStack> entry : ((Map<DoubleMachineInput, ItemStack>) tileEntity.getRecipes()).entrySet()) {
-            if (entry.getKey().itemStack.isItemEqual(itemstack)) {
-                return true;
-            }
-        }
-        return false;
+        return tileEntity.getRecipes().keySet().stream().anyMatch(input -> input.itemStack.isItemEqual(itemstack));
     }
 
     private boolean isExtraItem(ItemStack itemstack) {
-        for (Map.Entry<DoubleMachineInput, ItemStack> entry : ((Map<DoubleMachineInput, ItemStack>) tileEntity.getRecipes()).entrySet()) {
-            if (entry.getKey().extraStack.isItemEqual(itemstack)) {
-                return true;
-            }
-        }
-        return false;
+        return tileEntity.getRecipes().keySet().stream().anyMatch(input -> input.extraStack.isItemEqual(itemstack));
     }
 
     @Override

--- a/src/main/java/mekanism/common/inventory/container/ContainerDoubleElectricMachine.java
+++ b/src/main/java/mekanism/common/inventory/container/ContainerDoubleElectricMachine.java
@@ -3,6 +3,7 @@ package mekanism.common.inventory.container;
 import javax.annotation.Nonnull;
 import mekanism.common.inventory.slot.SlotEnergy.SlotDischarge;
 import mekanism.common.inventory.slot.SlotOutput;
+import mekanism.common.recipe.inputs.DoubleMachineInput;
 import mekanism.common.recipe.machines.DoubleMachineRecipe;
 import mekanism.common.tile.prefab.TileEntityDoubleElectricMachine;
 import mekanism.common.util.ChargeUtils;
@@ -10,6 +11,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.items.ItemHandlerHelper;
 
 public class ContainerDoubleElectricMachine<RECIPE extends DoubleMachineRecipe<RECIPE>> extends ContainerMekanism<TileEntityDoubleElectricMachine<RECIPE>> {
 
@@ -78,11 +80,21 @@ public class ContainerDoubleElectricMachine<RECIPE extends DoubleMachineRecipe<R
     }
 
     private boolean isInputItem(ItemStack itemstack) {
-        return tileEntity.getRecipes().keySet().stream().anyMatch(input -> input.itemStack.isItemEqual(itemstack));
+        for (DoubleMachineInput input : tileEntity.getRecipes().keySet()) {
+            if (ItemHandlerHelper.canItemStacksStack(input.itemStack, itemstack)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private boolean isExtraItem(ItemStack itemstack) {
-        return tileEntity.getRecipes().keySet().stream().anyMatch(input -> input.extraStack.isItemEqual(itemstack));
+        for (DoubleMachineInput input : tileEntity.getRecipes().keySet()) {
+            if (ItemHandlerHelper.canItemStacksStack(input.extraStack, itemstack)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/mekanism/common/inventory/container/ContainerElectricMachine.java
+++ b/src/main/java/mekanism/common/inventory/container/ContainerElectricMachine.java
@@ -5,6 +5,7 @@ import mekanism.common.inventory.slot.SlotEnergy.SlotDischarge;
 import mekanism.common.inventory.slot.SlotOutput;
 import mekanism.common.recipe.RecipeHandler;
 import mekanism.common.recipe.inputs.ItemStackInput;
+import mekanism.common.recipe.machines.BasicMachineRecipe;
 import mekanism.common.tile.prefab.TileEntityElectricMachine;
 import mekanism.common.util.ChargeUtils;
 import net.minecraft.entity.player.EntityPlayer;
@@ -12,9 +13,9 @@ import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 
-public class ContainerElectricMachine extends ContainerMekanism<TileEntityElectricMachine> {
+public class ContainerElectricMachine<RECIPE extends BasicMachineRecipe<RECIPE>> extends ContainerMekanism<TileEntityElectricMachine<RECIPE>> {
 
-    public ContainerElectricMachine(InventoryPlayer inventory, TileEntityElectricMachine tile) {
+    public ContainerElectricMachine(InventoryPlayer inventory, TileEntityElectricMachine<RECIPE> tile) {
         super(tile, inventory);
     }
 

--- a/src/main/java/mekanism/common/inventory/container/ContainerElectrolyticSeparator.java
+++ b/src/main/java/mekanism/common/inventory/container/ContainerElectrolyticSeparator.java
@@ -5,7 +5,7 @@ import mekanism.api.gas.IGasItem;
 import mekanism.common.MekanismFluids;
 import mekanism.common.inventory.slot.SlotEnergy.SlotDischarge;
 import mekanism.common.inventory.slot.SlotStorageTank;
-import mekanism.common.recipe.RecipeHandler;
+import mekanism.common.recipe.RecipeHandler.Recipe;
 import mekanism.common.tile.TileEntityElectrolyticSeparator;
 import mekanism.common.util.ChargeUtils;
 import net.minecraft.entity.player.EntityPlayer;
@@ -78,7 +78,7 @@ public class ContainerElectrolyticSeparator extends ContainerMekanism<TileEntity
     }
 
     public boolean isCorrectFluid(ItemStack itemStack) {
-        return RecipeHandler.Recipe.ELECTROLYTIC_SEPARATOR.containsRecipe(itemStack);
+        return Recipe.ELECTROLYTIC_SEPARATOR.containsRecipe(itemStack);
     }
 
     @Override

--- a/src/main/java/mekanism/common/recipe/MekanismRecipeEnabledCondition.java
+++ b/src/main/java/mekanism/common/recipe/MekanismRecipeEnabledCondition.java
@@ -5,7 +5,7 @@ import java.util.function.BooleanSupplier;
 import mekanism.common.block.states.BlockStateMachine.MachineType;
 import mekanism.common.config.MekanismConfig;
 import mekanism.generators.common.MekanismGenerators;
-import mekanism.generators.common.block.states.BlockStateGenerator;
+import mekanism.generators.common.block.states.BlockStateGenerator.GeneratorType;
 import net.minecraft.util.JsonUtils;
 import net.minecraftforge.common.crafting.IConditionFactory;
 import net.minecraftforge.common.crafting.JsonContext;
@@ -28,7 +28,7 @@ public class MekanismRecipeEnabledCondition implements IConditionFactory {
 
         if (Loader.isModLoaded(MekanismGenerators.MODID) && JsonUtils.hasField(json, "generatorType")) {
             final String generatorType = JsonUtils.getString(json, "generatorType");
-            final BlockStateGenerator.GeneratorType type = MekanismConfig.current().generators.generatorsManager.typeFromName(generatorType);
+            final GeneratorType type = MekanismConfig.current().generators.generatorsManager.typeFromName(generatorType);
             //noinspection Convert2Lambda - classloading issues if generators not installed
             return new BooleanSupplier() {
                 @Override

--- a/src/main/java/mekanism/common/recipe/RecipeHandler.java
+++ b/src/main/java/mekanism/common/recipe/RecipeHandler.java
@@ -69,19 +69,20 @@ import net.minecraftforge.fluids.FluidStack;
  */
 public final class RecipeHandler {
 
-    public static void addRecipe(@Nonnull Recipe recipeMap, @Nonnull MachineRecipe recipe) {
+    public static <INPUT extends MachineInput<INPUT>, OUTPUT extends MachineOutput<OUTPUT>, RECIPE extends MachineRecipe<INPUT, OUTPUT, RECIPE>>
+    void addRecipe(@Nonnull Recipe<INPUT, OUTPUT, RECIPE> recipeMap, @Nonnull RECIPE recipe) {
         recipeMap.put(recipe);
     }
 
-    public static void removeRecipe(@Nonnull Recipe recipeMap, @Nonnull MachineRecipe recipe) {
-        List<MachineInput> toRemove = new ArrayList<>();
-        for (Object o : recipeMap.get().keySet()) {
-            MachineInput iterInput = (MachineInput) o;
+    public static <INPUT extends MachineInput<INPUT>, OUTPUT extends MachineOutput<OUTPUT>, RECIPE extends MachineRecipe<INPUT, OUTPUT, RECIPE>>
+    void removeRecipe(@Nonnull Recipe<INPUT, OUTPUT, RECIPE> recipeMap, @Nonnull RECIPE recipe) {
+        List<INPUT> toRemove = new ArrayList<>();
+        for (INPUT iterInput : recipeMap.get().keySet()) {
             if (iterInput.testEquality(recipe.getInput())) {
                 toRemove.add(iterInput);
             }
         }
-        for (MachineInput iterInput : toRemove) {
+        for (INPUT iterInput : toRemove) {
             recipeMap.get().remove(iterInput);
         }
     }
@@ -754,6 +755,10 @@ public final class RecipeHandler {
                 }
             }
             return false;
+        }
+
+        public Class<RECIPE> getRecipeClass() {
+            return recipeClass;
         }
 
         // N.B. Must return a HashMap, not Map as Unidict expects the stronger type

--- a/src/main/java/mekanism/common/recipe/RecipeHandler.java
+++ b/src/main/java/mekanism/common/recipe/RecipeHandler.java
@@ -571,61 +571,61 @@ public final class RecipeHandler {
         private static List<Recipe> values = new ArrayList<>();
 
         public static final Recipe<ItemStackInput, ItemStackOutput, SmeltingRecipe> ENERGIZED_SMELTER = new Recipe<>(
-              MachineType.ENERGIZED_SMELTER.blockName, "ENERGIZED_SMELTER", ItemStackInput.class, ItemStackOutput.class, SmeltingRecipe.class);
+              MachineType.ENERGIZED_SMELTER.blockName, ItemStackInput.class, ItemStackOutput.class, SmeltingRecipe.class);
 
         public static final Recipe<ItemStackInput, ItemStackOutput, EnrichmentRecipe> ENRICHMENT_CHAMBER = new Recipe<>(
-              MachineType.ENRICHMENT_CHAMBER.blockName, "ENRICHMENT_CHAMBER", ItemStackInput.class, ItemStackOutput.class, EnrichmentRecipe.class);
+              MachineType.ENRICHMENT_CHAMBER.blockName, ItemStackInput.class, ItemStackOutput.class, EnrichmentRecipe.class);
 
         public static final Recipe<AdvancedMachineInput, ItemStackOutput, OsmiumCompressorRecipe> OSMIUM_COMPRESSOR = new Recipe<>(
-              MachineType.OSMIUM_COMPRESSOR.blockName, "OSMIUM_COMPRESSOR", AdvancedMachineInput.class, ItemStackOutput.class, OsmiumCompressorRecipe.class);
+              MachineType.OSMIUM_COMPRESSOR.blockName, AdvancedMachineInput.class, ItemStackOutput.class, OsmiumCompressorRecipe.class);
 
         public static final Recipe<DoubleMachineInput, ItemStackOutput, CombinerRecipe> COMBINER = new Recipe<>(
-              MachineType.COMBINER.blockName, "COMBINER", DoubleMachineInput.class, ItemStackOutput.class, CombinerRecipe.class);
+              MachineType.COMBINER.blockName, DoubleMachineInput.class, ItemStackOutput.class, CombinerRecipe.class);
 
         public static final Recipe<ItemStackInput, ItemStackOutput, CrusherRecipe> CRUSHER = new Recipe<>(
-              MachineType.CRUSHER.blockName, "CRUSHER", ItemStackInput.class, ItemStackOutput.class, CrusherRecipe.class);
+              MachineType.CRUSHER.blockName, ItemStackInput.class, ItemStackOutput.class, CrusherRecipe.class);
 
         public static final Recipe<AdvancedMachineInput, ItemStackOutput, PurificationRecipe> PURIFICATION_CHAMBER = new Recipe<>(
-              MachineType.PURIFICATION_CHAMBER.blockName, "PURIFICATION_CHAMBER", AdvancedMachineInput.class, ItemStackOutput.class, PurificationRecipe.class);
+              MachineType.PURIFICATION_CHAMBER.blockName, AdvancedMachineInput.class, ItemStackOutput.class, PurificationRecipe.class);
 
         public static final Recipe<InfusionInput, ItemStackOutput, MetallurgicInfuserRecipe> METALLURGIC_INFUSER = new Recipe<>(
-              MachineType.METALLURGIC_INFUSER.blockName, "METALLURGIC_INFUSER", InfusionInput.class, ItemStackOutput.class, MetallurgicInfuserRecipe.class);
+              MachineType.METALLURGIC_INFUSER.blockName, InfusionInput.class, ItemStackOutput.class, MetallurgicInfuserRecipe.class);
 
         public static final Recipe<ChemicalPairInput, GasOutput, ChemicalInfuserRecipe> CHEMICAL_INFUSER = new Recipe<>(
-              MachineType.CHEMICAL_INFUSER.blockName, "CHEMICAL_INFUSER", ChemicalPairInput.class, GasOutput.class, ChemicalInfuserRecipe.class);
+              MachineType.CHEMICAL_INFUSER.blockName, ChemicalPairInput.class, GasOutput.class, ChemicalInfuserRecipe.class);
 
         public static final Recipe<ItemStackInput, GasOutput, OxidationRecipe> CHEMICAL_OXIDIZER = new Recipe<>(
-              MachineType.CHEMICAL_OXIDIZER.blockName, "CHEMICAL_OXIDIZER", ItemStackInput.class, GasOutput.class, OxidationRecipe.class);
+              MachineType.CHEMICAL_OXIDIZER.blockName, ItemStackInput.class, GasOutput.class, OxidationRecipe.class);
 
         public static final Recipe<AdvancedMachineInput, ItemStackOutput, InjectionRecipe> CHEMICAL_INJECTION_CHAMBER = new Recipe<>(
-              MachineType.CHEMICAL_INJECTION_CHAMBER.blockName, "CHEMICAL_INJECTION_CHAMBER", AdvancedMachineInput.class, ItemStackOutput.class, InjectionRecipe.class);
+              MachineType.CHEMICAL_INJECTION_CHAMBER.blockName, AdvancedMachineInput.class, ItemStackOutput.class, InjectionRecipe.class);
 
         public static final Recipe<FluidInput, ChemicalPairOutput, SeparatorRecipe> ELECTROLYTIC_SEPARATOR = new Recipe<>(
-              MachineType.ELECTROLYTIC_SEPARATOR.blockName, "ELECTROLYTIC_SEPARATOR", FluidInput.class, ChemicalPairOutput.class, SeparatorRecipe.class);
+              MachineType.ELECTROLYTIC_SEPARATOR.blockName, FluidInput.class, ChemicalPairOutput.class, SeparatorRecipe.class);
 
         public static final Recipe<ItemStackInput, ChanceOutput, SawmillRecipe> PRECISION_SAWMILL = new Recipe<>(
-              MachineType.PRECISION_SAWMILL.blockName, "PRECISION_SAWMILL", ItemStackInput.class, ChanceOutput.class, SawmillRecipe.class);
+              MachineType.PRECISION_SAWMILL.blockName, ItemStackInput.class, ChanceOutput.class, SawmillRecipe.class);
 
         public static final Recipe<ItemStackInput, GasOutput, DissolutionRecipe> CHEMICAL_DISSOLUTION_CHAMBER = new Recipe<>(
-              MachineType.CHEMICAL_DISSOLUTION_CHAMBER.blockName, "CHEMICAL_DISSOLUTION_CHAMBER", ItemStackInput.class, GasOutput.class, DissolutionRecipe.class);
+              MachineType.CHEMICAL_DISSOLUTION_CHAMBER.blockName, ItemStackInput.class, GasOutput.class, DissolutionRecipe.class);
 
         public static final Recipe<GasInput, GasOutput, WasherRecipe> CHEMICAL_WASHER = new Recipe<>(
-              MachineType.CHEMICAL_WASHER.blockName, "CHEMICAL_WASHER", GasInput.class, GasOutput.class, WasherRecipe.class);
+              MachineType.CHEMICAL_WASHER.blockName, GasInput.class, GasOutput.class, WasherRecipe.class);
 
         public static final Recipe<GasInput, ItemStackOutput, CrystallizerRecipe> CHEMICAL_CRYSTALLIZER = new Recipe<>(
-              MachineType.CHEMICAL_CRYSTALLIZER.blockName, "CHEMICAL_CRYSTALLIZER", GasInput.class, ItemStackOutput.class, CrystallizerRecipe.class);
+              MachineType.CHEMICAL_CRYSTALLIZER.blockName, GasInput.class, ItemStackOutput.class, CrystallizerRecipe.class);
 
         public static final Recipe<PressurizedInput, PressurizedOutput, PressurizedRecipe> PRESSURIZED_REACTION_CHAMBER = new Recipe<>(
-              MachineType.PRESSURIZED_REACTION_CHAMBER.blockName, "PRESSURIZED_REACTION_CHAMBER", PressurizedInput.class, PressurizedOutput.class, PressurizedRecipe.class);
+              MachineType.PRESSURIZED_REACTION_CHAMBER.blockName, PressurizedInput.class, PressurizedOutput.class, PressurizedRecipe.class);
 
         public static final Recipe<IntegerInput, GasOutput, AmbientGasRecipe> AMBIENT_ACCUMULATOR = new Recipe<>(
-              MachineType.AMBIENT_ACCUMULATOR.blockName, "AMBIENT_ACCUMULATOR", IntegerInput.class, GasOutput.class, AmbientGasRecipe.class);
+              MachineType.AMBIENT_ACCUMULATOR.blockName, IntegerInput.class, GasOutput.class, AmbientGasRecipe.class);
 
         public static final Recipe<FluidInput, FluidOutput, ThermalEvaporationRecipe> THERMAL_EVAPORATION_PLANT = new Recipe<>(
-              "ThermalEvaporationPlant", "THERMAL_EVAPORATION_PLANT", FluidInput.class, FluidOutput.class, ThermalEvaporationRecipe.class);
+              "ThermalEvaporationPlant", FluidInput.class, FluidOutput.class, ThermalEvaporationRecipe.class);
 
         public static final Recipe<GasInput, GasOutput, SolarNeutronRecipe> SOLAR_NEUTRON_ACTIVATOR = new Recipe<>(
-              MachineType.SOLAR_NEUTRON_ACTIVATOR.blockName, "SOLAR_NEUTRON_ACTIVATOR", GasInput.class, GasOutput.class, SolarNeutronRecipe.class);
+              MachineType.SOLAR_NEUTRON_ACTIVATOR.blockName, GasInput.class, GasOutput.class, SolarNeutronRecipe.class);
 
         static {
             values = ImmutableList.copyOf(values);
@@ -637,7 +637,6 @@ public final class RecipeHandler {
 
         private final HashMap<INPUT, RECIPE> recipes = new HashMap<>();
         private final String recipeName;
-        private final String oldRecipeName;
         @Nonnull
         private final String jeiCategory;
 
@@ -646,9 +645,8 @@ public final class RecipeHandler {
         private Class<RECIPE> recipeClass;
 
 
-        private Recipe(String name, String oldName, Class<INPUT> input, Class<OUTPUT> output, Class<RECIPE> recipe) {
+        private Recipe(String name, Class<INPUT> input, Class<OUTPUT> output, Class<RECIPE> recipe) {
             recipeName = name;
-            oldRecipeName = oldName;
             jeiCategory = "mekanism." + recipeName.toLowerCase(Locale.ROOT);
 
             inputClass = input;
@@ -670,10 +668,6 @@ public final class RecipeHandler {
             return recipeName;
         }
 
-        public String getOldRecipeName() {
-            return oldRecipeName;
-        }
-
         @Nonnull
         public String getJEICategory() {
             return jeiCategory;
@@ -693,7 +687,7 @@ public final class RecipeHandler {
         @Nullable
         public RECIPE createRecipe(INPUT input, NBTTagCompound nbtTags) {
             try {
-                MachineOutput output = outputClass.newInstance();
+                OUTPUT output = outputClass.newInstance();
                 output.load(nbtTags);
                 try {
                     Constructor<RECIPE> construct = recipeClass.getDeclaredConstructor(inputClass, outputClass);

--- a/src/main/java/mekanism/common/recipe/RecipeHandler.java
+++ b/src/main/java/mekanism/common/recipe/RecipeHandler.java
@@ -540,7 +540,7 @@ public final class RecipeHandler {
         private Class<RECIPE> recipeClass;
 
         private Recipe(MachineType type, Class<INPUT> input, Class<OUTPUT> output, Class<RECIPE> recipe) {
-            this(type.blockName, input, output, recipe);
+            this(type.getBlockName(), input, output, recipe);
         }
 
         private Recipe(String name, Class<INPUT> input, Class<OUTPUT> output, Class<RECIPE> recipe) {

--- a/src/main/java/mekanism/common/recipe/RecipeHandler.java
+++ b/src/main/java/mekanism/common/recipe/RecipeHandler.java
@@ -19,21 +19,19 @@ import mekanism.common.recipe.inputs.ChemicalPairInput;
 import mekanism.common.recipe.inputs.DoubleMachineInput;
 import mekanism.common.recipe.inputs.FluidInput;
 import mekanism.common.recipe.inputs.GasInput;
+import mekanism.common.recipe.inputs.IWildInput;
 import mekanism.common.recipe.inputs.InfusionInput;
 import mekanism.common.recipe.inputs.IntegerInput;
 import mekanism.common.recipe.inputs.ItemStackInput;
 import mekanism.common.recipe.inputs.MachineInput;
 import mekanism.common.recipe.inputs.PressurizedInput;
-import mekanism.common.recipe.machines.AdvancedMachineRecipe;
 import mekanism.common.recipe.machines.AmbientGasRecipe;
-import mekanism.common.recipe.machines.BasicMachineRecipe;
 import mekanism.common.recipe.machines.ChanceMachineRecipe;
 import mekanism.common.recipe.machines.ChemicalInfuserRecipe;
 import mekanism.common.recipe.machines.CombinerRecipe;
 import mekanism.common.recipe.machines.CrusherRecipe;
 import mekanism.common.recipe.machines.CrystallizerRecipe;
 import mekanism.common.recipe.machines.DissolutionRecipe;
-import mekanism.common.recipe.machines.DoubleMachineRecipe;
 import mekanism.common.recipe.machines.EnrichmentRecipe;
 import mekanism.common.recipe.machines.InjectionRecipe;
 import mekanism.common.recipe.machines.MachineRecipe;
@@ -293,15 +291,7 @@ public final class RecipeHandler {
      */
     @Nullable
     public static MetallurgicInfuserRecipe getMetallurgicInfuserRecipe(@Nonnull InfusionInput input) {
-        if (input.isValid()) {
-            Map<InfusionInput, MetallurgicInfuserRecipe> recipes = Recipe.METALLURGIC_INFUSER.get();
-            MetallurgicInfuserRecipe recipe = recipes.get(input);
-            if (recipe == null) {
-                recipe = recipes.get(input.wildCopy());
-            }
-            return recipe == null ? null : recipe.copy();
-        }
-        return null;
+        return getRecipe(input, Recipe.METALLURGIC_INFUSER);
     }
 
     /**
@@ -313,12 +303,7 @@ public final class RecipeHandler {
      */
     @Nullable
     public static ChemicalInfuserRecipe getChemicalInfuserRecipe(@Nonnull ChemicalPairInput input) {
-        if (input.isValid()) {
-            Map<ChemicalPairInput, ChemicalInfuserRecipe> recipes = Recipe.CHEMICAL_INFUSER.get();
-            ChemicalInfuserRecipe recipe = recipes.get(input);
-            return recipe == null ? null : recipe.copy();
-        }
-        return null;
+        return getRecipe(input, Recipe.CHEMICAL_INFUSER);
     }
 
     /**
@@ -330,12 +315,7 @@ public final class RecipeHandler {
      */
     @Nullable
     public static CrystallizerRecipe getChemicalCrystallizerRecipe(@Nonnull GasInput input) {
-        if (input.isValid()) {
-            Map<GasInput, CrystallizerRecipe> recipes = Recipe.CHEMICAL_CRYSTALLIZER.get();
-            CrystallizerRecipe recipe = recipes.get(input);
-            return recipe == null ? null : recipe.copy();
-        }
-        return null;
+        return getRecipe(input, Recipe.CHEMICAL_CRYSTALLIZER);
     }
 
     /**
@@ -347,12 +327,7 @@ public final class RecipeHandler {
      */
     @Nullable
     public static WasherRecipe getChemicalWasherRecipe(@Nonnull GasInput input) {
-        if (input.isValid()) {
-            Map<GasInput, WasherRecipe> recipes = Recipe.CHEMICAL_WASHER.get();
-            WasherRecipe recipe = recipes.get(input);
-            return recipe == null ? null : recipe.copy();
-        }
-        return null;
+        return getRecipe(input, Recipe.CHEMICAL_WASHER);
     }
 
     /**
@@ -364,12 +339,7 @@ public final class RecipeHandler {
      */
     @Nullable
     public static DissolutionRecipe getDissolutionRecipe(@Nonnull ItemStackInput input) {
-        if (input.isValid()) {
-            Map<ItemStackInput, DissolutionRecipe> recipes = Recipe.CHEMICAL_DISSOLUTION_CHAMBER.get();
-            DissolutionRecipe recipe = getRecipeTryWildcard(input, recipes);
-            return recipe == null ? null : recipe.copy();
-        }
-        return null;
+        return getRecipe(input, Recipe.CHEMICAL_DISSOLUTION_CHAMBER);
     }
 
     /**
@@ -381,12 +351,7 @@ public final class RecipeHandler {
      */
     @Nullable
     public static OxidationRecipe getOxidizerRecipe(@Nonnull ItemStackInput input) {
-        if (input.isValid()) {
-            Map<ItemStackInput, OxidationRecipe> recipes = Recipe.CHEMICAL_OXIDIZER.get();
-            OxidationRecipe recipe = getRecipeTryWildcard(input, recipes);
-            return recipe == null ? null : recipe.copy();
-        }
-        return null;
+        return getRecipe(input, Recipe.CHEMICAL_OXIDIZER);
     }
 
     /**
@@ -399,69 +364,36 @@ public final class RecipeHandler {
      */
     @Nullable
     public static <RECIPE extends ChanceMachineRecipe<RECIPE>> RECIPE getChanceRecipe(@Nonnull ItemStackInput input, @Nonnull Map<ItemStackInput, RECIPE> recipes) {
-        if (input.isValid()) {
-            RECIPE recipe = getRecipeTryWildcard(input, recipes);
-            return recipe == null ? null : recipe.copy();
-        }
-        return null;
+        return getRecipe(input, recipes);
     }
 
     /**
-     * Gets the BasicMachineRecipe of the ItemStackInput in the parameters, using the map in the parameters.
+     * Gets the Recipe of the given Input in the parameters, using the map in the parameters.
      *
-     * @param input   - ItemStackInput
+     * @param input   - Input
      * @param recipes - Map of recipes
      *
-     * @return BasicMachineRecipe
+     * @return Recipe
      */
     @Nullable
-    public static <RECIPE extends BasicMachineRecipe<RECIPE>> RECIPE getRecipe(@Nonnull ItemStackInput input, @Nonnull Map<ItemStackInput, RECIPE> recipes) {
-        if (input.isValid()) {
-            RECIPE recipe = getRecipeTryWildcard(input, recipes);
-            return recipe == null ? null : recipe.copy();
-        }
-        return null;
-    }
-
-    /**
-     * Gets the AdvancedMachineRecipe of the AdvancedInput in the parameters, using the map in the paramaters.
-     *
-     * @param input   - AdvancedInput
-     * @param recipes - Map of recipes
-     *
-     * @return AdvancedMachineRecipe
-     */
-    @Nullable
-    public static <RECIPE extends AdvancedMachineRecipe<RECIPE>> RECIPE getRecipe(@Nonnull AdvancedMachineInput input, @Nonnull Map<AdvancedMachineInput, RECIPE> recipes) {
+    public static <INPUT extends MachineInput<INPUT>, RECIPE extends MachineRecipe<INPUT, ?, RECIPE>>
+    RECIPE getRecipe(@Nonnull INPUT input, @Nonnull Map<INPUT, RECIPE> recipes) {
         if (input.isValid()) {
             RECIPE recipe = recipes.get(input);
-            if (recipe == null) {
-                recipe = recipes.get(input.wildCopy());
+            if (recipe == null && input instanceof IWildInput) {
+                //noinspection unchecked
+                IWildInput<INPUT> wildInput = (IWildInput<INPUT>) input;
+                recipe = recipes.get(wildInput.wildCopy());
             }
             return recipe == null ? null : recipe.copy();
         }
         return null;
     }
 
-
-    /**
-     * Gets the DoubleMachineRecipe of the DoubleInput in the parameters, using the map in the paramaters.
-     *
-     * @param input   - DoubleInput
-     * @param recipes - Map of recipes
-     *
-     * @return DoubleMachineRecipe
-     */
     @Nullable
-    public static <RECIPE extends DoubleMachineRecipe<RECIPE>> RECIPE getRecipe(@Nonnull DoubleMachineInput input, @Nonnull Map<DoubleMachineInput, RECIPE> recipes) {
-        if (input.isValid()) {
-            RECIPE recipe = recipes.get(input);
-            if (recipe == null) {
-                recipe = recipes.get(input.wildCopy());
-            }
-            return recipe == null ? null : recipe.copy();
-        }
-        return null;
+    public static <INPUT extends MachineInput<INPUT>, RECIPE extends MachineRecipe<INPUT, ?, RECIPE>>
+    RECIPE getRecipe(@Nonnull INPUT input, @Nonnull Recipe<INPUT, ?, RECIPE> type) {
+        return getRecipe(input, type.get());
     }
 
     /**
@@ -473,52 +405,27 @@ public final class RecipeHandler {
      */
     @Nullable
     public static SeparatorRecipe getElectrolyticSeparatorRecipe(@Nonnull FluidInput input) {
-        if (input.isValid()) {
-            Map<FluidInput, SeparatorRecipe> recipes = Recipe.ELECTROLYTIC_SEPARATOR.get();
-            SeparatorRecipe recipe = recipes.get(input);
-            return recipe == null ? null : recipe.copy();
-        }
-        return null;
+        return getRecipe(input, Recipe.ELECTROLYTIC_SEPARATOR);
     }
 
     @Nullable
     public static ThermalEvaporationRecipe getThermalEvaporationRecipe(@Nonnull FluidInput input) {
-        if (input.isValid()) {
-            Map<FluidInput, ThermalEvaporationRecipe> recipes = Recipe.THERMAL_EVAPORATION_PLANT.get();
-            ThermalEvaporationRecipe recipe = recipes.get(input);
-            return recipe == null ? null : recipe.copy();
-        }
-        return null;
+        return getRecipe(input, Recipe.THERMAL_EVAPORATION_PLANT);
     }
 
     @Nullable
     public static SolarNeutronRecipe getSolarNeutronRecipe(@Nonnull GasInput input) {
-        if (input.isValid()) {
-            Map<GasInput, SolarNeutronRecipe> recipes = Recipe.SOLAR_NEUTRON_ACTIVATOR.get();
-            SolarNeutronRecipe recipe = recipes.get(input);
-            return recipe == null ? null : recipe.copy();
-        }
-        return null;
+        return getRecipe(input, Recipe.SOLAR_NEUTRON_ACTIVATOR);
     }
 
     @Nullable
     public static PressurizedRecipe getPRCRecipe(@Nonnull PressurizedInput input) {
-        if (input.isValid()) {
-            Map<PressurizedInput, PressurizedRecipe> recipes = Recipe.PRESSURIZED_REACTION_CHAMBER.get();
-            PressurizedRecipe recipe = recipes.get(input);
-            if (recipe == null) {
-                recipe = recipes.get(input.wildCopy());
-            }
-            return recipe == null ? null : recipe.copy();
-        }
-        return null;
+        return getRecipe(input, Recipe.PRESSURIZED_REACTION_CHAMBER);
     }
 
     @Nullable
     public static AmbientGasRecipe getDimensionGas(IntegerInput input) {
-        Map<IntegerInput, AmbientGasRecipe> recipes = Recipe.AMBIENT_ACCUMULATOR.get();
-        AmbientGasRecipe recipe = recipes.get(input);
-        return recipe == null ? null : recipe.copy();
+        return getRecipe(input, Recipe.AMBIENT_ACCUMULATOR);
     }
 
     /**
@@ -554,78 +461,66 @@ public final class RecipeHandler {
         return false;
     }
 
-    public static <RECIPE extends MachineRecipe<ItemStackInput, ?, RECIPE>> RECIPE getRecipeTryWildcard(ItemStack stack, @Nonnull Map<ItemStackInput, RECIPE> recipes) {
-        return getRecipeTryWildcard(new ItemStackInput(stack), recipes);
-    }
-
-    public static <RECIPE extends MachineRecipe<ItemStackInput, ?, RECIPE>> RECIPE getRecipeTryWildcard(@Nonnull ItemStackInput input, @Nonnull Map<ItemStackInput, RECIPE> recipes) {
-        RECIPE recipe = recipes.get(input);
-        if (recipe == null) {
-            recipe = recipes.get(input.wildCopy());
-        }
-        return recipe;
-    }
-
     public static class Recipe<INPUT extends MachineInput<INPUT>, OUTPUT extends MachineOutput<OUTPUT>, RECIPE extends MachineRecipe<INPUT, OUTPUT, RECIPE>> {
 
         private static List<Recipe> values = new ArrayList<>();
 
         public static final Recipe<ItemStackInput, ItemStackOutput, SmeltingRecipe> ENERGIZED_SMELTER = new Recipe<>(
-              MachineType.ENERGIZED_SMELTER.blockName, ItemStackInput.class, ItemStackOutput.class, SmeltingRecipe.class);
+              MachineType.ENERGIZED_SMELTER, ItemStackInput.class, ItemStackOutput.class, SmeltingRecipe.class);
 
         public static final Recipe<ItemStackInput, ItemStackOutput, EnrichmentRecipe> ENRICHMENT_CHAMBER = new Recipe<>(
-              MachineType.ENRICHMENT_CHAMBER.blockName, ItemStackInput.class, ItemStackOutput.class, EnrichmentRecipe.class);
+              MachineType.ENRICHMENT_CHAMBER, ItemStackInput.class, ItemStackOutput.class, EnrichmentRecipe.class);
 
         public static final Recipe<AdvancedMachineInput, ItemStackOutput, OsmiumCompressorRecipe> OSMIUM_COMPRESSOR = new Recipe<>(
-              MachineType.OSMIUM_COMPRESSOR.blockName, AdvancedMachineInput.class, ItemStackOutput.class, OsmiumCompressorRecipe.class);
+              MachineType.OSMIUM_COMPRESSOR, AdvancedMachineInput.class, ItemStackOutput.class, OsmiumCompressorRecipe.class);
 
         public static final Recipe<DoubleMachineInput, ItemStackOutput, CombinerRecipe> COMBINER = new Recipe<>(
-              MachineType.COMBINER.blockName, DoubleMachineInput.class, ItemStackOutput.class, CombinerRecipe.class);
+              MachineType.COMBINER, DoubleMachineInput.class, ItemStackOutput.class, CombinerRecipe.class);
 
         public static final Recipe<ItemStackInput, ItemStackOutput, CrusherRecipe> CRUSHER = new Recipe<>(
-              MachineType.CRUSHER.blockName, ItemStackInput.class, ItemStackOutput.class, CrusherRecipe.class);
+              MachineType.CRUSHER, ItemStackInput.class, ItemStackOutput.class, CrusherRecipe.class);
 
         public static final Recipe<AdvancedMachineInput, ItemStackOutput, PurificationRecipe> PURIFICATION_CHAMBER = new Recipe<>(
-              MachineType.PURIFICATION_CHAMBER.blockName, AdvancedMachineInput.class, ItemStackOutput.class, PurificationRecipe.class);
+              MachineType.PURIFICATION_CHAMBER, AdvancedMachineInput.class, ItemStackOutput.class, PurificationRecipe.class);
 
         public static final Recipe<InfusionInput, ItemStackOutput, MetallurgicInfuserRecipe> METALLURGIC_INFUSER = new Recipe<>(
-              MachineType.METALLURGIC_INFUSER.blockName, InfusionInput.class, ItemStackOutput.class, MetallurgicInfuserRecipe.class);
+              MachineType.METALLURGIC_INFUSER, InfusionInput.class, ItemStackOutput.class, MetallurgicInfuserRecipe.class);
 
         public static final Recipe<ChemicalPairInput, GasOutput, ChemicalInfuserRecipe> CHEMICAL_INFUSER = new Recipe<>(
-              MachineType.CHEMICAL_INFUSER.blockName, ChemicalPairInput.class, GasOutput.class, ChemicalInfuserRecipe.class);
+              MachineType.CHEMICAL_INFUSER, ChemicalPairInput.class, GasOutput.class, ChemicalInfuserRecipe.class);
 
         public static final Recipe<ItemStackInput, GasOutput, OxidationRecipe> CHEMICAL_OXIDIZER = new Recipe<>(
-              MachineType.CHEMICAL_OXIDIZER.blockName, ItemStackInput.class, GasOutput.class, OxidationRecipe.class);
+              MachineType.CHEMICAL_OXIDIZER, ItemStackInput.class, GasOutput.class, OxidationRecipe.class);
 
         public static final Recipe<AdvancedMachineInput, ItemStackOutput, InjectionRecipe> CHEMICAL_INJECTION_CHAMBER = new Recipe<>(
-              MachineType.CHEMICAL_INJECTION_CHAMBER.blockName, AdvancedMachineInput.class, ItemStackOutput.class, InjectionRecipe.class);
+              MachineType.CHEMICAL_INJECTION_CHAMBER, AdvancedMachineInput.class, ItemStackOutput.class, InjectionRecipe.class);
 
         public static final Recipe<FluidInput, ChemicalPairOutput, SeparatorRecipe> ELECTROLYTIC_SEPARATOR = new Recipe<>(
-              MachineType.ELECTROLYTIC_SEPARATOR.blockName, FluidInput.class, ChemicalPairOutput.class, SeparatorRecipe.class);
+              MachineType.ELECTROLYTIC_SEPARATOR, FluidInput.class, ChemicalPairOutput.class, SeparatorRecipe.class);
 
         public static final Recipe<ItemStackInput, ChanceOutput, SawmillRecipe> PRECISION_SAWMILL = new Recipe<>(
-              MachineType.PRECISION_SAWMILL.blockName, ItemStackInput.class, ChanceOutput.class, SawmillRecipe.class);
+              MachineType.PRECISION_SAWMILL, ItemStackInput.class, ChanceOutput.class, SawmillRecipe.class);
 
         public static final Recipe<ItemStackInput, GasOutput, DissolutionRecipe> CHEMICAL_DISSOLUTION_CHAMBER = new Recipe<>(
-              MachineType.CHEMICAL_DISSOLUTION_CHAMBER.blockName, ItemStackInput.class, GasOutput.class, DissolutionRecipe.class);
+              MachineType.CHEMICAL_DISSOLUTION_CHAMBER, ItemStackInput.class, GasOutput.class, DissolutionRecipe.class);
 
         public static final Recipe<GasInput, GasOutput, WasherRecipe> CHEMICAL_WASHER = new Recipe<>(
-              MachineType.CHEMICAL_WASHER.blockName, GasInput.class, GasOutput.class, WasherRecipe.class);
+              MachineType.CHEMICAL_WASHER, GasInput.class, GasOutput.class, WasherRecipe.class);
 
         public static final Recipe<GasInput, ItemStackOutput, CrystallizerRecipe> CHEMICAL_CRYSTALLIZER = new Recipe<>(
-              MachineType.CHEMICAL_CRYSTALLIZER.blockName, GasInput.class, ItemStackOutput.class, CrystallizerRecipe.class);
+              MachineType.CHEMICAL_CRYSTALLIZER, GasInput.class, ItemStackOutput.class, CrystallizerRecipe.class);
 
         public static final Recipe<PressurizedInput, PressurizedOutput, PressurizedRecipe> PRESSURIZED_REACTION_CHAMBER = new Recipe<>(
-              MachineType.PRESSURIZED_REACTION_CHAMBER.blockName, PressurizedInput.class, PressurizedOutput.class, PressurizedRecipe.class);
+              MachineType.PRESSURIZED_REACTION_CHAMBER, PressurizedInput.class, PressurizedOutput.class, PressurizedRecipe.class);
 
         public static final Recipe<IntegerInput, GasOutput, AmbientGasRecipe> AMBIENT_ACCUMULATOR = new Recipe<>(
-              MachineType.AMBIENT_ACCUMULATOR.blockName, IntegerInput.class, GasOutput.class, AmbientGasRecipe.class);
+              MachineType.AMBIENT_ACCUMULATOR, IntegerInput.class, GasOutput.class, AmbientGasRecipe.class);
 
         public static final Recipe<FluidInput, FluidOutput, ThermalEvaporationRecipe> THERMAL_EVAPORATION_PLANT = new Recipe<>(
               "ThermalEvaporationPlant", FluidInput.class, FluidOutput.class, ThermalEvaporationRecipe.class);
 
         public static final Recipe<GasInput, GasOutput, SolarNeutronRecipe> SOLAR_NEUTRON_ACTIVATOR = new Recipe<>(
-              MachineType.SOLAR_NEUTRON_ACTIVATOR.blockName, GasInput.class, GasOutput.class, SolarNeutronRecipe.class);
+              MachineType.SOLAR_NEUTRON_ACTIVATOR, GasInput.class, GasOutput.class, SolarNeutronRecipe.class);
 
         static {
             values = ImmutableList.copyOf(values);
@@ -644,6 +539,9 @@ public final class RecipeHandler {
         private Class<OUTPUT> outputClass;
         private Class<RECIPE> recipeClass;
 
+        private Recipe(MachineType type, Class<INPUT> input, Class<OUTPUT> output, Class<RECIPE> recipe) {
+            this(type.blockName, input, output, recipe);
+        }
 
         private Recipe(String name, Class<INPUT> input, Class<OUTPUT> output, Class<RECIPE> recipe) {
             recipeName = name;
@@ -760,18 +658,5 @@ public final class RecipeHandler {
         public HashMap<INPUT, RECIPE> get() {
             return recipes;
         }
-
-        /*@Nullable
-        public RECIPE getRecipe(INPUT input) {
-            if (input.isValid()) {
-                RECIPE recipe;
-                recipe = recipes.get(input);
-                if (recipe == null && input instanceof ItemStackInput) {
-                    recipe = recipes.get(((ItemStackInput) input).wildCopy());
-                }
-                return recipe == null ? null : recipe.copy();
-            }
-            return null;
-        }*/
     }
 }

--- a/src/main/java/mekanism/common/recipe/inputs/AdvancedMachineInput.java
+++ b/src/main/java/mekanism/common/recipe/inputs/AdvancedMachineInput.java
@@ -8,7 +8,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.NonNullList;
 import net.minecraftforge.oredict.OreDictionary;
 
-public class AdvancedMachineInput extends MachineInput<AdvancedMachineInput> {
+public class AdvancedMachineInput extends MachineInput<AdvancedMachineInput> implements IWildInput<AdvancedMachineInput> {
 
     public ItemStack itemStack = ItemStack.EMPTY;
 
@@ -78,6 +78,7 @@ public class AdvancedMachineInput extends MachineInput<AdvancedMachineInput> {
         return other instanceof AdvancedMachineInput;
     }
 
+    @Override
     public AdvancedMachineInput wildCopy() {
         return new AdvancedMachineInput(new ItemStack(itemStack.getItem(), itemStack.getCount(), OreDictionary.WILDCARD_VALUE), gasType);
     }

--- a/src/main/java/mekanism/common/recipe/inputs/DoubleMachineInput.java
+++ b/src/main/java/mekanism/common/recipe/inputs/DoubleMachineInput.java
@@ -6,7 +6,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.NonNullList;
 import net.minecraftforge.oredict.OreDictionary;
 
-public class DoubleMachineInput extends MachineInput<DoubleMachineInput> {
+public class DoubleMachineInput extends MachineInput<DoubleMachineInput> implements IWildInput<DoubleMachineInput> {
 
     public ItemStack itemStack = ItemStack.EMPTY;
     public ItemStack extraStack = ItemStack.EMPTY;
@@ -76,6 +76,7 @@ public class DoubleMachineInput extends MachineInput<DoubleMachineInput> {
         return other instanceof DoubleMachineInput;
     }
 
+    @Override
     public DoubleMachineInput wildCopy() {
         return new DoubleMachineInput(new ItemStack(itemStack.getItem(), itemStack.getCount(), OreDictionary.WILDCARD_VALUE),
               new ItemStack(extraStack.getItem(), extraStack.getCount(), OreDictionary.WILDCARD_VALUE));

--- a/src/main/java/mekanism/common/recipe/inputs/IWildInput.java
+++ b/src/main/java/mekanism/common/recipe/inputs/IWildInput.java
@@ -1,0 +1,6 @@
+package mekanism.common.recipe.inputs;
+
+public interface IWildInput<INPUT extends MachineInput<INPUT>> {
+
+    INPUT wildCopy();
+}

--- a/src/main/java/mekanism/common/recipe/inputs/InfusionInput.java
+++ b/src/main/java/mekanism/common/recipe/inputs/InfusionInput.java
@@ -14,7 +14,7 @@ import net.minecraftforge.oredict.OreDictionary;
  *
  * @author AidanBrady
  */
-public class InfusionInput extends MachineInput<InfusionInput> {
+public class InfusionInput extends MachineInput<InfusionInput> implements IWildInput<InfusionInput> {
 
     public InfuseStorage infuse;
 
@@ -83,6 +83,7 @@ public class InfusionInput extends MachineInput<InfusionInput> {
         return other instanceof InfusionInput;
     }
 
+    @Override
     public InfusionInput wildCopy() {
         return new InfusionInput(infuse, new ItemStack(inputStack.getItem(), inputStack.getCount(), OreDictionary.WILDCARD_VALUE));
     }

--- a/src/main/java/mekanism/common/recipe/inputs/ItemStackInput.java
+++ b/src/main/java/mekanism/common/recipe/inputs/ItemStackInput.java
@@ -6,7 +6,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.NonNullList;
 import net.minecraftforge.oredict.OreDictionary;
 
-public class ItemStackInput extends MachineInput<ItemStackInput> {
+public class ItemStackInput extends MachineInput<ItemStackInput> implements IWildInput<ItemStackInput> {
 
     public ItemStack ingredient = ItemStack.EMPTY;
     private ItemStackInput wildVersion = null;
@@ -37,6 +37,7 @@ public class ItemStackInput extends MachineInput<ItemStackInput> {
         return !ingredient.isEmpty();
     }
 
+    @Override
     public ItemStackInput wildCopy() {
         if (wildVersion == null) {
             if (ingredient.getMetadata() != OreDictionary.WILDCARD_VALUE) {

--- a/src/main/java/mekanism/common/recipe/inputs/PressurizedInput.java
+++ b/src/main/java/mekanism/common/recipe/inputs/PressurizedInput.java
@@ -13,7 +13,7 @@ import net.minecraftforge.oredict.OreDictionary;
 /**
  * An input of a gas, a fluid and an item for the pressurized reaction chamber
  */
-public class PressurizedInput extends MachineInput<PressurizedInput> {
+public class PressurizedInput extends MachineInput<PressurizedInput> implements IWildInput<PressurizedInput> {
 
     private ItemStack theSolid = ItemStack.EMPTY;
     private FluidStack theFluid;
@@ -146,6 +146,7 @@ public class PressurizedInput extends MachineInput<PressurizedInput> {
         return other instanceof PressurizedInput;
     }
 
+    @Override
     public PressurizedInput wildCopy() {
         return new PressurizedInput(new ItemStack(theSolid.getItem(), theSolid.getCount(), OreDictionary.WILDCARD_VALUE), theFluid, theGas);
     }

--- a/src/main/java/mekanism/common/tile/TileEntityChanceMachine.java
+++ b/src/main/java/mekanism/common/tile/TileEntityChanceMachine.java
@@ -6,6 +6,7 @@ import mekanism.api.EnumColor;
 import mekanism.api.transmitters.TransmissionType;
 import mekanism.common.MekanismItems;
 import mekanism.common.SideData;
+import mekanism.common.block.states.BlockStateMachine.MachineType;
 import mekanism.common.recipe.RecipeHandler;
 import mekanism.common.recipe.inputs.ItemStackInput;
 import mekanism.common.recipe.machines.ChanceMachineRecipe;
@@ -25,8 +26,8 @@ public abstract class TileEntityChanceMachine<RECIPE extends ChanceMachineRecipe
 
     private static final String[] methods = new String[]{"getEnergy", "getProgress", "isActive", "facing", "canOperate", "getMaxEnergy", "getEnergyNeeded"};
 
-    public TileEntityChanceMachine(String soundPath, String name, double baseMaxEnergy, double baseEnergyUsage, int ticksRequired, ResourceLocation location) {
-        super(soundPath, name, baseMaxEnergy, baseEnergyUsage, 3, ticksRequired, location);
+    public TileEntityChanceMachine(String soundPath, MachineType type, int ticksRequired, ResourceLocation location) {
+        super(soundPath, type, 3, ticksRequired, location);
         configComponent = new TileComponentConfig(this, TransmissionType.ITEM, TransmissionType.ENERGY);
 
         configComponent.addOutput(TransmissionType.ITEM, new SideData("None", EnumColor.GREY, InventoryUtils.EMPTY));

--- a/src/main/java/mekanism/common/tile/TileEntityChemicalCrystallizer.java
+++ b/src/main/java/mekanism/common/tile/TileEntityChemicalCrystallizer.java
@@ -48,7 +48,7 @@ public class TileEntityChemicalCrystallizer extends TileEntityOperationalMachine
     public TileComponentConfig configComponent;
 
     public TileEntityChemicalCrystallizer() {
-        super("machine.crystallizer", "ChemicalCrystallizer", MachineType.CHEMICAL_CRYSTALLIZER.getStorage(), MachineType.CHEMICAL_CRYSTALLIZER.getUsage(), 3, 200);
+        super("machine.crystallizer", MachineType.CHEMICAL_CRYSTALLIZER, 3, 200);
         configComponent = new TileComponentConfig(this, TransmissionType.ITEM, TransmissionType.ENERGY, TransmissionType.GAS);
 
         configComponent.addOutput(TransmissionType.ITEM, new SideData("None", EnumColor.GREY, InventoryUtils.EMPTY));

--- a/src/main/java/mekanism/common/tile/TileEntityChemicalCrystallizer.java
+++ b/src/main/java/mekanism/common/tile/TileEntityChemicalCrystallizer.java
@@ -19,6 +19,7 @@ import mekanism.common.base.ITankManager;
 import mekanism.common.block.states.BlockStateMachine.MachineType;
 import mekanism.common.capabilities.Capabilities;
 import mekanism.common.recipe.RecipeHandler;
+import mekanism.common.recipe.RecipeHandler.Recipe;
 import mekanism.common.recipe.inputs.GasInput;
 import mekanism.common.recipe.machines.CrystallizerRecipe;
 import mekanism.common.tile.component.TileComponentConfig;
@@ -156,7 +157,7 @@ public class TileEntityChemicalCrystallizer extends TileEntityOperationalMachine
     @Override
     public boolean canReceiveGas(EnumFacing side, Gas type) {
         return configComponent.getOutput(TransmissionType.GAS, side, facing).hasSlot(0) && inputTank.canReceive(type) &&
-               RecipeHandler.Recipe.CHEMICAL_CRYSTALLIZER.containsRecipe(type);
+               Recipe.CHEMICAL_CRYSTALLIZER.containsRecipe(type);
     }
 
     @Override
@@ -211,7 +212,7 @@ public class TileEntityChemicalCrystallizer extends TileEntityOperationalMachine
     public boolean isItemValidForSlot(int slotID, @Nonnull ItemStack itemstack) {
         if (slotID == 0) {
             return !itemstack.isEmpty() && itemstack.getItem() instanceof IGasItem && ((IGasItem) itemstack.getItem()).getGas(itemstack) != null &&
-                   RecipeHandler.Recipe.CHEMICAL_CRYSTALLIZER.containsRecipe(((IGasItem) itemstack.getItem()).getGas(itemstack).getGas());
+                   Recipe.CHEMICAL_CRYSTALLIZER.containsRecipe(((IGasItem) itemstack.getItem()).getGas(itemstack).getGas());
         } else if (slotID == 2) {
             return ChargeUtils.canBeDischarged(itemstack);
         }

--- a/src/main/java/mekanism/common/tile/TileEntityChemicalDissolutionChamber.java
+++ b/src/main/java/mekanism/common/tile/TileEntityChemicalDissolutionChamber.java
@@ -53,7 +53,7 @@ public class TileEntityChemicalDissolutionChamber extends TileEntityMachine impl
     public DissolutionRecipe cachedRecipe;
 
     public TileEntityChemicalDissolutionChamber() {
-        super("machine.dissolution", "ChemicalDissolutionChamber", MachineType.CHEMICAL_DISSOLUTION_CHAMBER.getStorage(), MachineType.CHEMICAL_DISSOLUTION_CHAMBER.getUsage(), 4);
+        super("machine.dissolution", MachineType.CHEMICAL_DISSOLUTION_CHAMBER, 4);
         inventory = NonNullList.withSize(5, ItemStack.EMPTY);
         upgradeComponent.setSupported(Upgrade.GAS);
     }

--- a/src/main/java/mekanism/common/tile/TileEntityChemicalInfuser.java
+++ b/src/main/java/mekanism/common/tile/TileEntityChemicalInfuser.java
@@ -50,7 +50,7 @@ public class TileEntityChemicalInfuser extends TileEntityMachine implements IGas
     public double clientEnergyUsed;
 
     public TileEntityChemicalInfuser() {
-        super("machine.cheminfuser", "ChemicalInfuser", MachineType.CHEMICAL_INFUSER.getStorage(), MachineType.CHEMICAL_INFUSER.getUsage(), 4);
+        super("machine.cheminfuser", MachineType.CHEMICAL_INFUSER, 4);
         inventory = NonNullList.withSize(5, ItemStack.EMPTY);
     }
 

--- a/src/main/java/mekanism/common/tile/TileEntityChemicalInjectionChamber.java
+++ b/src/main/java/mekanism/common/tile/TileEntityChemicalInjectionChamber.java
@@ -19,8 +19,7 @@ import net.minecraft.util.EnumFacing;
 public class TileEntityChemicalInjectionChamber extends TileEntityAdvancedElectricMachine<InjectionRecipe> {
 
     public TileEntityChemicalInjectionChamber() {
-        super("injection", "ChemicalInjectionChamber", MachineType.CHEMICAL_INJECTION_CHAMBER.getStorage(),
-              MachineType.CHEMICAL_INJECTION_CHAMBER.getUsage(), BASE_TICKS_REQUIRED, BASE_GAS_PER_TICK);
+        super("injection", MachineType.CHEMICAL_INJECTION_CHAMBER, BASE_TICKS_REQUIRED, BASE_GAS_PER_TICK);
         configComponent.addSupported(TransmissionType.GAS);
         configComponent.addOutput(TransmissionType.GAS, new SideData("None", EnumColor.GREY, InventoryUtils.EMPTY));
         configComponent.addOutput(TransmissionType.GAS, new SideData("Gas", EnumColor.DARK_RED, new int[]{0}));

--- a/src/main/java/mekanism/common/tile/TileEntityChemicalOxidizer.java
+++ b/src/main/java/mekanism/common/tile/TileEntityChemicalOxidizer.java
@@ -40,7 +40,7 @@ public class TileEntityChemicalOxidizer extends TileEntityOperationalMachine imp
     public OxidationRecipe cachedRecipe;
 
     public TileEntityChemicalOxidizer() {
-        super("machine.oxidizer", "ChemicalOxidizer", MachineType.CHEMICAL_OXIDIZER.getStorage(), MachineType.CHEMICAL_OXIDIZER.getUsage(), 3, 100);
+        super("machine.oxidizer", MachineType.CHEMICAL_OXIDIZER, 3, 100);
         inventory = NonNullList.withSize(4, ItemStack.EMPTY);
     }
 

--- a/src/main/java/mekanism/common/tile/TileEntityChemicalWasher.java
+++ b/src/main/java/mekanism/common/tile/TileEntityChemicalWasher.java
@@ -21,6 +21,7 @@ import mekanism.common.base.ITankManager;
 import mekanism.common.block.states.BlockStateMachine.MachineType;
 import mekanism.common.capabilities.Capabilities;
 import mekanism.common.recipe.RecipeHandler;
+import mekanism.common.recipe.RecipeHandler.Recipe;
 import mekanism.common.recipe.inputs.GasInput;
 import mekanism.common.recipe.machines.WasherRecipe;
 import mekanism.common.tile.prefab.TileEntityMachine;
@@ -186,7 +187,7 @@ public class TileEntityChemicalWasher extends TileEntityMachine implements IGasH
     @Override
     public boolean canReceiveGas(EnumFacing side, Gas type) {
         if (getTank(side) == inputTank) {
-            return getTank(side).canReceive(type) && RecipeHandler.Recipe.CHEMICAL_WASHER.containsRecipe(type);
+            return getTank(side).canReceive(type) && Recipe.CHEMICAL_WASHER.containsRecipe(type);
         }
         return false;
     }

--- a/src/main/java/mekanism/common/tile/TileEntityChemicalWasher.java
+++ b/src/main/java/mekanism/common/tile/TileEntityChemicalWasher.java
@@ -64,7 +64,7 @@ public class TileEntityChemicalWasher extends TileEntityMachine implements IGasH
     public double clientEnergyUsed;
 
     public TileEntityChemicalWasher() {
-        super("machine.washer", "ChemicalWasher", MachineType.CHEMICAL_WASHER.getStorage(), MachineType.CHEMICAL_WASHER.getUsage(), 4);
+        super("machine.washer", MachineType.CHEMICAL_WASHER, 4);
         inventory = NonNullList.withSize(5, ItemStack.EMPTY);
     }
 

--- a/src/main/java/mekanism/common/tile/TileEntityCombiner.java
+++ b/src/main/java/mekanism/common/tile/TileEntityCombiner.java
@@ -10,7 +10,7 @@ import mekanism.common.tile.prefab.TileEntityDoubleElectricMachine;
 public class TileEntityCombiner extends TileEntityDoubleElectricMachine<CombinerRecipe> {
 
     public TileEntityCombiner() {
-        super("combiner", "Combiner", MachineType.COMBINER.getStorage(), MachineType.COMBINER.getUsage(), 200);
+        super("combiner", MachineType.COMBINER, 200);
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/TileEntityCrusher.java
+++ b/src/main/java/mekanism/common/tile/TileEntityCrusher.java
@@ -10,7 +10,7 @@ import mekanism.common.tile.prefab.TileEntityElectricMachine;
 public class TileEntityCrusher extends TileEntityElectricMachine<CrusherRecipe> {
 
     public TileEntityCrusher() {
-        super("crusher", "Crusher", MachineType.CRUSHER.getStorage(), MachineType.CRUSHER.getUsage(), 200);
+        super("crusher", MachineType.CRUSHER, 200);
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/TileEntityElectrolyticSeparator.java
+++ b/src/main/java/mekanism/common/tile/TileEntityElectrolyticSeparator.java
@@ -95,7 +95,7 @@ public class TileEntityElectrolyticSeparator extends TileEntityMachine implement
     private int currentRedstoneLevel;
 
     public TileEntityElectrolyticSeparator() {
-        super("machine.electrolyticseparator", "ElectrolyticSeparator", MachineType.ELECTROLYTIC_SEPARATOR.getStorage(), 0, 4);
+        super("machine.electrolyticseparator", MachineType.ELECTROLYTIC_SEPARATOR, 4);
         inventory = NonNullList.withSize(5, ItemStack.EMPTY);
     }
 

--- a/src/main/java/mekanism/common/tile/TileEntityElectrolyticSeparator.java
+++ b/src/main/java/mekanism/common/tile/TileEntityElectrolyticSeparator.java
@@ -105,7 +105,7 @@ public class TileEntityElectrolyticSeparator extends TileEntityMachine implement
         if (!world.isRemote) {
             ChargeUtils.discharge(3, this);
             if (!inventory.get(0).isEmpty()) {
-                if (RecipeHandler.Recipe.ELECTROLYTIC_SEPARATOR.containsRecipe(inventory.get(0))) {
+                if (Recipe.ELECTROLYTIC_SEPARATOR.containsRecipe(inventory.get(0))) {
                     if (FluidContainerUtils.isFluidContainer(inventory.get(0))) {
                         fluidTank.fill(FluidContainerUtils.extractFluid(fluidTank, this, 0), true);
                     }

--- a/src/main/java/mekanism/common/tile/TileEntityEnergizedSmelter.java
+++ b/src/main/java/mekanism/common/tile/TileEntityEnergizedSmelter.java
@@ -10,7 +10,7 @@ import mekanism.common.tile.prefab.TileEntityElectricMachine;
 public class TileEntityEnergizedSmelter extends TileEntityElectricMachine<SmeltingRecipe> {
 
     public TileEntityEnergizedSmelter() {
-        super("smelter", "EnergizedSmelter", MachineType.ENERGIZED_SMELTER.getStorage(), MachineType.ENERGIZED_SMELTER.getUsage(), 200);
+        super("smelter", MachineType.ENERGIZED_SMELTER, 200);
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/TileEntityEnrichmentChamber.java
+++ b/src/main/java/mekanism/common/tile/TileEntityEnrichmentChamber.java
@@ -10,7 +10,7 @@ import mekanism.common.tile.prefab.TileEntityElectricMachine;
 public class TileEntityEnrichmentChamber extends TileEntityElectricMachine<EnrichmentRecipe> {
 
     public TileEntityEnrichmentChamber() {
-        super("enrichment", "EnrichmentChamber", MachineType.ENRICHMENT_CHAMBER.getStorage(), MachineType.ENRICHMENT_CHAMBER.getUsage(), 200);
+        super("enrichment", MachineType.ENRICHMENT_CHAMBER, 200);
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/TileEntityFactory.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFactory.java
@@ -152,7 +152,7 @@ public class TileEntityFactory extends TileEntityMachine implements IComputerInt
     }
 
     public TileEntityFactory(FactoryTier type, MachineType machine) {
-        super("null", machine.blockName, 0, 0, 0);
+        super("null", machine, 0);
         tier = type;
         inventory = NonNullList.withSize(5 + type.processes * 2, ItemStack.EMPTY);
         progress = new int[type.processes];

--- a/src/main/java/mekanism/common/tile/TileEntityMetallurgicInfuser.java
+++ b/src/main/java/mekanism/common/tile/TileEntityMetallurgicInfuser.java
@@ -19,8 +19,8 @@ import mekanism.common.base.IFactory.RecipeType;
 import mekanism.common.base.ISideConfiguration;
 import mekanism.common.base.ISustainedData;
 import mekanism.common.base.ITierUpgradeable;
+import mekanism.common.block.states.BlockStateMachine.MachineType;
 import mekanism.common.capabilities.Capabilities;
-import mekanism.common.config.MekanismConfig;
 import mekanism.common.integration.computer.IComputerIntegration;
 import mekanism.common.recipe.RecipeHandler;
 import mekanism.common.recipe.RecipeHandler.Recipe;
@@ -59,8 +59,7 @@ public class TileEntityMetallurgicInfuser extends TileEntityOperationalMachine i
     public TileComponentConfig configComponent;
 
     public TileEntityMetallurgicInfuser() {
-        super("machine.metalinfuser", "MetallurgicInfuser", MekanismConfig.current().storage.metallurgicInfuser.val(),
-              MekanismConfig.current().usage.metallurgicInfuser.val(), 0, 200);
+        super("machine.metalinfuser", MachineType.METALLURGIC_INFUSER, 0, 200);
         configComponent = new TileComponentConfig(this, TransmissionType.ITEM);
 
         configComponent.addOutput(TransmissionType.ITEM, new SideData("None", EnumColor.GREY, InventoryUtils.EMPTY));

--- a/src/main/java/mekanism/common/tile/TileEntityOredictionificator.java
+++ b/src/main/java/mekanism/common/tile/TileEntityOredictionificator.java
@@ -50,7 +50,7 @@ public class TileEntityOredictionificator extends TileEntityContainerBlock imple
     public TileComponentSecurity securityComponent = new TileComponentSecurity(this);
 
     public TileEntityOredictionificator() {
-        super(MachineType.OREDICTIONIFICATOR.blockName);
+        super(MachineType.OREDICTIONIFICATOR.getBlockName());
         inventory = NonNullList.withSize(2, ItemStack.EMPTY);
         doAutoSync = false;
     }

--- a/src/main/java/mekanism/common/tile/TileEntityOsmiumCompressor.java
+++ b/src/main/java/mekanism/common/tile/TileEntityOsmiumCompressor.java
@@ -13,8 +13,7 @@ import net.minecraft.util.EnumFacing;
 public class TileEntityOsmiumCompressor extends TileEntityAdvancedElectricMachine<OsmiumCompressorRecipe> {
 
     public TileEntityOsmiumCompressor() {
-        super("compressor", "OsmiumCompressor", MachineType.OSMIUM_COMPRESSOR.getStorage(), MachineType.OSMIUM_COMPRESSOR.getUsage(),
-              BASE_TICKS_REQUIRED, BASE_GAS_PER_TICK);
+        super("compressor", MachineType.OSMIUM_COMPRESSOR, BASE_TICKS_REQUIRED, BASE_GAS_PER_TICK);
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/TileEntityPRC.java
+++ b/src/main/java/mekanism/common/tile/TileEntityPRC.java
@@ -57,8 +57,7 @@ public class TileEntityPRC extends TileEntityBasicMachine<PressurizedInput, Pres
     public GasTank outputGasTank = new GasTank(10000);
 
     public TileEntityPRC() {
-        super("prc", MachineType.PRESSURIZED_REACTION_CHAMBER.blockName, MachineType.PRESSURIZED_REACTION_CHAMBER.getStorage(),
-              MachineType.PRESSURIZED_REACTION_CHAMBER.getUsage(), 3, 100, new ResourceLocation(Mekanism.MODID, "gui/GuiPRC.png"));
+        super("prc", MachineType.PRESSURIZED_REACTION_CHAMBER, 3, 100, new ResourceLocation(Mekanism.MODID, "gui/GuiPRC.png"));
         configComponent = new TileComponentConfig(this, TransmissionType.ITEM, TransmissionType.ENERGY, TransmissionType.FLUID, TransmissionType.GAS);
 
         configComponent.addOutput(TransmissionType.ITEM, new SideData("None", EnumColor.GREY, InventoryUtils.EMPTY));

--- a/src/main/java/mekanism/common/tile/TileEntityPrecisionSawmill.java
+++ b/src/main/java/mekanism/common/tile/TileEntityPrecisionSawmill.java
@@ -11,8 +11,7 @@ import mekanism.common.util.MekanismUtils.ResourceType;
 public class TileEntityPrecisionSawmill extends TileEntityChanceMachine<SawmillRecipe> {
 
     public TileEntityPrecisionSawmill() {
-        super("sawmill", "PrecisionSawmill", MachineType.PRECISION_SAWMILL.getStorage(), MachineType.PRECISION_SAWMILL.getUsage(), 200,
-              MekanismUtils.getResource(ResourceType.GUI, "GuiBasicMachine.png"));
+        super("sawmill", MachineType.PRECISION_SAWMILL, 200, MekanismUtils.getResource(ResourceType.GUI, "GuiBasicMachine.png"));
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/TileEntityPurificationChamber.java
+++ b/src/main/java/mekanism/common/tile/TileEntityPurificationChamber.java
@@ -16,8 +16,7 @@ import net.minecraft.util.EnumFacing;
 public class TileEntityPurificationChamber extends TileEntityAdvancedElectricMachine<PurificationRecipe> {
 
     public TileEntityPurificationChamber() {
-        super("purification", "PurificationChamber", MachineType.PURIFICATION_CHAMBER.getStorage(), MachineType.PURIFICATION_CHAMBER.getUsage(),
-              BASE_TICKS_REQUIRED, BASE_GAS_PER_TICK);
+        super("purification", MachineType.PURIFICATION_CHAMBER, BASE_TICKS_REQUIRED, BASE_GAS_PER_TICK);
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/TileEntityRotaryCondensentrator.java
+++ b/src/main/java/mekanism/common/tile/TileEntityRotaryCondensentrator.java
@@ -65,8 +65,7 @@ public class TileEntityRotaryCondensentrator extends TileEntityMachine implement
     private int currentRedstoneLevel;
 
     public TileEntityRotaryCondensentrator() {
-        super("machine.rotarycondensentrator", "RotaryCondensentrator", MachineType.ROTARY_CONDENSENTRATOR.getStorage(),
-              MachineType.ROTARY_CONDENSENTRATOR.getUsage(), 5);
+        super("machine.rotarycondensentrator", MachineType.ROTARY_CONDENSENTRATOR, 5);
         inventory = NonNullList.withSize(6, ItemStack.EMPTY);
     }
 

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityAdvancedElectricMachine.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityAdvancedElectricMachine.java
@@ -14,6 +14,7 @@ import mekanism.common.MekanismItems;
 import mekanism.common.SideData;
 import mekanism.common.Upgrade;
 import mekanism.common.base.ISustainedData;
+import mekanism.common.block.states.BlockStateMachine.MachineType;
 import mekanism.common.capabilities.Capabilities;
 import mekanism.common.recipe.GasConversionHandler;
 import mekanism.common.recipe.RecipeHandler;
@@ -62,14 +63,12 @@ public abstract class TileEntityAdvancedElectricMachine<RECIPE extends AdvancedM
      * The machine will not run if it does not have enough electricity, or if it doesn't have enough fuel ticks.
      *
      * @param soundPath        - location of the sound effect
-     * @param name             - full name of this machine
-     * @param baseMaxEnergy    - maximum amount of energy this machine can hold.
-     * @param baseEnergyUsage  - how much energy this machine uses per tick.
+     * @param type             - the type of this machine
      * @param ticksRequired    - how many ticks it takes to smelt an item.
      * @param secondaryPerTick - how much secondary energy (fuel) this machine uses per tick.
      */
-    public TileEntityAdvancedElectricMachine(String soundPath, String name, double baseMaxEnergy, double baseEnergyUsage, int ticksRequired, int secondaryPerTick) {
-        super(soundPath, name, baseMaxEnergy, baseEnergyUsage, 4, ticksRequired, MekanismUtils.getResource(ResourceType.GUI, "GuiAdvancedMachine.png"));
+    public TileEntityAdvancedElectricMachine(String soundPath, MachineType type, int ticksRequired, int secondaryPerTick) {
+        super(soundPath, type, 4, ticksRequired, MekanismUtils.getResource(ResourceType.GUI, "GuiAdvancedMachine.png"));
         configComponent = new TileComponentConfig(this, TransmissionType.ITEM, TransmissionType.ENERGY);
 
         configComponent.addOutput(TransmissionType.ITEM, new SideData("None", EnumColor.GREY, InventoryUtils.EMPTY));

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityAdvancedElectricMachine.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityAdvancedElectricMachine.java
@@ -347,7 +347,7 @@ public abstract class TileEntityAdvancedElectricMachine<RECIPE extends AdvancedM
             case 4:
                 return new Object[]{facing};
             case 5:
-                return new Object[]{canOperate(RecipeHandler.getRecipe(getInput(), getRecipes()))};
+                return new Object[]{canOperate(getRecipe())};
             case 6:
                 return new Object[]{maxEnergy};
             case 7:

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityBasicBlock.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityBasicBlock.java
@@ -73,7 +73,7 @@ public abstract class TileEntityBasicBlock extends TileEntity implements ITileNe
         if (!world.isRemote && MekanismConfig.current().general.destroyDisabledBlocks.val()) {
             MachineType type = MachineType.get(getBlockType(), getBlockMetadata());
             if (type != null && !type.isEnabled()) {
-                Mekanism.logger.info("Destroying machine of type '" + type.blockName + "' at coords " + Coord4D.get(this) + " as according to config.");
+                Mekanism.logger.info("Destroying machine of type '" + type.getBlockName() + "' at coords " + Coord4D.get(this) + " as according to config.");
                 world.setBlockToAir(getPos());
                 return;
             }

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityBasicMachine.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityBasicMachine.java
@@ -5,6 +5,7 @@ import mekanism.api.IConfigCardAccess;
 import mekanism.api.transmitters.TransmissionType;
 import mekanism.common.base.IElectricMachine;
 import mekanism.common.base.ISideConfiguration;
+import mekanism.common.block.states.BlockStateMachine.MachineType;
 import mekanism.common.capabilities.Capabilities;
 import mekanism.common.integration.computer.IComputerIntegration;
 import mekanism.common.recipe.inputs.MachineInput;
@@ -30,12 +31,11 @@ public abstract class TileEntityBasicMachine<INPUT extends MachineInput<INPUT>, 
      * The foundation of all machines - a simple tile entity with a facing, active state, initialized state, sound effect, and animated texture.
      *
      * @param soundPath         - location of the sound effect
-     * @param name              - full name of this machine
-     * @param baseMaxEnergy     - how much energy this machine can store
+     * @param type              - the type of this machine
      * @param baseTicksRequired - how many ticks it takes to run a cycle
      */
-    public TileEntityBasicMachine(String soundPath, String name, double baseMaxEnergy, double baseEnergyUsage, int upgradeSlot, int baseTicksRequired, ResourceLocation location) {
-        super("machine." + soundPath, name, baseMaxEnergy, baseEnergyUsage, upgradeSlot, baseTicksRequired);
+    public TileEntityBasicMachine(String soundPath, MachineType type, int upgradeSlot, int baseTicksRequired, ResourceLocation location) {
+        super("machine." + soundPath, type, upgradeSlot, baseTicksRequired);
         guiLocation = location;
     }
 

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityDoubleElectricMachine.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityDoubleElectricMachine.java
@@ -5,6 +5,7 @@ import mekanism.api.EnumColor;
 import mekanism.api.transmitters.TransmissionType;
 import mekanism.common.MekanismItems;
 import mekanism.common.SideData;
+import mekanism.common.block.states.BlockStateMachine.MachineType;
 import mekanism.common.recipe.RecipeHandler;
 import mekanism.common.recipe.inputs.DoubleMachineInput;
 import mekanism.common.recipe.machines.DoubleMachineRecipe;
@@ -28,14 +29,12 @@ public abstract class TileEntityDoubleElectricMachine<RECIPE extends DoubleMachi
      * Double Electric Machine -- a machine like this has a total of 4 slots. Input slot (0), secondary slot (1), output slot (2), energy slot (3), and the upgrade slot
      * (4). The machine will not run if it does not have enough electricity.
      *
-     * @param soundPath       - location of the sound effect
-     * @param name            - full name of this machine
-     * @param baseMaxEnergy   - maximum amount of energy this machine can hold.
-     * @param baseEnergyUsage - how much energy this machine uses per tick.
-     * @param ticksRequired   - how many ticks it takes to smelt an item.
+     * @param soundPath     - location of the sound effect
+     * @param type          - the type of this machine
+     * @param ticksRequired - how many ticks it takes to smelt an item.
      */
-    public TileEntityDoubleElectricMachine(String soundPath, String name, double baseMaxEnergy, double baseEnergyUsage, int ticksRequired) {
-        super(soundPath, name, baseMaxEnergy, baseEnergyUsage, 4, ticksRequired, MekanismUtils.getResource(ResourceType.GUI, "guibasicmachine.png"));
+    public TileEntityDoubleElectricMachine(String soundPath, MachineType type, int ticksRequired) {
+        super(soundPath, type, 4, ticksRequired, MekanismUtils.getResource(ResourceType.GUI, "guibasicmachine.png"));
         configComponent = new TileComponentConfig(this, TransmissionType.ITEM, TransmissionType.ENERGY);
 
         configComponent.addOutput(TransmissionType.ITEM, new SideData("None", EnumColor.GREY, InventoryUtils.EMPTY));

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityDoubleElectricMachine.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityDoubleElectricMachine.java
@@ -164,7 +164,7 @@ public abstract class TileEntityDoubleElectricMachine<RECIPE extends DoubleMachi
             case 3:
                 return new Object[]{facing};
             case 4:
-                return new Object[]{canOperate(RecipeHandler.getRecipe(getInput(), getRecipes()))};
+                return new Object[]{canOperate(getRecipe())};
             case 5:
                 return new Object[]{maxEnergy};
             case 6:

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityElectricMachine.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityElectricMachine.java
@@ -5,6 +5,7 @@ import mekanism.api.EnumColor;
 import mekanism.api.transmitters.TransmissionType;
 import mekanism.common.MekanismItems;
 import mekanism.common.SideData;
+import mekanism.common.block.states.BlockStateMachine.MachineType;
 import mekanism.common.recipe.RecipeHandler;
 import mekanism.common.recipe.inputs.ItemStackInput;
 import mekanism.common.recipe.machines.BasicMachineRecipe;
@@ -29,13 +30,11 @@ public abstract class TileEntityElectricMachine<RECIPE extends BasicMachineRecip
      * have enough energy.
      *
      * @param soundPath     - location of the sound effect
-     * @param name          - full name of this machine
-     * @param perTick       - energy used per tick.
+     * @param type          - type of this machine
      * @param ticksRequired - ticks required to operate -- or smelt an item.
-     * @param maxEnergy     - maximum energy this machine can hold.
      */
-    public TileEntityElectricMachine(String soundPath, String name, double maxEnergy, double perTick, int ticksRequired) {
-        super(soundPath, name, maxEnergy, perTick, 3, ticksRequired, MekanismUtils.getResource(ResourceType.GUI, "GuiBasicMachine.png"));
+    public TileEntityElectricMachine(String soundPath, MachineType type, int ticksRequired) {
+        super(soundPath, type, 3, ticksRequired, MekanismUtils.getResource(ResourceType.GUI, "GuiBasicMachine.png"));
         configComponent = new TileComponentConfig(this, TransmissionType.ITEM, TransmissionType.ENERGY);
 
         configComponent.addOutput(TransmissionType.ITEM, new SideData("None", EnumColor.GREY, InventoryUtils.EMPTY));

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityMachine.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityMachine.java
@@ -7,6 +7,7 @@ import mekanism.api.TileNetworkList;
 import mekanism.common.Upgrade;
 import mekanism.common.base.IRedstoneControl;
 import mekanism.common.base.IUpgradeTile;
+import mekanism.common.block.states.BlockStateMachine.MachineType;
 import mekanism.common.security.ISecurityTile;
 import mekanism.common.tile.component.TileComponentSecurity;
 import mekanism.common.tile.component.TileComponentUpgrade;
@@ -30,9 +31,9 @@ public abstract class TileEntityMachine extends TileEntityEffectsBlock implement
     public TileComponentUpgrade upgradeComponent;
     public TileComponentSecurity securityComponent = new TileComponentSecurity(this);
 
-    public TileEntityMachine(String sound, String name, double baseMaxEnergy, double baseEnergyUsage, int upgradeSlot) {
-        super(sound, name, baseMaxEnergy);
-        energyPerTick = BASE_ENERGY_PER_TICK = baseEnergyUsage;
+    public TileEntityMachine(String sound, MachineType type, int upgradeSlot) {
+        super(sound, type.getBlockName(), type.getStorage());
+        energyPerTick = BASE_ENERGY_PER_TICK = type.getUsage();
 
         upgradeComponent = new TileComponentUpgrade(this, upgradeSlot);
         upgradeComponent.setSupported(Upgrade.MUFFLING);

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityOperationalMachine.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityOperationalMachine.java
@@ -5,6 +5,7 @@ import javax.annotation.Nonnull;
 import mekanism.api.TileNetworkList;
 import mekanism.common.Upgrade;
 import mekanism.common.base.IComparatorSupport;
+import mekanism.common.block.states.BlockStateMachine.MachineType;
 import mekanism.common.util.MekanismUtils;
 import net.minecraft.inventory.Container;
 import net.minecraft.nbt.NBTTagCompound;
@@ -18,8 +19,8 @@ public abstract class TileEntityOperationalMachine extends TileEntityMachine imp
 
     public int ticksRequired;
 
-    protected TileEntityOperationalMachine(String sound, String name, double baseMaxEnergy, double baseEnergyUsage, int upgradeSlot, int baseTicksRequired) {
-        super(sound, name, baseMaxEnergy, baseEnergyUsage, upgradeSlot);
+    protected TileEntityOperationalMachine(String sound, MachineType type, int upgradeSlot, int baseTicksRequired) {
+        super(sound, type, upgradeSlot);
         ticksRequired = BASE_TICKS_REQUIRED = baseTicksRequired;
     }
 

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityUpgradeableMachine.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityUpgradeableMachine.java
@@ -6,6 +6,7 @@ import mekanism.common.MekanismBlocks;
 import mekanism.common.Upgrade;
 import mekanism.common.base.IFactory.RecipeType;
 import mekanism.common.base.ITierUpgradeable;
+import mekanism.common.block.states.BlockStateMachine.MachineType;
 import mekanism.common.recipe.inputs.MachineInput;
 import mekanism.common.recipe.machines.MachineRecipe;
 import mekanism.common.recipe.outputs.MachineOutput;
@@ -20,12 +21,11 @@ public abstract class TileEntityUpgradeableMachine<INPUT extends MachineInput<IN
      * The foundation of all machines - a simple tile entity with a facing, active state, initialized state, sound effect, and animated texture.
      *
      * @param soundPath         - location of the sound effect
-     * @param name              - full name of this machine
-     * @param baseMaxEnergy     - how much energy this machine can store
+     * @param type              - the type of this machine
      * @param baseTicksRequired - how many ticks it takes to run a cycle
      */
-    public TileEntityUpgradeableMachine(String soundPath, String name, double baseMaxEnergy, double baseEnergyUsage, int upgradeSlot, int baseTicksRequired, ResourceLocation location) {
-        super(soundPath, name, baseMaxEnergy, baseEnergyUsage, upgradeSlot, baseTicksRequired, location);
+    public TileEntityUpgradeableMachine(String soundPath, MachineType type, int upgradeSlot, int baseTicksRequired, ResourceLocation location) {
+        super(soundPath, type, upgradeSlot, baseTicksRequired, location);
     }
 
     @Override

--- a/src/main/java/mekanism/generators/common/block/BlockReactor.java
+++ b/src/main/java/mekanism/generators/common/block/BlockReactor.java
@@ -137,7 +137,7 @@ public abstract class BlockReactor extends Block implements ITileEntityProvider 
 
         if (tileEntity instanceof TileEntityReactorLogicAdapter) {
             if (!entityplayer.isSneaking()) {
-                entityplayer.openGui(MekanismGenerators.instance, BlockStateReactor.ReactorBlockType.get(this, metadata).guiId, world, pos.getX(), pos.getY(), pos.getZ());
+                entityplayer.openGui(MekanismGenerators.instance, ReactorBlockType.get(this, metadata).guiId, world, pos.getX(), pos.getY(), pos.getZ());
                 return true;
             }
         }
@@ -146,7 +146,7 @@ public abstract class BlockReactor extends Block implements ITileEntityProvider 
 
     @Override
     public void getSubBlocks(CreativeTabs creativetabs, NonNullList<ItemStack> list) {
-        for (BlockStateReactor.ReactorBlockType type : BlockStateReactor.ReactorBlockType.values()) {
+        for (ReactorBlockType type : ReactorBlockType.values()) {
             if (type.blockType == getReactorBlock()) {
                 list.add(new ItemStack(this, 1, type.meta));
             }
@@ -238,7 +238,7 @@ public abstract class BlockReactor extends Block implements ITileEntityProvider 
 
     @Override
     public boolean canConnectRedstone(IBlockState state, IBlockAccess world, BlockPos pos, EnumFacing side) {
-        ReactorBlockType type = BlockStateReactor.ReactorBlockType.get(this, state.getBlock().getMetaFromState(state));
+        ReactorBlockType type = ReactorBlockType.get(this, state.getBlock().getMetaFromState(state));
         return type == ReactorBlockType.REACTOR_LOGIC_ADAPTER;
     }
 

--- a/src/main/java/mekanism/generators/common/block/states/BlockStateGenerator.java
+++ b/src/main/java/mekanism/generators/common/block/states/BlockStateGenerator.java
@@ -109,18 +109,18 @@ public class BlockStateGenerator extends ExtendedBlockState {
         public boolean activable;
         public boolean hasRedstoneOutput;
 
-        GeneratorType(GeneratorBlock block, int i, String s, int j, double k, Supplier<TileEntity> tileClass, boolean model, Predicate<EnumFacing> predicate,
+        GeneratorType(GeneratorBlock block, int m, String name, int gui, double energy, Supplier<TileEntity> tileClass, boolean model, Predicate<EnumFacing> predicate,
               boolean hasActiveTexture) {
-            this(block, i, s, j, k, tileClass, model, predicate, hasActiveTexture, false);
+            this(block, m, name, gui, energy, tileClass, model, predicate, hasActiveTexture, false);
         }
 
-        GeneratorType(GeneratorBlock block, int i, String s, int j, double k, Supplier<TileEntity> tileClass, boolean model, Predicate<EnumFacing> predicate,
+        GeneratorType(GeneratorBlock block, int m, String name, int gui, double energy, Supplier<TileEntity> tileClass, boolean model, Predicate<EnumFacing> predicate,
               boolean hasActiveTexture, boolean hasRedstoneOutput) {
             blockType = block;
-            meta = i;
-            blockName = s;
-            guiId = j;
-            maxEnergy = k;
+            meta = m;
+            blockName = name;
+            guiId = gui;
+            maxEnergy = energy;
             tileEntitySupplier = tileClass;
             hasModel = model;
             facingPredicate = predicate;

--- a/src/main/java/mekanism/generators/common/item/ItemBlockGenerator.java
+++ b/src/main/java/mekanism/generators/common/item/ItemBlockGenerator.java
@@ -93,7 +93,7 @@ public class ItemBlockGenerator extends ItemBlock implements IEnergizedItem, ISp
         if (generatorType == null) {
             return "KillMe!";
         }
-        return getTranslationKey() + "." + generatorType.blockName;
+        return getTranslationKey() + "." + generatorType.getBlockName();
     }
 
     @Override

--- a/src/main/java/mekanism/generators/common/tile/TileEntityGenerator.java
+++ b/src/main/java/mekanism/generators/common/tile/TileEntityGenerator.java
@@ -55,7 +55,7 @@ public abstract class TileEntityGenerator extends TileEntityEffectsBlock impleme
             if (MekanismConfig.current().general.destroyDisabledBlocks.val()) {
                 GeneratorType type = BlockStateGenerator.GeneratorType.get(getBlockType(), getBlockMetadata());
                 if (type != null && !type.isEnabled()) {
-                    Mekanism.logger.info("Destroying generator of type '" + type.blockName + "' at coords " + Coord4D.get(this) + " as according to config.");
+                    Mekanism.logger.info("Destroying generator of type '" + type.getBlockName() + "' at coords " + Coord4D.get(this) + " as according to config.");
                     world.setBlockToAir(getPos());
                     return;
                 }

--- a/src/main/java/mekanism/generators/common/tile/TileEntityGenerator.java
+++ b/src/main/java/mekanism/generators/common/tile/TileEntityGenerator.java
@@ -13,7 +13,6 @@ import mekanism.common.tile.component.TileComponentSecurity;
 import mekanism.common.tile.prefab.TileEntityEffectsBlock;
 import mekanism.common.util.CableUtils;
 import mekanism.common.util.MekanismUtils;
-import mekanism.generators.common.block.states.BlockStateGenerator;
 import mekanism.generators.common.block.states.BlockStateGenerator.GeneratorType;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumFacing;
@@ -53,7 +52,7 @@ public abstract class TileEntityGenerator extends TileEntityEffectsBlock impleme
         super.onUpdate();
         if (!world.isRemote) {
             if (MekanismConfig.current().general.destroyDisabledBlocks.val()) {
-                GeneratorType type = BlockStateGenerator.GeneratorType.get(getBlockType(), getBlockMetadata());
+                GeneratorType type = GeneratorType.get(getBlockType(), getBlockMetadata());
                 if (type != null && !type.isEnabled()) {
                     Mekanism.logger.info("Destroying generator of type '" + type.getBlockName() + "' at coords " + Coord4D.get(this) + " as according to config.");
                     world.setBlockToAir(getPos());


### PR DESCRIPTION
## Changes proposed in this pull request:
- Use Generics in more places when interacting with recipes
- Removed Recipe oldRecipeName as I was incorrect about that having actually been needed.
- Pass machine type to super constructors for Machine Tile's rather than passing three pieces of the type up each time. Improves readability. Only noteable changes about that are:
  - Factory now sets base energy usage and storage is overwritten at end of constructor so probably doesn't matter
  - Electrolytic separator now sets usage instead of passing zero. This still seems to work properly and doesn't break anything.