### PR TITLE
Check ItemStack NBT for comparison in more places

### DIFF
--- a/src/main/java/mekanism/api/infuse/InfuseRegistry.java
+++ b/src/main/java/mekanism/api/infuse/InfuseRegistry.java
@@ -3,6 +3,7 @@ package mekanism.api.infuse;
 import java.util.HashMap;
 import java.util.Map;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.items.ItemHandlerHelper;
 
 /**
  * Use this class to add a new object that registers as an infuse object.
@@ -82,7 +83,7 @@ public class InfuseRegistry {
      */
     public static InfuseObject getObject(ItemStack itemStack) {
         for (Map.Entry<ItemStack, InfuseObject> obj : infuseObjects.entrySet()) {
-            if (itemStack.isItemEqual(obj.getKey())) {
+            if (ItemHandlerHelper.canItemStacksStack(obj.getKey(), itemStack)) {
                 return obj.getValue();
             }
         }

--- a/src/main/java/mekanism/client/gui/GuiFormulaicAssemblicator.java
+++ b/src/main/java/mekanism/client/gui/GuiFormulaicAssemblicator.java
@@ -33,6 +33,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+import net.minecraftforge.items.ItemHandlerHelper;
 import org.lwjgl.opengl.GL11;
 
 @SideOnly(Side.CLIENT)
@@ -164,7 +165,7 @@ public class GuiFormulaicAssemblicator extends GuiMekanismTile<TileEntityFormula
 
                     int guiX = guiWidth + slot.xPos;
                     int guiY = guiHeight + slot.yPos;
-                    if (slot.getStack().isEmpty() || !slot.getStack().isItemEqual(stack)) {
+                    if (slot.getStack().isEmpty() || !ItemHandlerHelper.canItemStacksStack(slot.getStack(), stack)) {
                         drawGradientRect(guiX, guiY, guiX + 16, guiY + 16, -2137456640, -2137456640);
                     }
 

--- a/src/main/java/mekanism/common/base/IFactory.java
+++ b/src/main/java/mekanism/common/base/IFactory.java
@@ -30,6 +30,7 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.IStringSerializable;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundEvent;
+import net.minecraftforge.items.ItemHandlerHelper;
 
 /**
  * Internal interface for managing various Factory types.
@@ -163,11 +164,10 @@ public interface IFactory {
             } else if (this == INFUSING) {
                 if (infuse.getType() != null) {
                     return RecipeHandler.getMetallurgicInfuserRecipe(new InfusionInput(infuse, slotStack));
-                } else {
-                    for (Entry<InfusionInput, MetallurgicInfuserRecipe> entry : Recipe.METALLURGIC_INFUSER.get().entrySet()) {
-                        if (entry.getKey().inputStack.isItemEqual(slotStack)) {
-                            return entry.getValue();
-                        }
+                }
+                for (Entry<InfusionInput, MetallurgicInfuserRecipe> entry : Recipe.METALLURGIC_INFUSER.get().entrySet()) {
+                    if (ItemHandlerHelper.canItemStacksStack(entry.getKey().inputStack, slotStack)) {
+                        return entry.getValue();
                     }
                 }
             }

--- a/src/main/java/mekanism/common/inventory/InventoryBin.java
+++ b/src/main/java/mekanism/common/inventory/InventoryBin.java
@@ -7,6 +7,7 @@ import mekanism.common.util.ItemDataUtils;
 import mekanism.common.util.StackUtils;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.items.ItemHandlerHelper;
 
 public class InventoryBin {
 
@@ -66,7 +67,7 @@ public class InventoryBin {
         if (getItemType().isEmpty()) {
             return true;
         }
-        return stack.isItemEqual(getItemType()) && ItemStack.areItemStackTagsEqual(stack, getItemType());
+        return ItemHandlerHelper.canItemStacksStack(stack, getItemType());
     }
 
     public int getMaxStorage() {

--- a/src/main/java/mekanism/common/inventory/container/ContainerFactory.java
+++ b/src/main/java/mekanism/common/inventory/container/ContainerFactory.java
@@ -1,6 +1,5 @@
 package mekanism.common.inventory.container;
 
-import java.util.Arrays;
 import javax.annotation.Nonnull;
 import mekanism.api.infuse.InfuseRegistry;
 import mekanism.common.base.IFactory.RecipeType;
@@ -15,6 +14,7 @@ import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.items.ItemHandlerHelper;
 
 public class ContainerFactory extends ContainerMekanism<TileEntityFactory> {
 
@@ -69,7 +69,7 @@ public class ContainerFactory extends ContainerMekanism<TileEntityFactory> {
                 if (!mergeItemStack(slotStack, tileEntity.inventory.size() - 1, inventorySlots.size(), true)) {
                     return ItemStack.EMPTY;
                 }
-            } else if (slotID != 1 && slotID != 2 && isProperMachine(slotStack) && !slotStack.isItemEqual(tileEntity.getMachineStack())) {
+            } else if (slotID != 1 && slotID != 2 && isProperMachine(slotStack) && !ItemHandlerHelper.canItemStacksStack(slotStack, tileEntity.getMachineStack())) {
                 if (!mergeItemStack(slotStack, 1, 2, false)) {
                     return ItemStack.EMPTY;
                 }
@@ -138,7 +138,11 @@ public class ContainerFactory extends ContainerMekanism<TileEntityFactory> {
 
     public boolean isProperMachine(ItemStack itemStack) {
         if (!itemStack.isEmpty() && itemStack.getItem() instanceof ItemBlockMachine) {
-            return Arrays.stream(RecipeType.values()).findFirst().filter(type -> itemStack.isItemEqual(type.getStack())).isPresent();
+            for (RecipeType type : RecipeType.values()) {
+                if (ItemHandlerHelper.canItemStacksStack(itemStack, type.getStack())) {
+                    return true;
+                }
+            }
         }
         return false;
     }

--- a/src/main/java/mekanism/common/inventory/container/ContainerMetallurgicInfuser.java
+++ b/src/main/java/mekanism/common/inventory/container/ContainerMetallurgicInfuser.java
@@ -13,6 +13,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.items.ItemHandlerHelper;
 
 public class ContainerMetallurgicInfuser extends ContainerMekanism<TileEntityMetallurgicInfuser> {
 
@@ -70,7 +71,12 @@ public class ContainerMetallurgicInfuser extends ContainerMekanism<TileEntityMet
         if (tileEntity.infuseStored.getType() != null) {
             return RecipeHandler.getMetallurgicInfuserRecipe(new InfusionInput(tileEntity.infuseStored, itemStack)) != null;
         }
-        return Recipe.METALLURGIC_INFUSER.get().keySet().stream().anyMatch(input -> input.inputStack.isItemEqual(itemStack));
+        for (InfusionInput input : Recipe.METALLURGIC_INFUSER.get().keySet()) {
+            if (ItemHandlerHelper.canItemStacksStack(input.inputStack, itemStack)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/mekanism/common/item/ItemAtomicDisassembler.java
+++ b/src/main/java/mekanism/common/item/ItemAtomicDisassembler.java
@@ -41,6 +41,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.util.Constants.WorldEvents;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+import net.minecraftforge.items.ItemHandlerHelper;
 
 public class ItemAtomicDisassembler extends ItemEnergized {
 
@@ -340,12 +341,13 @@ public class ItemAtomicDisassembler extends ItemEnergized {
         }
 
         private final EntityPlayer player;
-        public World world;
-        public ItemStack stack;
-        public Coord4D location;
-        public Set<Coord4D> found = new HashSet<>();
-        RayTraceResult rayTraceResult;
-        private Block startBlock;
+        public final World world;
+        public final ItemStack stack;
+        public final Coord4D location;
+        public final Set<Coord4D> found = new HashSet<>();
+        private final RayTraceResult rayTraceResult;
+        private final Block startBlock;
+        private final boolean isWood;
 
         public Finder(EntityPlayer p, ItemStack s, Coord4D loc, RayTraceResult traceResult) {
             player = p;
@@ -354,6 +356,7 @@ public class ItemAtomicDisassembler extends ItemEnergized {
             location = loc;
             startBlock = loc.getBlock(world);
             rayTraceResult = traceResult;
+            isWood = OreDictCache.getOreDictName(stack).contains("logWood");
         }
 
         public void loop(Coord4D pointer) {
@@ -365,8 +368,7 @@ public class ItemAtomicDisassembler extends ItemEnergized {
                 Coord4D coord = pointer.offset(side);
                 ItemStack blockStack = coord.getBlock(world).getPickBlock(coord.getBlockState(world), rayTraceResult, world, coord.getPos(), player);
                 if (coord.exists(world) && checkID(coord.getBlock(world)) &&
-                    (stack.isItemEqual(blockStack) || (coord.getBlock(world) == startBlock && OreDictCache.getOreDictName(stack).contains("logWood")
-                                                       && coord.getBlockMeta(world) % 4 == stack.getItemDamage() % 4))) {
+                    (ItemHandlerHelper.canItemStacksStack(stack, blockStack) || (coord.getBlock(world) == startBlock && isWood && coord.getBlockMeta(world) % 4 == stack.getItemDamage() % 4))) {
                     loop(coord);
                 }
             }

--- a/src/main/java/mekanism/common/recipe/BinRecipe.java
+++ b/src/main/java/mekanism/common/recipe/BinRecipe.java
@@ -17,6 +17,7 @@ import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.PlayerEvent.ItemCraftedEvent;
+import net.minecraftforge.items.ItemHandlerHelper;
 import net.minecraftforge.registries.IForgeRegistryEntry;
 
 public class BinRecipe extends IForgeRegistryEntry.Impl<IRecipe> implements IRecipe {
@@ -80,7 +81,7 @@ public class BinRecipe extends IForgeRegistryEntry.Impl<IRecipe> implements IRec
 
         if (!addStack.isEmpty()) {
             if (!(addStack.getItem() instanceof ItemProxy)) {
-                if (!binInv.getItemType().isEmpty() && !binInv.getItemType().isItemEqual(addStack)) {
+                if (!binInv.getItemType().isEmpty() && !ItemHandlerHelper.canItemStacksStack(binInv.getItemType(), addStack)) {
                     return ItemStack.EMPTY;
                 }
                 binInv.add(addStack);

--- a/src/main/java/mekanism/common/recipe/ingredients/ItemStackMekIngredient.java
+++ b/src/main/java/mekanism/common/recipe/ingredients/ItemStackMekIngredient.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
 import net.minecraft.item.ItemStack;
+import net.minecraftforge.items.ItemHandlerHelper;
 
 public class ItemStackMekIngredient implements IMekanismIngredient<ItemStack> {
 
@@ -27,7 +28,7 @@ public class ItemStackMekIngredient implements IMekanismIngredient<ItemStack> {
 
     @Override
     public boolean contains(@Nonnull ItemStack stack) {
-        return ItemStack.areItemStacksEqual(this.stack, stack);
+        return ItemHandlerHelper.canItemStacksStack(this.stack, stack);
     }
 
     @Override

--- a/src/main/java/mekanism/common/recipe/outputs/ChanceOutput.java
+++ b/src/main/java/mekanism/common/recipe/outputs/ChanceOutput.java
@@ -4,6 +4,7 @@ import java.util.Random;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.NonNullList;
+import net.minecraftforge.items.ItemHandlerHelper;
 
 public class ChanceOutput extends MachineOutput<ChanceOutput> {
 
@@ -49,33 +50,28 @@ public class ChanceOutput extends MachineOutput<ChanceOutput> {
 
     public boolean applyOutputs(NonNullList<ItemStack> inventory, int primaryIndex, int secondaryIndex, boolean doEmit) {
         if (hasPrimary()) {
-            ItemStack primaryStack = inventory.get(primaryIndex);
-            if (primaryStack.isEmpty()) {
-                if (doEmit) {
-                    inventory.set(primaryIndex, primaryOutput.copy());
-                }
-            } else if (primaryStack.isItemEqual(primaryOutput) && primaryStack.getCount() + primaryOutput.getCount() <= primaryStack.getMaxStackSize()) {
-                if (doEmit) {
-                    primaryStack.grow(primaryOutput.getCount());
-                }
-            } else {
+            if (applyOutputs(inventory, primaryIndex, doEmit, primaryOutput)) {
                 return false;
             }
         }
-
         if (hasSecondary() && (!doEmit || checkSecondary())) {
-            ItemStack secondaryStack = inventory.get(secondaryIndex);
-            if (secondaryStack.isEmpty()) {
-                if (doEmit) {
-                    inventory.set(secondaryIndex, secondaryOutput.copy());
-                }
-            } else if (secondaryStack.isItemEqual(secondaryOutput) && secondaryStack.getCount() + primaryOutput.getCount() <= secondaryStack.getMaxStackSize()) {
-                if (doEmit) {
-                    secondaryStack.grow(secondaryOutput.getCount());
-                }
-            } else {
-                return false;
+            return !applyOutputs(inventory, secondaryIndex, doEmit, secondaryOutput);
+        }
+        return true;
+    }
+
+    private boolean applyOutputs(NonNullList<ItemStack> inventory, int index, boolean doEmit, ItemStack output) {
+        ItemStack stack = inventory.get(index);
+        if (stack.isEmpty()) {
+            if (doEmit) {
+                inventory.set(index, output.copy());
             }
+            return false;
+        } else if (ItemHandlerHelper.canItemStacksStack(stack, output) && stack.getCount() + output.getCount() <= stack.getMaxStackSize()) {
+            if (doEmit) {
+                stack.grow(output.getCount());
+            }
+            return false;
         }
         return true;
     }

--- a/src/main/java/mekanism/common/recipe/outputs/ItemStackOutput.java
+++ b/src/main/java/mekanism/common/recipe/outputs/ItemStackOutput.java
@@ -3,6 +3,7 @@ package mekanism.common.recipe.outputs;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.NonNullList;
+import net.minecraftforge.items.ItemHandlerHelper;
 
 public class ItemStackOutput extends MachineOutput<ItemStackOutput> {
 
@@ -27,7 +28,7 @@ public class ItemStackOutput extends MachineOutput<ItemStackOutput> {
                 inventory.set(index, output.copy());
             }
             return true;
-        } else if (stack.isItemEqual(output) && stack.getCount() + output.getCount() <= stack.getMaxStackSize()) {
+        } else if (ItemHandlerHelper.canItemStacksStack(stack, output) && stack.getCount() + output.getCount() <= stack.getMaxStackSize()) {
             if (doEmit) {
                 stack.grow(output.getCount());
             }

--- a/src/main/java/mekanism/common/recipe/outputs/PressurizedOutput.java
+++ b/src/main/java/mekanism/common/recipe/outputs/PressurizedOutput.java
@@ -5,6 +5,7 @@ import mekanism.api.gas.GasTank;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.NonNullList;
+import net.minecraftforge.items.ItemHandlerHelper;
 
 public class PressurizedOutput extends MachineOutput<PressurizedOutput> {
 
@@ -30,8 +31,8 @@ public class PressurizedOutput extends MachineOutput<PressurizedOutput> {
     }
 
     public boolean canAddProducts(NonNullList<ItemStack> inventory, int index) {
-        return inventory.get(index).isEmpty() ||
-               (inventory.get(index).isItemEqual(itemOutput) && inventory.get(index).getCount() + itemOutput.getCount() <= inventory.get(index).getMaxStackSize());
+        ItemStack stack = inventory.get(index);
+        return stack.isEmpty() || (ItemHandlerHelper.canItemStacksStack(stack, itemOutput) && stack.getCount() + itemOutput.getCount() <= stack.getMaxStackSize());
     }
 
     public void fillTank(GasTank tank) {
@@ -39,10 +40,11 @@ public class PressurizedOutput extends MachineOutput<PressurizedOutput> {
     }
 
     public void addProducts(NonNullList<ItemStack> inventory, int index) {
-        if (inventory.get(index).isEmpty()) {
+        ItemStack stack = inventory.get(index);
+        if (stack.isEmpty()) {
             inventory.set(index, itemOutput.copy());
-        } else if (inventory.get(index).isItemEqual(itemOutput)) {
-            inventory.get(index).grow(itemOutput.getCount());
+        } else if (ItemHandlerHelper.canItemStacksStack(stack, itemOutput)) {
+            stack.grow(itemOutput.getCount());
         }
     }
 

--- a/src/main/java/mekanism/common/tile/TileEntityBin.java
+++ b/src/main/java/mekanism/common/tile/TileEntityBin.java
@@ -41,6 +41,7 @@ import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
+import net.minecraftforge.items.ItemHandlerHelper;
 
 public class TileEntityBin extends TileEntityBasicBlock implements ISidedInventory, IActiveState, IConfigurable, ITierUpgradeable, IComparatorSupport {
 
@@ -120,7 +121,7 @@ public class TileEntityBin extends TileEntityBasicBlock implements ISidedInvento
         if (itemType.isEmpty()) {
             return true;
         }
-        return stack.isItemEqual(itemType) && ItemStack.areItemStackTagsEqual(stack, itemType);
+        return ItemHandlerHelper.canItemStacksStack(itemType, stack);
     }
 
     public ItemStack add(ItemStack stack, boolean simulate) {

--- a/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
+++ b/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
@@ -372,8 +372,9 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
             return ItemStack.EMPTY;
         }
         for (int i = 0; i < 27; i++) {
-            if (!inventory.get(i).isEmpty() && inventory.get(i).isItemEqual(filter.replaceStack)) {
-                inventory.get(i).shrink(1);
+            ItemStack stack = inventory.get(i);
+            if (!stack.isEmpty() && stack.isItemEqual(filter.replaceStack)) {
+                stack.shrink(1);
                 return StackUtils.size(filter.replaceStack, 1);
             }
         }
@@ -456,15 +457,15 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
             return;
         }
 
-        stacks:
         for (ItemStack stack : stacks) {
             for (int i = 0; i < 27; i++) {
-                if (inventory.get(i).isEmpty()) {
+                ItemStack currentStack = inventory.get(i);
+                if (currentStack.isEmpty()) {
                     inventory.set(i, stack);
-                    continue stacks;
-                } else if (inventory.get(i).isItemEqual(stack) && inventory.get(i).getCount() + stack.getCount() <= stack.getMaxStackSize()) {
-                    inventory.get(i).grow(stack.getCount());
-                    continue stacks;
+                    break;
+                } else if (ItemHandlerHelper.canItemStacksStack(currentStack, stack) && currentStack.getCount() + stack.getCount() <= stack.getMaxStackSize()) {
+                    currentStack.grow(stack.getCount());
+                    break;
                 }
             }
         }

--- a/src/main/java/mekanism/common/tile/TileEntityFactory.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFactory.java
@@ -70,6 +70,7 @@ import net.minecraft.util.NonNullList;
 import net.minecraft.util.text.translation.I18n;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fml.common.FMLCommonHandler;
+import net.minecraftforge.items.ItemHandlerHelper;
 
 public class TileEntityFactory extends TileEntityMachine implements IComputerIntegration, ISideConfiguration, IGasHandler, ISpecialConfigData, ITierUpgradeable,
       ISustainedData, IComparatorSupport {
@@ -240,7 +241,7 @@ public class TileEntityFactory extends TileEntityMachine implements IComputerInt
                 RecipeType toSet = null;
 
                 for (RecipeType type : RecipeType.values()) {
-                    if (inventory.get(2).isItemEqual(type.getStack())) {
+                    if (ItemHandlerHelper.canItemStacksStack(inventory.get(2), type.getStack())) {
                         toSet = type;
                         break;
                     }

--- a/src/main/java/mekanism/common/tile/TileEntityMetallurgicInfuser.java
+++ b/src/main/java/mekanism/common/tile/TileEntityMetallurgicInfuser.java
@@ -40,6 +40,7 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.NonNullList;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fml.common.FMLCommonHandler;
+import net.minecraftforge.items.ItemHandlerHelper;
 import org.jetbrains.annotations.Contract;
 
 public class TileEntityMetallurgicInfuser extends TileEntityOperationalMachine implements IComputerIntegration, ISideConfiguration, IConfigCardAccess, ITierUpgradeable,
@@ -194,7 +195,11 @@ public class TileEntityMetallurgicInfuser extends TileEntityOperationalMachine i
             if (infuseStored.getType() != null) {
                 return RecipeHandler.getMetallurgicInfuserRecipe(new InfusionInput(infuseStored, itemstack)) != null;
             }
-            return Recipe.METALLURGIC_INFUSER.get().keySet().stream().anyMatch(input -> input.inputStack.isItemEqual(itemstack));
+            for (InfusionInput input : Recipe.METALLURGIC_INFUSER.get().keySet()) {
+                if (ItemHandlerHelper.canItemStacksStack(input.inputStack, itemstack)) {
+                    return true;
+                }
+            }
         } else if (slotID == 4) {
             return ChargeUtils.canBeDischarged(itemstack);
         }

--- a/src/main/java/mekanism/common/tile/TileEntityOredictionificator.java
+++ b/src/main/java/mekanism/common/tile/TileEntityOredictionificator.java
@@ -35,6 +35,7 @@ import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.util.Constants.NBT;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.items.CapabilityItemHandler;
+import net.minecraftforge.items.ItemHandlerHelper;
 import net.minecraftforge.oredict.OreDictionary;
 
 public class TileEntityOredictionificator extends TileEntityContainerBlock implements IRedstoneControl, ISpecialConfigData, ISustainedData, ISecurityTile {
@@ -65,22 +66,24 @@ public class TileEntityOredictionificator extends TileEntityContainerBlock imple
             }
 
             didProcess = false;
-            if (MekanismUtils.canFunction(this) && !inventory.get(0).isEmpty() && getValidName(inventory.get(0)) != null) {
-                ItemStack result = getResult(inventory.get(0));
+            ItemStack inputStack = inventory.get(0);
+            if (MekanismUtils.canFunction(this) && !inputStack.isEmpty() && getValidName(inputStack) != null) {
+                ItemStack result = getResult(inputStack);
                 if (!result.isEmpty()) {
-                    if (inventory.get(1).isEmpty()) {
-                        inventory.get(0).shrink(1);
-                        if (inventory.get(0).getCount() <= 0) {
+                    ItemStack outputStack = inventory.get(1);
+                    if (outputStack.isEmpty()) {
+                        inputStack.shrink(1);
+                        if (inputStack.getCount() <= 0) {
                             inventory.set(0, ItemStack.EMPTY);
                         }
                         inventory.set(1, result);
                         didProcess = true;
-                    } else if (inventory.get(1).isItemEqual(result) && inventory.get(1).getCount() < inventory.get(1).getMaxStackSize()) {
-                        inventory.get(0).shrink(1);
-                        if (inventory.get(0).getCount() <= 0) {
+                    } else if (ItemHandlerHelper.canItemStacksStack(outputStack, result) && outputStack.getCount() < outputStack.getMaxStackSize()) {
+                        inputStack.shrink(1);
+                        if (inputStack.getCount() <= 0) {
                             inventory.set(0, ItemStack.EMPTY);
                         }
-                        inventory.get(1).grow(1);
+                        outputStack.grow(1);
                         didProcess = true;
                     }
                     markDirty();

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityAdvancedElectricMachine.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityAdvancedElectricMachine.java
@@ -37,6 +37,7 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.NonNullList;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fml.common.FMLCommonHandler;
+import net.minecraftforge.items.ItemHandlerHelper;
 
 public abstract class TileEntityAdvancedElectricMachine<RECIPE extends AdvancedMachineRecipe<RECIPE>> extends
       TileEntityUpgradeableMachine<AdvancedMachineInput, ItemStackOutput, RECIPE> implements IGasHandler, ISustainedData {
@@ -188,7 +189,7 @@ public abstract class TileEntityAdvancedElectricMachine<RECIPE extends AdvancedM
             return itemstack.getItem() == MekanismItems.SpeedUpgrade || itemstack.getItem() == MekanismItems.EnergyUpgrade;
         } else if (slotID == 0) {
             for (AdvancedMachineInput input : getRecipes().keySet()) {
-                if (input.itemStack.isItemEqual(itemstack)) {
+                if (ItemHandlerHelper.canItemStacksStack(input.itemStack, itemstack)) {
                     return true;
                 }
             }

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityDoubleElectricMachine.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityDoubleElectricMachine.java
@@ -20,6 +20,7 @@ import mekanism.common.util.MekanismUtils.ResourceType;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.NonNullList;
+import net.minecraftforge.items.ItemHandlerHelper;
 
 public abstract class TileEntityDoubleElectricMachine<RECIPE extends DoubleMachineRecipe<RECIPE>> extends TileEntityUpgradeableMachine<DoubleMachineInput, ItemStackOutput, RECIPE> {
 
@@ -96,7 +97,7 @@ public abstract class TileEntityDoubleElectricMachine<RECIPE extends DoubleMachi
             return itemstack.getItem() == MekanismItems.SpeedUpgrade || itemstack.getItem() == MekanismItems.EnergyUpgrade;
         } else if (slotID == 0) {
             for (DoubleMachineInput input : getRecipes().keySet()) {
-                if (input.itemStack.isItemEqual(itemstack)) {
+                if (ItemHandlerHelper.canItemStacksStack(input.itemStack, itemstack)) {
                     return true;
                 }
             }
@@ -104,7 +105,7 @@ public abstract class TileEntityDoubleElectricMachine<RECIPE extends DoubleMachi
             return ChargeUtils.canBeDischarged(itemstack);
         } else if (slotID == 1) {
             for (DoubleMachineInput input : getRecipes().keySet()) {
-                if (input.extraStack.isItemEqual(itemstack)) {
+                if (ItemHandlerHelper.canItemStacksStack(input.extraStack, itemstack)) {
                     return true;
                 }
             }

--- a/src/main/java/mekanism/common/util/StackUtils.java
+++ b/src/main/java/mekanism/common/util/StackUtils.java
@@ -13,6 +13,7 @@ import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+import net.minecraftforge.items.ItemHandlerHelper;
 import net.minecraftforge.oredict.OreDictionary;
 
 public final class StackUtils {
@@ -80,10 +81,7 @@ public final class StackUtils {
         if (orig.isEmpty()) {
             return toAdd;
         }
-        if (toAdd.isEmpty()) {
-            return orig;
-        }
-        if (!orig.isItemEqual(toAdd) || !ItemStack.areItemStackTagsEqual(orig, toAdd)) {
+        if (toAdd.isEmpty() || !ItemHandlerHelper.canItemStacksStack(orig, toAdd)) {
             return orig;
         }
         return size(orig, Math.min(orig.getMaxStackSize(), orig.getCount() + toAdd.getCount()));
@@ -93,10 +91,7 @@ public final class StackUtils {
         if (orig.isEmpty()) {
             return ItemStack.EMPTY;
         }
-        if (toAdd.isEmpty()) {
-            return orig;
-        }
-        if (!orig.isItemEqual(toAdd) || !ItemStack.areItemStackTagsEqual(orig, toAdd)) {
+        if (toAdd.isEmpty() || !ItemHandlerHelper.canItemStacksStack(orig, toAdd)) {
             return orig;
         }
         int newSize = orig.getCount() + toAdd.getCount();


### PR DESCRIPTION
## Changes proposed in this pull request:
- Checks NBT in more places to see if two itemstacks are stackable/the same
- Also fixes Gas Conversions checking stack size for if two items are the same.

Remaining spots:
- Filters (I believe they are meant to not be "advanced" enough to support NBT though if this is not the case I can modify it to check the NBT
- The miner has a couple spots for the replace stack comparison which I believe is the same as the filters I mentioned above