### PR TITLE
Use sendToAllTracking for update packets

### DIFF
--- a/src/main/java/mekanism/api/MekanismAPI.java
+++ b/src/main/java/mekanism/api/MekanismAPI.java
@@ -18,7 +18,7 @@ public class MekanismAPI {
     /**
      * The version of the api classes - may not always match the mod's version
      */
-    public static final String API_VERSION = "9.7.5";
+    public static final String API_VERSION = "9.7.6";
 
     /**
      * Mekanism debug mode

--- a/src/main/java/mekanism/api/Range4D.java
+++ b/src/main/java/mekanism/api/Range4D.java
@@ -36,13 +36,7 @@ public class Range4D {
     }
 
     public Range4D(Coord4D coord) {
-        xMin = coord.x;
-        yMin = coord.y;
-        zMin = coord.z;
-        xMax = coord.x + 1;
-        yMax = coord.y + 1;
-        zMax = coord.z + 1;
-        dimensionId = coord.dimensionId;
+        this(coord.x, coord.y, coord.z, coord.x + 1, coord.y + 1, coord.z + 1, coord.dimensionId);
     }
 
     public static Range4D getChunkRange(EntityPlayer player) {
@@ -77,8 +71,17 @@ public class Range4D {
     }
 
     public boolean intersects(Range4D range) {
-        return (xMax + 1 - 1.E-05D > range.xMin) && (range.xMax + 1 - 1.E-05D > xMin) && (yMax + 1 - 1.E-05D > range.yMin) &&
-               (range.yMax + 1 - 1.E-05D > yMin) && (zMax + 1 - 1.E-05D > range.zMin) && (range.zMax + 1 - 1.E-05D > zMin);
+        return (xMax + 0.99999 > range.xMin) && (range.xMax + 0.99999 > xMin) && (yMax + 0.99999 > range.yMin) &&
+               (range.yMax + 0.99999 > yMin) && (zMax + 0.99999 > range.zMin) && (range.zMax + 0.99999 > zMin);
+    }
+
+    public boolean hasPlayerInRange(EntityPlayer player) {
+        //Ignore height for partial Cubic chunks support as range comparision gets used ignoring player height normally anyways
+        int radius = FMLCommonHandler.instance().getMinecraftServerInstance().getPlayerList().getViewDistance() * 16;
+        int playerX = (int) player.posX;
+        int playerZ = (int) player.posZ;
+        return player.dimension == dimensionId && (playerX + radius + 0.99999 > xMin) && (xMax + 0.99999 > playerX - radius) &&
+               (playerZ + radius + 0.99999 > zMin) && (zMax + 1 - 0.99999 > playerZ - radius);
     }
 
     @Override

--- a/src/main/java/mekanism/api/Range4D.java
+++ b/src/main/java/mekanism/api/Range4D.java
@@ -3,6 +3,7 @@ package mekanism.api;
 import java.util.HashSet;
 import java.util.Set;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 
 public class Range4D {
@@ -75,12 +76,15 @@ public class Range4D {
                (range.yMax + 0.99999 > yMin) && (zMax + 0.99999 > range.zMin) && (range.zMax + 0.99999 > zMin);
     }
 
-    public boolean hasPlayerInRange(EntityPlayer player) {
+    public boolean hasPlayerInRange(EntityPlayerMP player) {
+        if (player.dimension != dimensionId) {
+            return false;
+        }
         //Ignore height for partial Cubic chunks support as range comparision gets used ignoring player height normally anyways
-        int radius = FMLCommonHandler.instance().getMinecraftServerInstance().getPlayerList().getViewDistance() * 16;
+        int radius = player.server.getPlayerList().getViewDistance() * 16;
         int playerX = (int) player.posX;
         int playerZ = (int) player.posZ;
-        return player.dimension == dimensionId && (playerX + radius + 0.99999 > xMin) && (xMax + 0.99999 > playerX - radius) &&
+        return (playerX + radius + 0.99999 > xMin) && (xMax + 0.99999 > playerX - radius) &&
                (playerZ + radius + 0.99999 > zMin) && (zMax + 1 - 0.99999 > playerZ - radius);
     }
 

--- a/src/main/java/mekanism/client/gui/GuiDigitalMiner.java
+++ b/src/main/java/mekanism/client/gui/GuiDigitalMiner.java
@@ -98,10 +98,10 @@ public class GuiDigitalMiner extends GuiMekanismTile<TileEntityDigitalMiner> {
         super.actionPerformed(guibutton);
         if (guibutton.id == 0) {
             TileNetworkList data = TileNetworkList.withContents(3);
-            Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), data));
+            Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, data));
         } else if (guibutton.id == 1) {
             TileNetworkList data = TileNetworkList.withContents(4);
-            Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), data));
+            Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, data));
         } else if (guibutton.id == 2) {
             Mekanism.packetHandler.sendToServer(new DigitalMinerGuiMessage(MinerGuiPacket.SERVER, Coord4D.get(tileEntity), 0, 0, 0));
         }
@@ -226,25 +226,25 @@ public class GuiDigitalMiner extends GuiMekanismTile<TileEntityDigitalMiner> {
             if (xAxis >= 147 && xAxis <= 161 && yAxis >= 47 && yAxis <= 61) {
                 SoundHandler.playSound(SoundEvents.UI_BUTTON_CLICK);
                 TileNetworkList data = TileNetworkList.withContents(0);
-                Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), data));
+                Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, data));
             }
 
             if (xAxis >= 147 && xAxis <= 161 && yAxis >= 63 && yAxis <= 77) {
                 SoundHandler.playSound(SoundEvents.UI_BUTTON_CLICK);
                 TileNetworkList data = TileNetworkList.withContents(1);
-                Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), data));
+                Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, data));
             }
 
             if (xAxis >= 131 && xAxis <= 145 && yAxis >= 47 && yAxis <= 61) {
                 SoundHandler.playSound(SoundEvents.UI_BUTTON_CLICK);
                 TileNetworkList data = TileNetworkList.withContents(5);
-                Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), data));
+                Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, data));
             }
 
             if (xAxis >= 131 && xAxis <= 145 && yAxis >= 63 && yAxis <= 77) {
                 SoundHandler.playSound(SoundEvents.UI_BUTTON_CLICK);
                 TileNetworkList data = TileNetworkList.withContents(9);
-                Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), data));
+                Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, data));
             }
         }
     }

--- a/src/main/java/mekanism/client/gui/GuiDigitalMinerConfig.java
+++ b/src/main/java/mekanism/client/gui/GuiDigitalMinerConfig.java
@@ -190,7 +190,7 @@ public class GuiDigitalMinerConfig extends GuiMekanismTile<TileEntityDigitalMine
                         if (xAxis >= arrowX && xAxis <= arrowX + 10 && yAxis >= yStart + 14 && yAxis <= yStart + 20) {
                             // Process up button click
                             final TileNetworkList data = TileNetworkList.withContents(11, getFilterIndex() + i);
-                            Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), data));
+                            Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, data));
                             SoundHandler.playSound(SoundEvents.UI_BUTTON_CLICK);
                             return;
                         }
@@ -200,7 +200,7 @@ public class GuiDigitalMinerConfig extends GuiMekanismTile<TileEntityDigitalMine
                         if (xAxis >= arrowX && xAxis <= arrowX + 10 && yAxis >= yStart + 21 && yAxis <= yStart + 27) {
                             // Process down button click
                             final TileNetworkList data = TileNetworkList.withContents(12, getFilterIndex() + i);
-                            Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), data));
+                            Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, data));
                             SoundHandler.playSound(SoundEvents.UI_BUTTON_CLICK);
                             return;
                         }
@@ -248,7 +248,7 @@ public class GuiDigitalMinerConfig extends GuiMekanismTile<TileEntityDigitalMine
 
             if (xAxis >= 11 && xAxis <= 25 && yAxis >= 141 && yAxis <= 155) {
                 TileNetworkList data = TileNetworkList.withContents(10);
-                Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), data));
+                Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, data));
                 SoundHandler.playSound(SoundEvents.UI_BUTTON_CLICK);
             }
         }
@@ -524,7 +524,7 @@ public class GuiDigitalMinerConfig extends GuiMekanismTile<TileEntityDigitalMine
         if (!radiusField.getText().isEmpty()) {
             int toUse = Math.max(0, Math.min(Integer.parseInt(radiusField.getText()), MekanismConfig.current().general.digitalMinerMaxRadius.val()));
             TileNetworkList data = TileNetworkList.withContents(6, toUse);
-            Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), data));
+            Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, data));
             radiusField.setText("");
         }
     }
@@ -533,7 +533,7 @@ public class GuiDigitalMinerConfig extends GuiMekanismTile<TileEntityDigitalMine
         if (!minField.getText().isEmpty()) {
             int toUse = Math.max(0, Math.min(Integer.parseInt(minField.getText()), tileEntity.maxY));
             TileNetworkList data = TileNetworkList.withContents(7, toUse);
-            Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), data));
+            Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, data));
             minField.setText("");
         }
     }
@@ -542,7 +542,7 @@ public class GuiDigitalMinerConfig extends GuiMekanismTile<TileEntityDigitalMine
         if (!maxField.getText().isEmpty()) {
             int toUse = Math.max(tileEntity.minY, Math.min(Integer.parseInt(maxField.getText()), 255));
             TileNetworkList data = TileNetworkList.withContents(8, toUse);
-            Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), data));
+            Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, data));
             maxField.setText("");
         }
     }

--- a/src/main/java/mekanism/client/gui/GuiElectrolyticSeparator.java
+++ b/src/main/java/mekanism/client/gui/GuiElectrolyticSeparator.java
@@ -2,7 +2,6 @@ package mekanism.client.gui;
 
 import java.io.IOException;
 import java.util.Arrays;
-import mekanism.api.Coord4D;
 import mekanism.api.TileNetworkList;
 import mekanism.client.gui.element.GuiEnergyInfo;
 import mekanism.client.gui.element.GuiFluidGauge;
@@ -71,11 +70,11 @@ public class GuiElectrolyticSeparator extends GuiMekanismTile<TileEntityElectrol
         int yAxis = y - (height - ySize) / 2;
         if (xAxis > 8 && xAxis < 17 && yAxis > 73 && yAxis < 82) {
             TileNetworkList data = TileNetworkList.withContents((byte) 0);
-            Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), data));
+            Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, data));
             SoundHandler.playSound(SoundEvents.UI_BUTTON_CLICK);
         } else if (xAxis > 160 && xAxis < 169 && yAxis > 73 && yAxis < 82) {
             TileNetworkList data = TileNetworkList.withContents((byte) 1);
-            Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), data));
+            Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, data));
             SoundHandler.playSound(SoundEvents.UI_BUTTON_CLICK);
         }
     }

--- a/src/main/java/mekanism/client/gui/GuiFactory.java
+++ b/src/main/java/mekanism/client/gui/GuiFactory.java
@@ -2,7 +2,6 @@ package mekanism.client.gui;
 
 import java.io.IOException;
 import java.util.Arrays;
-import mekanism.api.Coord4D;
 import mekanism.api.TileNetworkList;
 import mekanism.api.gas.GasStack;
 import mekanism.api.infuse.InfuseType;
@@ -136,7 +135,7 @@ public class GuiFactory extends GuiMekanismTile<TileEntityFactory> {
                 ItemStack stack = mc.player.inventory.getItemStack();
                 if (!stack.isEmpty() && stack.getItem() instanceof ItemGaugeDropper) {
                     TileNetworkList data = TileNetworkList.withContents(1);
-                    Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), data));
+                    Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, data));
                     SoundHandler.playSound(SoundEvents.UI_BUTTON_CLICK);
                 }
             }

--- a/src/main/java/mekanism/client/gui/GuiFormulaicAssemblicator.java
+++ b/src/main/java/mekanism/client/gui/GuiFormulaicAssemblicator.java
@@ -2,7 +2,6 @@ package mekanism.client.gui;
 
 import java.io.IOException;
 import java.util.Arrays;
-import mekanism.api.Coord4D;
 import mekanism.api.TileNetworkList;
 import mekanism.client.gui.element.GuiEnergyInfo;
 import mekanism.client.gui.element.GuiPowerBar;
@@ -14,7 +13,7 @@ import mekanism.client.gui.element.GuiSlot.SlotOverlay;
 import mekanism.client.gui.element.GuiSlot.SlotType;
 import mekanism.client.gui.element.GuiTransporterConfigTab;
 import mekanism.client.gui.element.GuiUpgradeTab;
-import mekanism.client.render.MekanismRenderer;
+import mekanism.client.render.MekanismRenderHelper;
 import mekanism.client.sound.SoundHandler;
 import mekanism.common.Mekanism;
 import mekanism.common.inventory.container.ContainerFormulaicAssemblicator;
@@ -24,8 +23,6 @@ import mekanism.common.tile.TileEntityFormulaicAssemblicator;
 import mekanism.common.util.LangUtils;
 import mekanism.common.util.MekanismUtils;
 import mekanism.common.util.MekanismUtils.ResourceType;
-import net.minecraft.client.renderer.GlStateManager;
-import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.init.SoundEvents;
 import net.minecraft.inventory.Slot;
@@ -34,7 +31,6 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.items.ItemHandlerHelper;
-import org.lwjgl.opengl.GL11;
 
 @SideOnly(Side.CLIENT)
 public class GuiFormulaicAssemblicator extends GuiMekanismTile<TileEntityFormulaicAssemblicator> {
@@ -87,7 +83,6 @@ public class GuiFormulaicAssemblicator extends GuiMekanismTile<TileEntityFormula
     @Override
     protected void drawGuiContainerBackgroundLayer(float partialTick, int mouseX, int mouseY) {
         mc.renderEngine.bindTexture(getGuiLocation());
-        GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
         int guiWidth = (width - xSize) / 2;
         int guiHeight = (height - ySize) / 2;
         drawTexturedModalRect(guiWidth, guiHeight, 0, 0, xSize, ySize);
@@ -161,7 +156,7 @@ public class GuiFormulaicAssemblicator extends GuiMekanismTile<TileEntityFormula
 
                 if (!stack.isEmpty()) {
                     Slot slot = inventorySlots.inventorySlots.get(i + 20);
-                    GlStateManager.pushMatrix();
+                    MekanismRenderHelper renderHelper = new MekanismRenderHelper(true);
 
                     int guiX = guiWidth + slot.xPos;
                     int guiY = guiHeight + slot.yPos;
@@ -169,10 +164,9 @@ public class GuiFormulaicAssemblicator extends GuiMekanismTile<TileEntityFormula
                         drawGradientRect(guiX, guiY, guiX + 16, guiY + 16, -2137456640, -2137456640);
                     }
 
-                    RenderHelper.enableGUIStandardItemLighting();
+                    renderHelper.enableGUIStandardItemLighting();
                     itemRender.renderItemAndEffectIntoGUI(stack, guiX, guiY);
-                    MekanismRenderer.resetColor();
-                    GlStateManager.popMatrix();
+                    renderHelper.cleanup();
                 }
             }
         }
@@ -200,7 +194,7 @@ public class GuiFormulaicAssemblicator extends GuiMekanismTile<TileEntityFormula
                 if (xAxis >= 44 && xAxis <= 60 && yAxis >= 75 && yAxis <= 91) {
                     SoundHandler.playSound(SoundEvents.UI_BUTTON_CLICK);
                     TileNetworkList data = TileNetworkList.withContents(4);
-                    Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), data));
+                    Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, data));
                 }
 
                 if (tileEntity.isRecipe) {
@@ -208,20 +202,20 @@ public class GuiFormulaicAssemblicator extends GuiMekanismTile<TileEntityFormula
                         if (xAxis >= 7 && xAxis <= 21 && yAxis >= 45 && yAxis <= 59) {
                             SoundHandler.playSound(SoundEvents.UI_BUTTON_CLICK);
                             TileNetworkList data = TileNetworkList.withContents(1);
-                            Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), data));
+                            Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, data));
                         }
                     }
 
                     if (xAxis >= 71 && xAxis <= 87 && yAxis >= 75 && yAxis <= 91) {
                         SoundHandler.playSound(SoundEvents.UI_BUTTON_CLICK);
                         TileNetworkList data = TileNetworkList.withContents(2);
-                        Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), data));
+                        Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, data));
                     }
 
                     if (xAxis >= 89 && xAxis <= 105 && yAxis >= 75 && yAxis <= 91) {
                         SoundHandler.playSound(SoundEvents.UI_BUTTON_CLICK);
                         TileNetworkList data = TileNetworkList.withContents(3);
-                        Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), data));
+                        Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, data));
                     }
                 }
             }
@@ -230,13 +224,13 @@ public class GuiFormulaicAssemblicator extends GuiMekanismTile<TileEntityFormula
                 if (xAxis >= 107 && xAxis <= 123 && yAxis >= 75 && yAxis <= 91) {
                     SoundHandler.playSound(SoundEvents.UI_BUTTON_CLICK);
                     TileNetworkList data = TileNetworkList.withContents(0);
-                    Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), data));
+                    Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, data));
                 }
 
                 if (xAxis >= 26 && xAxis <= 42 && yAxis >= 75 && yAxis <= 91) {
                     SoundHandler.playSound(SoundEvents.UI_BUTTON_CLICK);
                     TileNetworkList data = TileNetworkList.withContents(5);
-                    Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), data));
+                    Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, data));
                 }
             }
         }

--- a/src/main/java/mekanism/client/gui/GuiFormulaicAssemblicator.java
+++ b/src/main/java/mekanism/client/gui/GuiFormulaicAssemblicator.java
@@ -13,7 +13,7 @@ import mekanism.client.gui.element.GuiSlot.SlotOverlay;
 import mekanism.client.gui.element.GuiSlot.SlotType;
 import mekanism.client.gui.element.GuiTransporterConfigTab;
 import mekanism.client.gui.element.GuiUpgradeTab;
-import mekanism.client.render.MekanismRenderHelper;
+import mekanism.client.render.MekanismRenderer;
 import mekanism.client.sound.SoundHandler;
 import mekanism.common.Mekanism;
 import mekanism.common.inventory.container.ContainerFormulaicAssemblicator;
@@ -23,6 +23,8 @@ import mekanism.common.tile.TileEntityFormulaicAssemblicator;
 import mekanism.common.util.LangUtils;
 import mekanism.common.util.MekanismUtils;
 import mekanism.common.util.MekanismUtils.ResourceType;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.init.SoundEvents;
 import net.minecraft.inventory.Slot;
@@ -156,7 +158,7 @@ public class GuiFormulaicAssemblicator extends GuiMekanismTile<TileEntityFormula
 
                 if (!stack.isEmpty()) {
                     Slot slot = inventorySlots.inventorySlots.get(i + 20);
-                    MekanismRenderHelper renderHelper = new MekanismRenderHelper(true);
+                    GlStateManager.pushMatrix();
 
                     int guiX = guiWidth + slot.xPos;
                     int guiY = guiHeight + slot.yPos;
@@ -164,9 +166,10 @@ public class GuiFormulaicAssemblicator extends GuiMekanismTile<TileEntityFormula
                         drawGradientRect(guiX, guiY, guiX + 16, guiY + 16, -2137456640, -2137456640);
                     }
 
-                    renderHelper.enableGUIStandardItemLighting();
+                    RenderHelper.enableGUIStandardItemLighting();
                     itemRender.renderItemAndEffectIntoGUI(stack, guiX, guiY);
-                    renderHelper.cleanup();
+                    MekanismRenderer.resetColor();
+                    GlStateManager.popMatrix();
                 }
             }
         }

--- a/src/main/java/mekanism/client/gui/GuiGasTank.java
+++ b/src/main/java/mekanism/client/gui/GuiGasTank.java
@@ -1,7 +1,6 @@
 package mekanism.client.gui;
 
 import java.io.IOException;
-import mekanism.api.Coord4D;
 import mekanism.api.TileNetworkList;
 import mekanism.client.gui.element.GuiRedstoneControl;
 import mekanism.client.gui.element.GuiSecurityTab;
@@ -78,7 +77,7 @@ public class GuiGasTank extends GuiMekanismTile<TileEntityGasTank> {
         int yAxis = y - (height - ySize) / 2;
         if (xAxis > 160 && xAxis < 169 && yAxis > 73 && yAxis < 82) {
             TileNetworkList data = TileNetworkList.withContents(0);
-            Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), data));
+            Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, data));
             SoundHandler.playSound(SoundEvents.UI_BUTTON_CLICK);
         }
     }

--- a/src/main/java/mekanism/client/gui/GuiLaserAmplifier.java
+++ b/src/main/java/mekanism/client/gui/GuiLaserAmplifier.java
@@ -1,7 +1,6 @@
 package mekanism.client.gui;
 
 import java.io.IOException;
-import mekanism.api.Coord4D;
 import mekanism.api.TileNetworkList;
 import mekanism.client.gui.element.GuiAmplifierTab;
 import mekanism.client.gui.element.GuiGauge.Type;
@@ -146,7 +145,7 @@ public class GuiLaserAmplifier extends GuiMekanismTile<TileEntityLaserAmplifier>
                 return;
             }
             TileNetworkList data = TileNetworkList.withContents(0, toUse);
-            Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), data));
+            Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, data));
             minField.setText("");
         }
     }
@@ -161,7 +160,7 @@ public class GuiLaserAmplifier extends GuiMekanismTile<TileEntityLaserAmplifier>
                 return;
             }
             TileNetworkList data = TileNetworkList.withContents(1, toUse);
-            Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), data));
+            Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, data));
             maxField.setText("");
         }
     }
@@ -170,7 +169,7 @@ public class GuiLaserAmplifier extends GuiMekanismTile<TileEntityLaserAmplifier>
         if (!timerField.getText().isEmpty()) {
             int toUse = Math.max(0, Integer.parseInt(timerField.getText()));
             TileNetworkList data = TileNetworkList.withContents(2, toUse);
-            Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), data));
+            Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, data));
             timerField.setText("");
         }
     }

--- a/src/main/java/mekanism/client/gui/GuiLogisticalSorter.java
+++ b/src/main/java/mekanism/client/gui/GuiLogisticalSorter.java
@@ -202,7 +202,7 @@ public class GuiLogisticalSorter extends GuiMekanismTile<TileEntityLogisticalSor
                                 && yAxis <= yStart + 20) {
                                 // Process up button click
                                 final TileNetworkList data = TileNetworkList.withContents(3, getFilterIndex() + i);
-                                Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), data));
+                                Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, data));
                                 SoundHandler.playSound(SoundEvents.UI_BUTTON_CLICK);
                                 return;
                             }
@@ -212,7 +212,7 @@ public class GuiLogisticalSorter extends GuiMekanismTile<TileEntityLogisticalSor
                                 && yAxis <= yStart + 27) {
                                 // Process down button click
                                 final TileNetworkList data = TileNetworkList.withContents(4, getFilterIndex() + i);
-                                Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), data));
+                                Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, data));
                                 SoundHandler.playSound(SoundEvents.UI_BUTTON_CLICK);
                                 return;
                             }
@@ -243,21 +243,21 @@ public class GuiLogisticalSorter extends GuiMekanismTile<TileEntityLogisticalSor
             // Check for auto eject button
             if (xAxis >= 12 && xAxis <= 26 && yAxis >= 110 && yAxis <= 124) {
                 final TileNetworkList data = TileNetworkList.withContents(1);
-                Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), data));
+                Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, data));
                 SoundHandler.playSound(SoundEvents.UI_BUTTON_CLICK);
             }
 
             // Check for round robin button
             if (xAxis >= 12 && xAxis <= 26 && yAxis >= 84 && yAxis <= 98) {
                 final TileNetworkList data = TileNetworkList.withContents(2);
-                Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), data));
+                Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, data));
                 SoundHandler.playSound(SoundEvents.UI_BUTTON_CLICK);
             }
 
             // Check for single item button
             if (xAxis >= 12 && xAxis <= 26 && yAxis >= 58 && yAxis <= 72) {
                 final TileNetworkList data = TileNetworkList.withContents(5);
-                Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), data));
+                Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, data));
                 SoundHandler.playSound(SoundEvents.UI_BUTTON_CLICK);
             }
         }
@@ -269,7 +269,7 @@ public class GuiLogisticalSorter extends GuiMekanismTile<TileEntityLogisticalSor
         // Check for default colour button
         if (xAxis >= 13 && xAxis <= 29 && yAxis >= 137 && yAxis <= 153) {
             final TileNetworkList data = TileNetworkList.withContents(0, mouseBtn);
-            Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), data));
+            Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, data));
             SoundHandler.playSound(MekanismSounds.DING);
         }
     }

--- a/src/main/java/mekanism/client/gui/GuiMetallurgicInfuser.java
+++ b/src/main/java/mekanism/client/gui/GuiMetallurgicInfuser.java
@@ -2,7 +2,6 @@ package mekanism.client.gui;
 
 import java.io.IOException;
 import java.util.Arrays;
-import mekanism.api.Coord4D;
 import mekanism.api.TileNetworkList;
 import mekanism.client.gui.element.GuiEnergyInfo;
 import mekanism.client.gui.element.GuiPowerBar;
@@ -98,7 +97,7 @@ public class GuiMetallurgicInfuser extends GuiMekanismTile<TileEntityMetallurgic
             int yAxis = y - (height - ySize) / 2;
             if (xAxis > 148 && xAxis < 168 && yAxis > 73 && yAxis < 82) {
                 TileNetworkList data = TileNetworkList.withContents(0);
-                Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), data));
+                Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, data));
                 SoundHandler.playSound(SoundEvents.UI_BUTTON_CLICK);
             }
         }

--- a/src/main/java/mekanism/client/gui/GuiQuantumEntangloporter.java
+++ b/src/main/java/mekanism/client/gui/GuiQuantumEntangloporter.java
@@ -3,7 +3,6 @@ package mekanism.client.gui;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
 import mekanism.api.TileNetworkList;
 import mekanism.client.gui.element.GuiScrollList;
@@ -81,7 +80,7 @@ public class GuiQuantumEntangloporter extends GuiMekanismTile<TileEntityQuantumE
             return;
         }
         TileNetworkList data = TileNetworkList.withContents(0, freq, !privateMode);
-        Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), data));
+        Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, data));
     }
 
     public String getSecurity(Frequency freq) {
@@ -183,7 +182,7 @@ public class GuiQuantumEntangloporter extends GuiMekanismTile<TileEntityQuantumE
             if (selection != -1) {
                 Frequency freq = privateMode ? tileEntity.privateCache.get(selection) : tileEntity.publicCache.get(selection);
                 TileNetworkList data = TileNetworkList.withContents(1, freq.name, freq.publicFreq);
-                Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), data));
+                Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, data));
                 scrollList.clearSelection();
             }
         }

--- a/src/main/java/mekanism/client/gui/GuiResistiveHeater.java
+++ b/src/main/java/mekanism/client/gui/GuiResistiveHeater.java
@@ -3,7 +3,6 @@ package mekanism.client.gui;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
-import mekanism.api.Coord4D;
 import mekanism.api.TileNetworkList;
 import mekanism.client.gui.element.GuiEnergyInfo;
 import mekanism.client.gui.element.GuiHeatInfo;
@@ -100,7 +99,7 @@ public class GuiResistiveHeater extends GuiMekanismTile<TileEntityResistiveHeate
         if (!energyUsageField.getText().isEmpty()) {
             int toUse = Integer.parseInt(energyUsageField.getText());
             TileNetworkList data = TileNetworkList.withContents(toUse);
-            Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), data));
+            Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, data));
             energyUsageField.setText("");
         }
     }

--- a/src/main/java/mekanism/client/gui/GuiRotaryCondensentrator.java
+++ b/src/main/java/mekanism/client/gui/GuiRotaryCondensentrator.java
@@ -2,7 +2,6 @@ package mekanism.client.gui;
 
 import java.io.IOException;
 import java.util.Arrays;
-import mekanism.api.Coord4D;
 import mekanism.api.TileNetworkList;
 import mekanism.client.gui.element.GuiEnergyInfo;
 import mekanism.client.gui.element.GuiFluidGauge;
@@ -121,7 +120,7 @@ public class GuiRotaryCondensentrator extends GuiMekanismTile<TileEntityRotaryCo
             int yAxis = mouseY - (height - ySize) / 2;
             if (xAxis >= 4 && xAxis <= 22 && yAxis >= 4 && yAxis <= 22) {
                 TileNetworkList data = TileNetworkList.withContents(0);
-                Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), data));
+                Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, data));
                 SoundHandler.playSound(SoundEvents.UI_BUTTON_CLICK);
             }
         }

--- a/src/main/java/mekanism/client/gui/GuiSecurityDesk.java
+++ b/src/main/java/mekanism/client/gui/GuiSecurityDesk.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
 import mekanism.api.TileNetworkList;
 import mekanism.client.gui.element.GuiScrollList;
@@ -61,7 +60,7 @@ public class GuiSecurityDesk extends GuiMekanismTile<TileEntitySecurityDesk> {
             return;
         }
         TileNetworkList data = TileNetworkList.withContents(0, trusted);
-        Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), data));
+        Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, data));
     }
 
     public void updateButtons() {
@@ -123,7 +122,7 @@ public class GuiSecurityDesk extends GuiMekanismTile<TileEntitySecurityDesk> {
                     }
                 }
                 if (!data.isEmpty()) {
-                    Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), data));
+                    Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, data));
                 }
             }
         }
@@ -158,7 +157,7 @@ public class GuiSecurityDesk extends GuiMekanismTile<TileEntitySecurityDesk> {
             int selection = scrollList.getSelection();
             if (tileEntity.frequency != null && selection != -1) {
                 TileNetworkList data = TileNetworkList.withContents(1, tileEntity.frequency.trusted.get(selection));
-                Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), data));
+                Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, data));
                 scrollList.clearSelection();
             }
         }

--- a/src/main/java/mekanism/client/gui/GuiTeleporter.java
+++ b/src/main/java/mekanism/client/gui/GuiTeleporter.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
 import mekanism.api.TileNetworkList;
 import mekanism.client.ClientTickHandler;
@@ -272,7 +271,7 @@ public class GuiTeleporter extends GuiMekanismTile<TileEntityTeleporter> {
                 Frequency freq = privateMode ? getPrivateCache().get(selection) : getPublicCache().get(selection);
                 if (tileEntity != null) {
                     TileNetworkList data = TileNetworkList.withContents(1, freq.name, freq.publicFreq);
-                    Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), data));
+                    Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, data));
                 } else {
                     Mekanism.packetHandler.sendToServer(new PortableTeleporterMessage(PortableTeleporterPacketType.DEL_FREQ, currentHand, freq));
                     Mekanism.packetHandler.sendToServer(new PortableTeleporterMessage(PortableTeleporterPacketType.DATA_REQUEST, currentHand, null));
@@ -383,7 +382,7 @@ public class GuiTeleporter extends GuiMekanismTile<TileEntityTeleporter> {
         }
         if (tileEntity != null) {
             TileNetworkList data = TileNetworkList.withContents(0, freq, !privateMode);
-            Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), data));
+            Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, data));
         } else {
             Frequency newFreq = new Frequency(freq, null).setPublic(!privateMode);
             Mekanism.packetHandler.sendToServer(new PortableTeleporterMessage(PortableTeleporterPacketType.SET_FREQ, currentHand, newFreq));

--- a/src/main/java/mekanism/client/gui/element/GuiAmplifierTab.java
+++ b/src/main/java/mekanism/client/gui/element/GuiAmplifierTab.java
@@ -1,6 +1,5 @@
 package mekanism.client.gui.element;
 
-import mekanism.api.Coord4D;
 import mekanism.api.TileNetworkList;
 import mekanism.client.gui.IGuiWrapper;
 import mekanism.client.sound.SoundHandler;
@@ -58,7 +57,7 @@ public class GuiAmplifierTab extends GuiTileEntityElement<TileEntityLaserAmplifi
     @Override
     public void mouseClicked(int xAxis, int yAxis, int button) {
         if (button == 0 && inBounds(xAxis, yAxis)) {
-            Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), TileNetworkList.withContents(3)));
+            Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, TileNetworkList.withContents(3)));
             SoundHandler.playSound(SoundEvents.UI_BUTTON_CLICK);
         }
     }

--- a/src/main/java/mekanism/client/gui/element/GuiSortingTab.java
+++ b/src/main/java/mekanism/client/gui/element/GuiSortingTab.java
@@ -1,6 +1,5 @@
 package mekanism.client.gui.element;
 
-import mekanism.api.Coord4D;
 import mekanism.api.TileNetworkList;
 import mekanism.client.gui.IGuiWrapper;
 import mekanism.client.sound.SoundHandler;
@@ -58,7 +57,7 @@ public class GuiSortingTab extends GuiTileEntityElement<TileEntityFactory> {
     public void mouseClicked(int xAxis, int yAxis, int button) {
         if (button == 0 && inBounds(xAxis, yAxis)) {
             TileNetworkList data = TileNetworkList.withContents(0);
-            Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), data));
+            Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, data));
             SoundHandler.playSound(SoundEvents.UI_BUTTON_CLICK);
         }
     }

--- a/src/main/java/mekanism/common/PacketHandler.java
+++ b/src/main/java/mekanism/common/PacketHandler.java
@@ -7,6 +7,8 @@ import java.util.UUID;
 import javax.annotation.Nonnull;
 import mekanism.api.Coord4D;
 import mekanism.api.Range4D;
+import mekanism.api.TileNetworkList;
+import mekanism.common.base.ITileNetwork;
 import mekanism.common.config.MekanismConfig;
 import mekanism.common.network.PacketBoxBlacklist;
 import mekanism.common.network.PacketBoxBlacklist.BoxBlacklistMessage;
@@ -290,6 +292,10 @@ public class PacketHandler {
                 }
             }
         }
+    }
+
+    public <TILE extends TileEntity & ITileNetwork> void sendToAllTracking(TILE tile) {
+        sendToAllTracking(new TileEntityMessage(tile, tile.getNetworkedData(new TileNetworkList())), tile);
     }
 
     public void sendToAllTracking(IMessage message, TileEntity tile) {

--- a/src/main/java/mekanism/common/PacketHandler.java
+++ b/src/main/java/mekanism/common/PacketHandler.java
@@ -295,7 +295,7 @@ public class PacketHandler {
         MinecraftServer server = FMLCommonHandler.instance().getMinecraftServerInstance();
         if (server != null) {
             for (EntityPlayerMP player : server.getPlayerList().getPlayers()) {
-                if (player.dimension == range.dimensionId && Range4D.getChunkRange(player).intersects(range)) {
+                if (range.hasPlayerInRange(player)) {
                     sendTo(message, player);
                 }
             }

--- a/src/main/java/mekanism/common/PacketHandler.java
+++ b/src/main/java/mekanism/common/PacketHandler.java
@@ -7,7 +7,6 @@ import java.util.UUID;
 import javax.annotation.Nonnull;
 import mekanism.api.Coord4D;
 import mekanism.api.Range4D;
-import mekanism.api.TileNetworkList;
 import mekanism.common.base.ITileNetwork;
 import mekanism.common.config.MekanismConfig;
 import mekanism.common.network.PacketBoxBlacklist;
@@ -295,7 +294,7 @@ public class PacketHandler {
     }
 
     public <TILE extends TileEntity & ITileNetwork> void sendToAllTracking(TILE tile) {
-        sendToAllTracking(new TileEntityMessage(tile, tile.getNetworkedData(new TileNetworkList())), tile);
+        sendToAllTracking(new TileEntityMessage(tile), tile);
     }
 
     public void sendToAllTracking(IMessage message, TileEntity tile) {

--- a/src/main/java/mekanism/common/PacketHandler.java
+++ b/src/main/java/mekanism/common/PacketHandler.java
@@ -293,7 +293,7 @@ public class PacketHandler {
         }
     }
 
-    public <TILE extends TileEntity & ITileNetwork> void sendToAllTracking(TILE tile) {
+    public <TILE extends TileEntity & ITileNetwork> void sendUpdatePacket(TILE tile) {
         sendToAllTracking(new TileEntityMessage(tile), tile);
     }
 
@@ -307,12 +307,11 @@ public class PacketHandler {
     }
 
     public void sendToAllTracking(IMessage message, int dimension, double x, double y, double z) {
-        //TODO: Double check if this range is fine
-        sendToAllTracking(message, new TargetPoint(dimension, x, y, z, 16));
+        //Range is ignored for sendToAllTracking, and only gets sent to clients that have the location loaded
+        sendToAllTracking(message, new TargetPoint(dimension, x, y, z, 1));
     }
 
     public void sendToAllTracking(IMessage message, TargetPoint point) {
-        //TODO: Does this need to check the server like sendToReceivers did
         netHandler.sendToAllTracking(message, point);
     }
 

--- a/src/main/java/mekanism/common/PacketHandler.java
+++ b/src/main/java/mekanism/common/PacketHandler.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.UUID;
 import javax.annotation.Nonnull;
+import mekanism.api.Coord4D;
 import mekanism.api.Range4D;
 import mekanism.common.config.MekanismConfig;
 import mekanism.common.network.PacketBoxBlacklist;
@@ -69,13 +70,16 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.network.ByteBufUtils;
 import net.minecraftforge.fml.common.network.NetworkRegistry;
+import net.minecraftforge.fml.common.network.NetworkRegistry.TargetPoint;
 import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
 import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
 import net.minecraftforge.fml.common.network.simpleimpl.SimpleNetworkWrapper;
@@ -238,10 +242,7 @@ public class PacketHandler {
      * @param message - message to send
      */
     public void sendToAll(IMessage message) {
-        MinecraftServer server = FMLCommonHandler.instance().getMinecraftServerInstance();
-        for (EntityPlayerMP player : server.getPlayerList().getPlayers()) {
-            sendTo(message, player);
-        }
+        netHandler.sendToAll(message);
     }
 
     /**
@@ -250,7 +251,7 @@ public class PacketHandler {
      * @param message - the message to send
      * @param point   - the TargetPoint around which to send
      */
-    public void sendToAllAround(IMessage message, NetworkRegistry.TargetPoint point) {
+    public void sendToAllAround(IMessage message, TargetPoint point) {
         netHandler.sendToAllAround(message, point);
     }
 
@@ -291,6 +292,26 @@ public class PacketHandler {
         }
     }
 
+    public void sendToAllTracking(IMessage message, TileEntity tile) {
+        BlockPos pos = tile.getPos();
+        sendToAllTracking(message, tile.getWorld().provider.getDimension(), pos.getX(), pos.getY(), pos.getZ());
+    }
+
+    public void sendToAllTracking(IMessage message, Coord4D point) {
+        sendToAllTracking(message, point.dimensionId, point.x, point.y, point.z);
+    }
+
+    public void sendToAllTracking(IMessage message, int dimension, double x, double y, double z) {
+        //TODO: Double check if this range is fine
+        sendToAllTracking(message, new TargetPoint(dimension, x, y, z, 16));
+    }
+
+    public void sendToAllTracking(IMessage message, TargetPoint point) {
+        //TODO: Does this need to check the server like sendToReceivers did
+        netHandler.sendToAllTracking(message, point);
+    }
+
+    //TODO: change Network stuff over to using this
     public void sendToReceivers(IMessage message, Range4D range) {
         MinecraftServer server = FMLCommonHandler.instance().getMinecraftServerInstance();
         if (server != null) {

--- a/src/main/java/mekanism/common/base/ITileNetwork.java
+++ b/src/main/java/mekanism/common/base/ITileNetwork.java
@@ -25,4 +25,13 @@ public interface ITileNetwork {
      * @return ArrayList of network data
      */
     TileNetworkList getNetworkedData(TileNetworkList data);
+
+    /**
+     * Gets an ArrayList of data this tile entity keeps synchronized with the client.
+     *
+     * @return ArrayList of network data
+     */
+    default TileNetworkList getNetworkedData() {
+        return getNetworkedData(new TileNetworkList());
+    }
 }

--- a/src/main/java/mekanism/common/item/ItemBlockBasic.java
+++ b/src/main/java/mekanism/common/item/ItemBlockBasic.java
@@ -180,13 +180,13 @@ public class ItemBlockBasic extends ItemBlock implements IEnergizedItem, ITierIt
                 TileEntityInductionCell tileEntity = (TileEntityInductionCell) world.getTileEntity(pos);
                 tileEntity.tier = InductionCellTier.values()[getBaseTier(stack).ordinal()];
                 if (!world.isRemote) {
-                    Mekanism.packetHandler.sendToAllTracking(tileEntity);
+                    Mekanism.packetHandler.sendUpdatePacket(tileEntity);
                 }
             } else if (type == BasicBlockType.INDUCTION_PROVIDER) {
                 TileEntityInductionProvider tileEntity = (TileEntityInductionProvider) world.getTileEntity(pos);
                 tileEntity.tier = InductionProviderTier.values()[getBaseTier(stack).ordinal()];
                 if (!world.isRemote) {
-                    Mekanism.packetHandler.sendToAllTracking(tileEntity);
+                    Mekanism.packetHandler.sendUpdatePacket(tileEntity);
                 }
             }
             TileEntity tileEntity = world.getTileEntity(pos);

--- a/src/main/java/mekanism/common/item/ItemBlockBasic.java
+++ b/src/main/java/mekanism/common/item/ItemBlockBasic.java
@@ -2,9 +2,7 @@ package mekanism.common.item;
 
 import java.util.List;
 import javax.annotation.Nonnull;
-import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
-import mekanism.api.TileNetworkList;
 import mekanism.api.energy.IEnergizedItem;
 import mekanism.api.energy.IStrictEnergyStorage;
 import mekanism.client.MekKeyHandler;
@@ -14,7 +12,6 @@ import mekanism.common.MekanismBlocks;
 import mekanism.common.base.ITierItem;
 import mekanism.common.block.states.BlockStateBasic.BasicBlockType;
 import mekanism.common.inventory.InventoryBin;
-import mekanism.common.network.PacketTileEntity.TileEntityMessage;
 import mekanism.common.tier.BaseTier;
 import mekanism.common.tier.BinTier;
 import mekanism.common.tier.InductionCellTier;
@@ -183,13 +180,13 @@ public class ItemBlockBasic extends ItemBlock implements IEnergizedItem, ITierIt
                 TileEntityInductionCell tileEntity = (TileEntityInductionCell) world.getTileEntity(pos);
                 tileEntity.tier = InductionCellTier.values()[getBaseTier(stack).ordinal()];
                 if (!world.isRemote) {
-                    Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(tileEntity), tileEntity.getNetworkedData(new TileNetworkList())), tileEntity);
+                    Mekanism.packetHandler.sendToAllTracking(tileEntity);
                 }
             } else if (type == BasicBlockType.INDUCTION_PROVIDER) {
                 TileEntityInductionProvider tileEntity = (TileEntityInductionProvider) world.getTileEntity(pos);
                 tileEntity.tier = InductionProviderTier.values()[getBaseTier(stack).ordinal()];
                 if (!world.isRemote) {
-                    Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(tileEntity), tileEntity.getNetworkedData(new TileNetworkList())), tileEntity);
+                    Mekanism.packetHandler.sendToAllTracking(tileEntity);
                 }
             }
             TileEntity tileEntity = world.getTileEntity(pos);

--- a/src/main/java/mekanism/common/item/ItemBlockBasic.java
+++ b/src/main/java/mekanism/common/item/ItemBlockBasic.java
@@ -4,7 +4,6 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
-import mekanism.api.Range4D;
 import mekanism.api.TileNetworkList;
 import mekanism.api.energy.IEnergizedItem;
 import mekanism.api.energy.IStrictEnergyStorage;
@@ -184,15 +183,13 @@ public class ItemBlockBasic extends ItemBlock implements IEnergizedItem, ITierIt
                 TileEntityInductionCell tileEntity = (TileEntityInductionCell) world.getTileEntity(pos);
                 tileEntity.tier = InductionCellTier.values()[getBaseTier(stack).ordinal()];
                 if (!world.isRemote) {
-                    Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(tileEntity), tileEntity.getNetworkedData(new TileNetworkList())),
-                          new Range4D(Coord4D.get(tileEntity)));
+                    Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(tileEntity), tileEntity.getNetworkedData(new TileNetworkList())), tileEntity);
                 }
             } else if (type == BasicBlockType.INDUCTION_PROVIDER) {
                 TileEntityInductionProvider tileEntity = (TileEntityInductionProvider) world.getTileEntity(pos);
                 tileEntity.tier = InductionProviderTier.values()[getBaseTier(stack).ordinal()];
                 if (!world.isRemote) {
-                    Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(tileEntity), tileEntity.getNetworkedData(new TileNetworkList())),
-                          new Range4D(Coord4D.get(tileEntity)));
+                    Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(tileEntity), tileEntity.getNetworkedData(new TileNetworkList())), tileEntity);
                 }
             }
             TileEntity tileEntity = world.getTileEntity(pos);

--- a/src/main/java/mekanism/common/item/ItemBlockEnergyCube.java
+++ b/src/main/java/mekanism/common/item/ItemBlockEnergyCube.java
@@ -8,7 +8,6 @@ import java.util.UUID;
 import javax.annotation.Nonnull;
 import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
-import mekanism.api.Range4D;
 import mekanism.api.TileNetworkList;
 import mekanism.api.energy.IEnergizedItem;
 import mekanism.api.transmitters.TransmissionType;
@@ -134,8 +133,7 @@ public class ItemBlockEnergyCube extends ItemBlock implements IEnergizedItem, IS
             }
             ((ISustainedInventory) tileEntity).setInventory(getInventory(stack));
             if (!world.isRemote) {
-                Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(tileEntity), tileEntity.getNetworkedData(new TileNetworkList())),
-                      new Range4D(Coord4D.get(tileEntity)));
+                Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(tileEntity), tileEntity.getNetworkedData(new TileNetworkList())), tileEntity);
             }
         }
         return place;

--- a/src/main/java/mekanism/common/item/ItemBlockEnergyCube.java
+++ b/src/main/java/mekanism/common/item/ItemBlockEnergyCube.java
@@ -130,7 +130,7 @@ public class ItemBlockEnergyCube extends ItemBlock implements IEnergizedItem, IS
             }
             ((ISustainedInventory) tileEntity).setInventory(getInventory(stack));
             if (!world.isRemote) {
-                Mekanism.packetHandler.sendToAllTracking(tileEntity);
+                Mekanism.packetHandler.sendUpdatePacket(tileEntity);
             }
         }
         return place;

--- a/src/main/java/mekanism/common/item/ItemBlockEnergyCube.java
+++ b/src/main/java/mekanism/common/item/ItemBlockEnergyCube.java
@@ -6,9 +6,7 @@ import ic2.api.item.ISpecialElectricItem;
 import java.util.List;
 import java.util.UUID;
 import javax.annotation.Nonnull;
-import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
-import mekanism.api.TileNetworkList;
 import mekanism.api.energy.IEnergizedItem;
 import mekanism.api.transmitters.TransmissionType;
 import mekanism.client.MekKeyHandler;
@@ -24,7 +22,6 @@ import mekanism.common.integration.MekanismHooks;
 import mekanism.common.integration.forgeenergy.ForgeEnergyItemWrapper;
 import mekanism.common.integration.ic2.IC2ItemManager;
 import mekanism.common.integration.tesla.TeslaItemWrapper;
-import mekanism.common.network.PacketTileEntity.TileEntityMessage;
 import mekanism.common.security.ISecurityItem;
 import mekanism.common.security.ISecurityTile;
 import mekanism.common.security.ISecurityTile.SecurityMode;
@@ -133,7 +130,7 @@ public class ItemBlockEnergyCube extends ItemBlock implements IEnergizedItem, IS
             }
             ((ISustainedInventory) tileEntity).setInventory(getInventory(stack));
             if (!world.isRemote) {
-                Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(tileEntity), tileEntity.getNetworkedData(new TileNetworkList())), tileEntity);
+                Mekanism.packetHandler.sendToAllTracking(tileEntity);
             }
         }
         return place;

--- a/src/main/java/mekanism/common/item/ItemBlockGasTank.java
+++ b/src/main/java/mekanism/common/item/ItemBlockGasTank.java
@@ -5,7 +5,6 @@ import java.util.UUID;
 import javax.annotation.Nonnull;
 import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
-import mekanism.api.Range4D;
 import mekanism.api.TileNetworkList;
 import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasRegistry;
@@ -104,8 +103,7 @@ public class ItemBlockGasTank extends ItemBlock implements IGasItem, ISustainedI
 
             ((ISustainedInventory) tileEntity).setInventory(getInventory(stack));
             if (!world.isRemote) {
-                Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(tileEntity),
-                      tileEntity.getNetworkedData(new TileNetworkList())), new Range4D(Coord4D.get(tileEntity)));
+                Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(tileEntity), tileEntity.getNetworkedData(new TileNetworkList())), tileEntity);
             }
         }
         return place;

--- a/src/main/java/mekanism/common/item/ItemBlockGasTank.java
+++ b/src/main/java/mekanism/common/item/ItemBlockGasTank.java
@@ -100,7 +100,7 @@ public class ItemBlockGasTank extends ItemBlock implements IGasItem, ISustainedI
 
             ((ISustainedInventory) tileEntity).setInventory(getInventory(stack));
             if (!world.isRemote) {
-                Mekanism.packetHandler.sendToAllTracking(tileEntity);
+                Mekanism.packetHandler.sendUpdatePacket(tileEntity);
             }
         }
         return place;

--- a/src/main/java/mekanism/common/item/ItemBlockGasTank.java
+++ b/src/main/java/mekanism/common/item/ItemBlockGasTank.java
@@ -3,9 +3,7 @@ package mekanism.common.item;
 import java.util.List;
 import java.util.UUID;
 import javax.annotation.Nonnull;
-import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
-import mekanism.api.TileNetworkList;
 import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasRegistry;
 import mekanism.api.gas.GasStack;
@@ -18,7 +16,6 @@ import mekanism.common.base.ISideConfiguration;
 import mekanism.common.base.ISustainedInventory;
 import mekanism.common.base.ITierItem;
 import mekanism.common.config.MekanismConfig;
-import mekanism.common.network.PacketTileEntity.TileEntityMessage;
 import mekanism.common.security.ISecurityItem;
 import mekanism.common.security.ISecurityTile;
 import mekanism.common.security.ISecurityTile.SecurityMode;
@@ -103,7 +100,7 @@ public class ItemBlockGasTank extends ItemBlock implements IGasItem, ISustainedI
 
             ((ISustainedInventory) tileEntity).setInventory(getInventory(stack));
             if (!world.isRemote) {
-                Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(tileEntity), tileEntity.getNetworkedData(new TileNetworkList())), tileEntity);
+                Mekanism.packetHandler.sendToAllTracking(tileEntity);
             }
         }
         return place;

--- a/src/main/java/mekanism/common/item/ItemBlockGlowPanel.java
+++ b/src/main/java/mekanism/common/item/ItemBlockGlowPanel.java
@@ -52,7 +52,7 @@ public class ItemBlockGlowPanel extends ItemBlockMultipartAble {
             }
             tileEntity.setColour(col);
             if (!world.isRemote) {
-                Mekanism.packetHandler.sendToAllTracking(tileEntity);
+                Mekanism.packetHandler.sendUpdatePacket(tileEntity);
             }
         }
         return place;

--- a/src/main/java/mekanism/common/item/ItemBlockGlowPanel.java
+++ b/src/main/java/mekanism/common/item/ItemBlockGlowPanel.java
@@ -4,7 +4,6 @@ import javax.annotation.Nonnull;
 import mcmultipart.api.multipart.IMultipart;
 import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
-import mekanism.api.Range4D;
 import mekanism.api.TileNetworkList;
 import mekanism.common.Mekanism;
 import mekanism.common.integration.MekanismHooks;
@@ -56,8 +55,7 @@ public class ItemBlockGlowPanel extends ItemBlockMultipartAble {
             }
             tileEntity.setColour(col);
             if (!world.isRemote) {
-                Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(tileEntity), tileEntity.getNetworkedData(new TileNetworkList())),
-                      new Range4D(Coord4D.get(tileEntity)));
+                Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(tileEntity), tileEntity.getNetworkedData(new TileNetworkList())), tileEntity);
             }
         }
         return place;

--- a/src/main/java/mekanism/common/item/ItemBlockGlowPanel.java
+++ b/src/main/java/mekanism/common/item/ItemBlockGlowPanel.java
@@ -2,13 +2,10 @@ package mekanism.common.item;
 
 import javax.annotation.Nonnull;
 import mcmultipart.api.multipart.IMultipart;
-import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
-import mekanism.api.TileNetworkList;
 import mekanism.common.Mekanism;
 import mekanism.common.integration.MekanismHooks;
 import mekanism.common.integration.multipart.MultipartMekanism;
-import mekanism.common.network.PacketTileEntity.TileEntityMessage;
 import mekanism.common.tile.TileEntityGlowPanel;
 import mekanism.common.util.LangUtils;
 import net.minecraft.block.Block;
@@ -55,7 +52,7 @@ public class ItemBlockGlowPanel extends ItemBlockMultipartAble {
             }
             tileEntity.setColour(col);
             if (!world.isRemote) {
-                Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(tileEntity), tileEntity.getNetworkedData(new TileNetworkList())), tileEntity);
+                Mekanism.packetHandler.sendToAllTracking(tileEntity);
             }
         }
         return place;

--- a/src/main/java/mekanism/common/item/ItemBlockMachine.java
+++ b/src/main/java/mekanism/common/item/ItemBlockMachine.java
@@ -12,7 +12,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
-import mekanism.api.Range4D;
 import mekanism.api.TileNetworkList;
 import mekanism.api.energy.IEnergizedItem;
 import mekanism.client.MekKeyHandler;
@@ -319,8 +318,7 @@ public class ItemBlockMachine extends ItemBlock implements IEnergizedItem, ISpec
                     factory.setRecipeType(recipeType);
                 }
                 world.notifyNeighborsOfStateChange(pos, tileEntity.getBlockType(), true);
-                Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(tileEntity), tileEntity.getNetworkedData(new TileNetworkList())),
-                      new Range4D(Coord4D.get(tileEntity)));
+                Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(tileEntity), tileEntity.getNetworkedData(new TileNetworkList())), tileEntity);
             }
 
             if (tileEntity instanceof ISustainedTank) {

--- a/src/main/java/mekanism/common/item/ItemBlockMachine.java
+++ b/src/main/java/mekanism/common/item/ItemBlockMachine.java
@@ -316,7 +316,7 @@ public class ItemBlockMachine extends ItemBlock implements IEnergizedItem, ISpec
                     factory.setRecipeType(recipeType);
                 }
                 world.notifyNeighborsOfStateChange(pos, tileEntity.getBlockType(), true);
-                Mekanism.packetHandler.sendToAllTracking(tileEntity);
+                Mekanism.packetHandler.sendUpdatePacket(tileEntity);
             }
 
             if (tileEntity instanceof ISustainedTank) {

--- a/src/main/java/mekanism/common/item/ItemBlockMachine.java
+++ b/src/main/java/mekanism/common/item/ItemBlockMachine.java
@@ -12,7 +12,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
-import mekanism.api.TileNetworkList;
 import mekanism.api.energy.IEnergizedItem;
 import mekanism.client.MekKeyHandler;
 import mekanism.client.MekanismClient;
@@ -40,7 +39,6 @@ import mekanism.common.integration.forgeenergy.ForgeEnergyItemWrapper;
 import mekanism.common.integration.ic2.IC2ItemManager;
 import mekanism.common.integration.tesla.TeslaItemWrapper;
 import mekanism.common.inventory.InventoryPersonalChest;
-import mekanism.common.network.PacketTileEntity.TileEntityMessage;
 import mekanism.common.security.ISecurityItem;
 import mekanism.common.security.ISecurityTile;
 import mekanism.common.security.ISecurityTile.SecurityMode;
@@ -318,7 +316,7 @@ public class ItemBlockMachine extends ItemBlock implements IEnergizedItem, ISpec
                     factory.setRecipeType(recipeType);
                 }
                 world.notifyNeighborsOfStateChange(pos, tileEntity.getBlockType(), true);
-                Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(tileEntity), tileEntity.getNetworkedData(new TileNetworkList())), tileEntity);
+                Mekanism.packetHandler.sendToAllTracking(tileEntity);
             }
 
             if (tileEntity instanceof ISustainedTank) {

--- a/src/main/java/mekanism/common/item/ItemBlockTransmitter.java
+++ b/src/main/java/mekanism/common/item/ItemBlockTransmitter.java
@@ -59,7 +59,7 @@ public class ItemBlockTransmitter extends ItemBlockMultipartAble implements ITie
             TileEntitySidedPipe tileEntity = (TileEntitySidedPipe) world.getTileEntity(pos);
             tileEntity.setBaseTier(getBaseTier(stack));
             if (!world.isRemote) {
-                Mekanism.packetHandler.sendToAllTracking(tileEntity);
+                Mekanism.packetHandler.sendUpdatePacket(tileEntity);
             }
         }
         return place;

--- a/src/main/java/mekanism/common/item/ItemBlockTransmitter.java
+++ b/src/main/java/mekanism/common/item/ItemBlockTransmitter.java
@@ -5,7 +5,6 @@ import javax.annotation.Nonnull;
 import mcmultipart.api.multipart.IMultipart;
 import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
-import mekanism.api.Range4D;
 import mekanism.api.TileNetworkList;
 import mekanism.api.transmitters.TransmissionType;
 import mekanism.client.MekKeyHandler;
@@ -63,8 +62,7 @@ public class ItemBlockTransmitter extends ItemBlockMultipartAble implements ITie
             TileEntitySidedPipe tileEntity = (TileEntitySidedPipe) world.getTileEntity(pos);
             tileEntity.setBaseTier(getBaseTier(stack));
             if (!world.isRemote) {
-                Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(tileEntity), tileEntity.getNetworkedData(new TileNetworkList())),
-                      new Range4D(Coord4D.get(tileEntity)));
+                Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(tileEntity), tileEntity.getNetworkedData(new TileNetworkList())), tileEntity);
             }
         }
         return place;

--- a/src/main/java/mekanism/common/item/ItemBlockTransmitter.java
+++ b/src/main/java/mekanism/common/item/ItemBlockTransmitter.java
@@ -3,9 +3,7 @@ package mekanism.common.item;
 import java.util.List;
 import javax.annotation.Nonnull;
 import mcmultipart.api.multipart.IMultipart;
-import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
-import mekanism.api.TileNetworkList;
 import mekanism.api.transmitters.TransmissionType;
 import mekanism.client.MekKeyHandler;
 import mekanism.client.MekanismKeyHandler;
@@ -14,7 +12,6 @@ import mekanism.common.base.ITierItem;
 import mekanism.common.block.states.BlockStateTransmitter.TransmitterType;
 import mekanism.common.integration.MekanismHooks;
 import mekanism.common.integration.multipart.MultipartMekanism;
-import mekanism.common.network.PacketTileEntity.TileEntityMessage;
 import mekanism.common.tier.BaseTier;
 import mekanism.common.tier.CableTier;
 import mekanism.common.tier.ConductorTier;
@@ -62,7 +59,7 @@ public class ItemBlockTransmitter extends ItemBlockMultipartAble implements ITie
             TileEntitySidedPipe tileEntity = (TileEntitySidedPipe) world.getTileEntity(pos);
             tileEntity.setBaseTier(getBaseTier(stack));
             if (!world.isRemote) {
-                Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(tileEntity), tileEntity.getNetworkedData(new TileNetworkList())), tileEntity);
+                Mekanism.packetHandler.sendToAllTracking(tileEntity);
             }
         }
         return place;

--- a/src/main/java/mekanism/common/item/ItemConfigurator.java
+++ b/src/main/java/mekanism/common/item/ItemConfigurator.java
@@ -102,7 +102,7 @@ public class ItemConfigurator extends ItemEnergized implements IMekWrench, ITool
                                                                                + getToggleModeText(transmissionType) + ": " + data.color + data.localize() + " (" +
                                                                                data.color.getColoredName() + ")"));
                                     if (config instanceof TileEntityBasicBlock) {
-                                        Mekanism.packetHandler.sendToAllTracking((TileEntityBasicBlock) config);
+                                        Mekanism.packetHandler.sendUpdatePacket((TileEntityBasicBlock) config);
                                     }
                                 } else {
                                     SecurityUtils.displayNoAccess(player);

--- a/src/main/java/mekanism/common/item/ItemConfigurator.java
+++ b/src/main/java/mekanism/common/item/ItemConfigurator.java
@@ -11,11 +11,9 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import mcp.MethodsReturnNonnullByDefault;
-import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
 import mekanism.api.IConfigurable;
 import mekanism.api.IMekWrench;
-import mekanism.api.TileNetworkList;
 import mekanism.api.transmitters.TransmissionType;
 import mekanism.common.Mekanism;
 import mekanism.common.SideData;
@@ -23,7 +21,6 @@ import mekanism.common.base.IItemNetwork;
 import mekanism.common.base.ISideConfiguration;
 import mekanism.common.capabilities.Capabilities;
 import mekanism.common.integration.MekanismHooks;
-import mekanism.common.network.PacketTileEntity.TileEntityMessage;
 import mekanism.common.tile.component.TileComponentConfig;
 import mekanism.common.tile.prefab.TileEntityBasicBlock;
 import mekanism.common.tile.prefab.TileEntityContainerBlock;
@@ -105,8 +102,7 @@ public class ItemConfigurator extends ItemEnergized implements IMekWrench, ITool
                                                                                + getToggleModeText(transmissionType) + ": " + data.color + data.localize() + " (" +
                                                                                data.color.getColoredName() + ")"));
                                     if (config instanceof TileEntityBasicBlock) {
-                                        TileEntityBasicBlock tileEntity = (TileEntityBasicBlock) config;
-                                        Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(tileEntity), tileEntity.getNetworkedData(new TileNetworkList())), tileEntity);
+                                        Mekanism.packetHandler.sendToAllTracking((TileEntityBasicBlock) config);
                                     }
                                 } else {
                                     SecurityUtils.displayNoAccess(player);

--- a/src/main/java/mekanism/common/item/ItemConfigurator.java
+++ b/src/main/java/mekanism/common/item/ItemConfigurator.java
@@ -15,7 +15,6 @@ import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
 import mekanism.api.IConfigurable;
 import mekanism.api.IMekWrench;
-import mekanism.api.Range4D;
 import mekanism.api.TileNetworkList;
 import mekanism.api.transmitters.TransmissionType;
 import mekanism.common.Mekanism;
@@ -107,8 +106,7 @@ public class ItemConfigurator extends ItemEnergized implements IMekWrench, ITool
                                                                                data.color.getColoredName() + ")"));
                                     if (config instanceof TileEntityBasicBlock) {
                                         TileEntityBasicBlock tileEntity = (TileEntityBasicBlock) config;
-                                        Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(tileEntity), tileEntity.getNetworkedData(new TileNetworkList())),
-                                              new Range4D(Coord4D.get(tileEntity)));
+                                        Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(tileEntity), tileEntity.getNetworkedData(new TileNetworkList())), tileEntity);
                                     }
                                 } else {
                                     SecurityUtils.displayNoAccess(player);

--- a/src/main/java/mekanism/common/network/PacketConfigurationUpdate.java
+++ b/src/main/java/mekanism/common/network/PacketConfigurationUpdate.java
@@ -2,7 +2,6 @@ package mekanism.common.network;
 
 import io.netty.buffer.ByteBuf;
 import mekanism.api.Coord4D;
-import mekanism.api.Range4D;
 import mekanism.api.TileNetworkList;
 import mekanism.api.transmitters.TransmissionType;
 import mekanism.common.Mekanism;
@@ -49,7 +48,7 @@ public class PacketConfigurationUpdate implements IMessageHandler<ConfigurationU
                     }
 
                     tile.markDirty();
-                    Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(message.coord4D, network.getNetworkedData(new TileNetworkList())), new Range4D(message.coord4D));
+                    Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(message.coord4D, network.getNetworkedData(new TileNetworkList())), message.coord4D);
                     //Notify the neighbor on that side our state changed
                     MekanismUtils.notifyNeighborOfChange(tile.getWorld(), message.configIndex, tile.getPos());
                 } else if (message.packetType == ConfigurationPacket.EJECT_COLOR) {

--- a/src/main/java/mekanism/common/network/PacketConfigurationUpdate.java
+++ b/src/main/java/mekanism/common/network/PacketConfigurationUpdate.java
@@ -2,7 +2,6 @@ package mekanism.common.network;
 
 import io.netty.buffer.ByteBuf;
 import mekanism.api.Coord4D;
-import mekanism.api.TileNetworkList;
 import mekanism.api.transmitters.TransmissionType;
 import mekanism.common.Mekanism;
 import mekanism.common.PacketHandler;
@@ -48,7 +47,7 @@ public class PacketConfigurationUpdate implements IMessageHandler<ConfigurationU
                     }
 
                     tile.markDirty();
-                    Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(message.coord4D, network.getNetworkedData(new TileNetworkList())), message.coord4D);
+                    Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(message.coord4D, network.getNetworkedData()), message.coord4D);
                     //Notify the neighbor on that side our state changed
                     MekanismUtils.notifyNeighborOfChange(tile.getWorld(), message.configIndex, tile.getPos());
                 } else if (message.packetType == ConfigurationPacket.EJECT_COLOR) {
@@ -74,7 +73,7 @@ public class PacketConfigurationUpdate implements IMessageHandler<ConfigurationU
                     config.getEjector().setStrictInput(!config.getEjector().hasStrictInput());
                 }
                 for (EntityPlayer p : ((TileEntityBasicBlock) config).playersUsing) {
-                    Mekanism.packetHandler.sendTo(new TileEntityMessage(message.coord4D, network.getNetworkedData(new TileNetworkList())), (EntityPlayerMP) p);
+                    Mekanism.packetHandler.sendTo(new TileEntityMessage(message.coord4D, network.getNetworkedData()), (EntityPlayerMP) p);
                 }
             }
         }, player);

--- a/src/main/java/mekanism/common/network/PacketDataRequest.java
+++ b/src/main/java/mekanism/common/network/PacketDataRequest.java
@@ -2,7 +2,6 @@ package mekanism.common.network;
 
 import io.netty.buffer.ByteBuf;
 import mekanism.api.Coord4D;
-import mekanism.api.TileNetworkList;
 import mekanism.api.transmitters.IGridTransmitter;
 import mekanism.common.Mekanism;
 import mekanism.common.PacketHandler;
@@ -42,7 +41,7 @@ public class PacketDataRequest implements IMessageHandler<DataRequestMessage, IM
                 }
                 if (CapabilityUtils.hasCapability(tileEntity, Capabilities.TILE_NETWORK_CAPABILITY, null)) {
                     ITileNetwork network = CapabilityUtils.getCapability(tileEntity, Capabilities.TILE_NETWORK_CAPABILITY, null);
-                    Mekanism.packetHandler.sendTo(new TileEntityMessage(tileEntity, network.getNetworkedData(new TileNetworkList())), (EntityPlayerMP) player);
+                    Mekanism.packetHandler.sendTo(new TileEntityMessage(tileEntity, network.getNetworkedData()), (EntityPlayerMP) player);
                 }
             }
         }, player);

--- a/src/main/java/mekanism/common/network/PacketDataRequest.java
+++ b/src/main/java/mekanism/common/network/PacketDataRequest.java
@@ -42,7 +42,7 @@ public class PacketDataRequest implements IMessageHandler<DataRequestMessage, IM
                 }
                 if (CapabilityUtils.hasCapability(tileEntity, Capabilities.TILE_NETWORK_CAPABILITY, null)) {
                     ITileNetwork network = CapabilityUtils.getCapability(tileEntity, Capabilities.TILE_NETWORK_CAPABILITY, null);
-                    Mekanism.packetHandler.sendTo(new TileEntityMessage(Coord4D.get(tileEntity), network.getNetworkedData(new TileNetworkList())), (EntityPlayerMP) player);
+                    Mekanism.packetHandler.sendTo(new TileEntityMessage(tileEntity, network.getNetworkedData(new TileNetworkList())), (EntityPlayerMP) player);
                 }
             }
         }, player);

--- a/src/main/java/mekanism/common/network/PacketEditFilter.java
+++ b/src/main/java/mekanism/common/network/PacketEditFilter.java
@@ -40,7 +40,7 @@ public class PacketEditFilter implements IMessageHandler<EditFilterMessage, IMes
                     sorter.filters.add(index, message.tEdited);
                 }
                 for (EntityPlayer iterPlayer : sorter.playersUsing) {
-                    Mekanism.packetHandler.sendTo(new TileEntityMessage(Coord4D.get(sorter), sorter.getFilterPacket(new TileNetworkList())), (EntityPlayerMP) iterPlayer);
+                    Mekanism.packetHandler.sendTo(new TileEntityMessage(sorter, sorter.getFilterPacket(new TileNetworkList())), (EntityPlayerMP) iterPlayer);
                 }
             } else if (message.type == 1 && message.coord4D.getTileEntity(worldServer) instanceof TileEntityDigitalMiner) {
                 TileEntityDigitalMiner miner = (TileEntityDigitalMiner) message.coord4D.getTileEntity(worldServer);
@@ -54,7 +54,7 @@ public class PacketEditFilter implements IMessageHandler<EditFilterMessage, IMes
                     miner.filters.add(index, message.mEdited);
                 }
                 for (EntityPlayer iterPlayer : miner.playersUsing) {
-                    Mekanism.packetHandler.sendTo(new TileEntityMessage(Coord4D.get(miner), miner.getFilterPacket(new TileNetworkList())), (EntityPlayerMP) iterPlayer);
+                    Mekanism.packetHandler.sendTo(new TileEntityMessage(miner, miner.getFilterPacket(new TileNetworkList())), (EntityPlayerMP) iterPlayer);
                 }
             } else if (message.type == 2 && message.coord4D.getTileEntity(worldServer) instanceof TileEntityOredictionificator) {
                 TileEntityOredictionificator oredictionificator = (TileEntityOredictionificator) message.coord4D.getTileEntity(worldServer);
@@ -67,8 +67,7 @@ public class PacketEditFilter implements IMessageHandler<EditFilterMessage, IMes
                     oredictionificator.filters.add(index, message.oEdited);
                 }
                 for (EntityPlayer iterPlayer : oredictionificator.playersUsing) {
-                    Mekanism.packetHandler.sendTo(new TileEntityMessage(Coord4D.get(oredictionificator),
-                          oredictionificator.getFilterPacket(new TileNetworkList())), (EntityPlayerMP) iterPlayer);
+                    Mekanism.packetHandler.sendTo(new TileEntityMessage(oredictionificator, oredictionificator.getFilterPacket(new TileNetworkList())), (EntityPlayerMP) iterPlayer);
                 }
             }
         });

--- a/src/main/java/mekanism/common/network/PacketNewFilter.java
+++ b/src/main/java/mekanism/common/network/PacketNewFilter.java
@@ -32,20 +32,19 @@ public class PacketNewFilter implements IMessageHandler<NewFilterMessage, IMessa
                 TileEntityLogisticalSorter sorter = (TileEntityLogisticalSorter) message.coord4D.getTileEntity(worldServer);
                 sorter.filters.add(message.tFilter);
                 for (EntityPlayer iterPlayer : sorter.playersUsing) {
-                    Mekanism.packetHandler.sendTo(new TileEntityMessage(Coord4D.get(sorter), sorter.getFilterPacket(new TileNetworkList())), (EntityPlayerMP) iterPlayer);
+                    Mekanism.packetHandler.sendTo(new TileEntityMessage(sorter, sorter.getFilterPacket(new TileNetworkList())), (EntityPlayerMP) iterPlayer);
                 }
             } else if (message.type == 1 && message.coord4D.getTileEntity(worldServer) instanceof TileEntityDigitalMiner) {
                 TileEntityDigitalMiner miner = (TileEntityDigitalMiner) message.coord4D.getTileEntity(worldServer);
                 miner.filters.add(message.mFilter);
                 for (EntityPlayer iterPlayer : miner.playersUsing) {
-                    Mekanism.packetHandler.sendTo(new TileEntityMessage(Coord4D.get(miner), miner.getFilterPacket(new TileNetworkList())), (EntityPlayerMP) iterPlayer);
+                    Mekanism.packetHandler.sendTo(new TileEntityMessage(miner, miner.getFilterPacket(new TileNetworkList())), (EntityPlayerMP) iterPlayer);
                 }
             } else if (message.type == 2 && message.coord4D.getTileEntity(worldServer) instanceof TileEntityOredictionificator) {
                 TileEntityOredictionificator oredictionificator = (TileEntityOredictionificator) message.coord4D.getTileEntity(worldServer);
                 oredictionificator.filters.add(message.oFilter);
                 for (EntityPlayer iterPlayer : oredictionificator.playersUsing) {
-                    Mekanism.packetHandler.sendTo(new TileEntityMessage(Coord4D.get(oredictionificator),
-                          oredictionificator.getFilterPacket(new TileNetworkList())), (EntityPlayerMP) iterPlayer);
+                    Mekanism.packetHandler.sendTo(new TileEntityMessage(oredictionificator, oredictionificator.getFilterPacket(new TileNetworkList())), (EntityPlayerMP) iterPlayer);
                 }
             }
         });

--- a/src/main/java/mekanism/common/network/PacketPortableTeleporter.java
+++ b/src/main/java/mekanism/common/network/PacketPortableTeleporter.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import mekanism.api.Coord4D;
-import mekanism.api.Range4D;
 import mekanism.api.TileNetworkList;
 import mekanism.common.Mekanism;
 import mekanism.common.PacketHandler;
@@ -96,7 +95,7 @@ public class PacketPortableTeleporter implements IMessageHandler<PortableTelepor
                                         TileEntityTeleporter.alignPlayer((EntityPlayerMP) player, coords);
                                     }
                                     world.playSound(player, player.posX, player.posY, player.posZ, SoundEvents.ENTITY_ENDERMEN_TELEPORT, SoundCategory.PLAYERS, 1.0F, 1.0F);
-                                    Mekanism.packetHandler.sendToReceivers(new PortalFXMessage(coords), new Range4D(coords));
+                                    Mekanism.packetHandler.sendToAllTracking(new PortalFXMessage(coords), coords);
                                 } catch (Exception ignored) {
                                 }
                             }

--- a/src/main/java/mekanism/common/network/PacketTileEntity.java
+++ b/src/main/java/mekanism/common/network/PacketTileEntity.java
@@ -52,6 +52,10 @@ public class PacketTileEntity implements IMessageHandler<TileEntityMessage, IMes
         public TileEntityMessage() {
         }
 
+        public TileEntityMessage(TileEntity tile, TileNetworkList params) {
+            this(Coord4D.get(tile), params);
+        }
+
         public TileEntityMessage(Coord4D coord, TileNetworkList params) {
             coord4D = coord;
             parameters = params;

--- a/src/main/java/mekanism/common/network/PacketTileEntity.java
+++ b/src/main/java/mekanism/common/network/PacketTileEntity.java
@@ -52,6 +52,10 @@ public class PacketTileEntity implements IMessageHandler<TileEntityMessage, IMes
         public TileEntityMessage() {
         }
 
+        public <TILE extends TileEntity & ITileNetwork> TileEntityMessage(TILE tile) {
+            this(Coord4D.get(tile), tile.getNetworkedData());
+        }
+
         public TileEntityMessage(TileEntity tile, TileNetworkList params) {
             this(Coord4D.get(tile), params);
         }

--- a/src/main/java/mekanism/common/tile/TileEntityBin.java
+++ b/src/main/java/mekanism/common/tile/TileEntityBin.java
@@ -78,7 +78,7 @@ public class TileEntityBin extends TileEntityBasicBlock implements ISidedInvento
             return false;
         }
         tier = BinTier.values()[upgradeTier.ordinal()];
-        Mekanism.packetHandler.sendToAllTracking(this);
+        Mekanism.packetHandler.sendUpdatePacket(this);
         markDirty();
         return true;
     }
@@ -349,7 +349,7 @@ public class TileEntityBin extends TileEntityBasicBlock implements ISidedInvento
         super.markDirty();
         if (!world.isRemote) {
             MekanismUtils.saveChunk(this);
-            Mekanism.packetHandler.sendToAllTracking(this);
+            Mekanism.packetHandler.sendUpdatePacket(this);
             prevCount = getItemCount();
             sortStacks();
         }
@@ -468,7 +468,7 @@ public class TileEntityBin extends TileEntityBasicBlock implements ISidedInvento
     public void setActive(boolean active) {
         isActive = active;
         if (clientActive != active) {
-            Mekanism.packetHandler.sendToAllTracking(this);
+            Mekanism.packetHandler.sendUpdatePacket(this);
             clientActive = active;
         }
     }

--- a/src/main/java/mekanism/common/tile/TileEntityBin.java
+++ b/src/main/java/mekanism/common/tile/TileEntityBin.java
@@ -4,7 +4,6 @@ import io.netty.buffer.ByteBuf;
 import javax.annotation.Nonnull;
 import mekanism.api.Coord4D;
 import mekanism.api.IConfigurable;
-import mekanism.api.Range4D;
 import mekanism.api.TileNetworkList;
 import mekanism.common.Mekanism;
 import mekanism.common.PacketHandler;
@@ -80,7 +79,7 @@ public class TileEntityBin extends TileEntityBasicBlock implements ISidedInvento
             return false;
         }
         tier = BinTier.values()[upgradeTier.ordinal()];
-        Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), new Range4D(Coord4D.get(this)));
+        Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
         markDirty();
         return true;
     }
@@ -351,7 +350,7 @@ public class TileEntityBin extends TileEntityBasicBlock implements ISidedInvento
         super.markDirty();
         if (!world.isRemote) {
             MekanismUtils.saveChunk(this);
-            Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), new Range4D(Coord4D.get(this)));
+            Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
             prevCount = getItemCount();
             sortStacks();
         }
@@ -470,7 +469,7 @@ public class TileEntityBin extends TileEntityBasicBlock implements ISidedInvento
     public void setActive(boolean active) {
         isActive = active;
         if (clientActive != active) {
-            Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), new Range4D(Coord4D.get(this)));
+            Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
             clientActive = active;
         }
     }

--- a/src/main/java/mekanism/common/tile/TileEntityBin.java
+++ b/src/main/java/mekanism/common/tile/TileEntityBin.java
@@ -15,7 +15,6 @@ import mekanism.common.capabilities.Capabilities;
 import mekanism.common.content.transporter.TransitRequest;
 import mekanism.common.content.transporter.TransitRequest.TransitResponse;
 import mekanism.common.item.ItemBlockBasic;
-import mekanism.common.network.PacketTileEntity.TileEntityMessage;
 import mekanism.common.tier.BaseTier;
 import mekanism.common.tier.BinTier;
 import mekanism.common.tile.prefab.TileEntityBasicBlock;
@@ -79,7 +78,7 @@ public class TileEntityBin extends TileEntityBasicBlock implements ISidedInvento
             return false;
         }
         tier = BinTier.values()[upgradeTier.ordinal()];
-        Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
+        Mekanism.packetHandler.sendToAllTracking(this);
         markDirty();
         return true;
     }
@@ -350,7 +349,7 @@ public class TileEntityBin extends TileEntityBasicBlock implements ISidedInvento
         super.markDirty();
         if (!world.isRemote) {
             MekanismUtils.saveChunk(this);
-            Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
+            Mekanism.packetHandler.sendToAllTracking(this);
             prevCount = getItemCount();
             sortStacks();
         }
@@ -469,7 +468,7 @@ public class TileEntityBin extends TileEntityBasicBlock implements ISidedInvento
     public void setActive(boolean active) {
         isActive = active;
         if (clientActive != active) {
-            Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
+            Mekanism.packetHandler.sendToAllTracking(this);
             clientActive = active;
         }
     }

--- a/src/main/java/mekanism/common/tile/TileEntityBoilerCasing.java
+++ b/src/main/java/mekanism/common/tile/TileEntityBoilerCasing.java
@@ -6,7 +6,6 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import mekanism.api.Coord4D;
 import mekanism.api.IHeatTransfer;
-import mekanism.api.Range4D;
 import mekanism.api.TileNetworkList;
 import mekanism.common.Mekanism;
 import mekanism.common.capabilities.Capabilities;
@@ -145,7 +144,7 @@ public class TileEntityBoilerCasing extends TileEntityMultiblock<SynchronizedBoi
     @Override
     public boolean onActivate(EntityPlayer player, EnumHand hand, ItemStack stack) {
         if (!player.isSneaking() && structure != null) {
-            Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), new Range4D(Coord4D.get(this)));
+            Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
             player.openGui(Mekanism.instance, 54, world, getPos().getX(), getPos().getY(), getPos().getZ());
             return true;
         }

--- a/src/main/java/mekanism/common/tile/TileEntityBoilerCasing.java
+++ b/src/main/java/mekanism/common/tile/TileEntityBoilerCasing.java
@@ -143,7 +143,7 @@ public class TileEntityBoilerCasing extends TileEntityMultiblock<SynchronizedBoi
     @Override
     public boolean onActivate(EntityPlayer player, EnumHand hand, ItemStack stack) {
         if (!player.isSneaking() && structure != null) {
-            Mekanism.packetHandler.sendToAllTracking(this);
+            Mekanism.packetHandler.sendUpdatePacket(this);
             player.openGui(Mekanism.instance, 54, world, getPos().getX(), getPos().getY(), getPos().getZ());
             return true;
         }

--- a/src/main/java/mekanism/common/tile/TileEntityBoilerCasing.java
+++ b/src/main/java/mekanism/common/tile/TileEntityBoilerCasing.java
@@ -14,7 +14,6 @@ import mekanism.common.content.boiler.BoilerUpdateProtocol;
 import mekanism.common.content.boiler.SynchronizedBoilerData;
 import mekanism.common.content.tank.SynchronizedTankData.ValveData;
 import mekanism.common.multiblock.MultiblockManager;
-import mekanism.common.network.PacketTileEntity.TileEntityMessage;
 import mekanism.common.util.InventoryUtils;
 import mekanism.common.util.LangUtils;
 import mekanism.common.util.MekanismUtils;
@@ -144,7 +143,7 @@ public class TileEntityBoilerCasing extends TileEntityMultiblock<SynchronizedBoi
     @Override
     public boolean onActivate(EntityPlayer player, EnumHand hand, ItemStack stack) {
         if (!player.isSneaking() && structure != null) {
-            Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
+            Mekanism.packetHandler.sendToAllTracking(this);
             player.openGui(Mekanism.instance, 54, world, getPos().getX(), getPos().getY(), getPos().getZ());
             return true;
         }

--- a/src/main/java/mekanism/common/tile/TileEntityBoundingBlock.java
+++ b/src/main/java/mekanism/common/tile/TileEntityBoundingBlock.java
@@ -53,7 +53,7 @@ public class TileEntityBoundingBlock extends TileEntity implements ITileNetwork 
                     onNoPower();
                 }
                 prevPower = power;
-                Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(tileEntity, tileEntity.getNetworkedData(new TileNetworkList())), this);
+                Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(tileEntity), this);
             }
         }
     }

--- a/src/main/java/mekanism/common/tile/TileEntityBoundingBlock.java
+++ b/src/main/java/mekanism/common/tile/TileEntityBoundingBlock.java
@@ -29,7 +29,7 @@ public class TileEntityBoundingBlock extends TileEntity implements ITileNetwork 
         receivedCoords = true;
         if (!world.isRemote) {
             mainPos = pos;
-            Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
+            Mekanism.packetHandler.sendToAllTracking(this);
         }
     }
 
@@ -53,7 +53,7 @@ public class TileEntityBoundingBlock extends TileEntity implements ITileNetwork 
                     onNoPower();
                 }
                 prevPower = power;
-                Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(tileEntity), tileEntity.getNetworkedData(new TileNetworkList())), this);
+                Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(tileEntity, tileEntity.getNetworkedData(new TileNetworkList())), this);
             }
         }
     }

--- a/src/main/java/mekanism/common/tile/TileEntityBoundingBlock.java
+++ b/src/main/java/mekanism/common/tile/TileEntityBoundingBlock.java
@@ -3,7 +3,6 @@ package mekanism.common.tile;
 import io.netty.buffer.ByteBuf;
 import javax.annotation.Nonnull;
 import mekanism.api.Coord4D;
-import mekanism.api.Range4D;
 import mekanism.api.TileNetworkList;
 import mekanism.common.Mekanism;
 import mekanism.common.base.ITileNetwork;
@@ -30,7 +29,7 @@ public class TileEntityBoundingBlock extends TileEntity implements ITileNetwork 
         receivedCoords = true;
         if (!world.isRemote) {
             mainPos = pos;
-            Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), new Range4D(Coord4D.get(this)));
+            Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
         }
     }
 
@@ -54,7 +53,7 @@ public class TileEntityBoundingBlock extends TileEntity implements ITileNetwork 
                     onNoPower();
                 }
                 prevPower = power;
-                Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(tileEntity), tileEntity.getNetworkedData(new TileNetworkList())), new Range4D(Coord4D.get(this)));
+                Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(tileEntity), tileEntity.getNetworkedData(new TileNetworkList())), this);
             }
         }
     }

--- a/src/main/java/mekanism/common/tile/TileEntityBoundingBlock.java
+++ b/src/main/java/mekanism/common/tile/TileEntityBoundingBlock.java
@@ -29,7 +29,7 @@ public class TileEntityBoundingBlock extends TileEntity implements ITileNetwork 
         receivedCoords = true;
         if (!world.isRemote) {
             mainPos = pos;
-            Mekanism.packetHandler.sendToAllTracking(this);
+            Mekanism.packetHandler.sendUpdatePacket(this);
         }
     }
 

--- a/src/main/java/mekanism/common/tile/TileEntityChargepad.java
+++ b/src/main/java/mekanism/common/tile/TileEntityChargepad.java
@@ -4,12 +4,10 @@ import io.netty.buffer.ByteBuf;
 import java.util.List;
 import java.util.Random;
 import javax.annotation.Nonnull;
-import mekanism.api.Coord4D;
 import mekanism.api.TileNetworkList;
 import mekanism.common.Mekanism;
 import mekanism.common.block.states.BlockStateMachine.MachineType;
 import mekanism.common.entity.EntityRobit;
-import mekanism.common.network.PacketTileEntity.TileEntityMessage;
 import mekanism.common.tile.prefab.TileEntityEffectsBlock;
 import mekanism.common.util.ChargeUtils;
 import mekanism.common.util.InventoryUtils;
@@ -108,7 +106,7 @@ public class TileEntityChargepad extends TileEntityEffectsBlock {
     public void setActive(boolean active) {
         isActive = active;
         if (clientActive != active) {
-            Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
+            Mekanism.packetHandler.sendToAllTracking(this);
         }
         clientActive = active;
     }

--- a/src/main/java/mekanism/common/tile/TileEntityChargepad.java
+++ b/src/main/java/mekanism/common/tile/TileEntityChargepad.java
@@ -106,7 +106,7 @@ public class TileEntityChargepad extends TileEntityEffectsBlock {
     public void setActive(boolean active) {
         isActive = active;
         if (clientActive != active) {
-            Mekanism.packetHandler.sendToAllTracking(this);
+            Mekanism.packetHandler.sendUpdatePacket(this);
         }
         clientActive = active;
     }

--- a/src/main/java/mekanism/common/tile/TileEntityChargepad.java
+++ b/src/main/java/mekanism/common/tile/TileEntityChargepad.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.Random;
 import javax.annotation.Nonnull;
 import mekanism.api.Coord4D;
-import mekanism.api.Range4D;
 import mekanism.api.TileNetworkList;
 import mekanism.common.Mekanism;
 import mekanism.common.block.states.BlockStateMachine.MachineType;
@@ -109,7 +108,7 @@ public class TileEntityChargepad extends TileEntityEffectsBlock {
     public void setActive(boolean active) {
         isActive = active;
         if (clientActive != active) {
-            Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), new Range4D(Coord4D.get(this)));
+            Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
         }
         clientActive = active;
     }

--- a/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
+++ b/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
@@ -279,7 +279,7 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
 
             if (playersUsing.size() > 0) {
                 for (EntityPlayer player : playersUsing) {
-                    Mekanism.packetHandler.sendTo(new TileEntityMessage(Coord4D.get(this), getSmallPacket(new TileNetworkList())), (EntityPlayerMP) player);
+                    Mekanism.packetHandler.sendTo(new TileEntityMessage(this, getSmallPacket(new TileNetworkList())), (EntityPlayerMP) player);
                 }
             }
             prevEnergy = getEnergy();
@@ -521,7 +521,7 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
     public void openInventory(@Nonnull EntityPlayer player) {
         super.openInventory(player);
         if (!world.isRemote) {
-            Mekanism.packetHandler.sendTo(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), (EntityPlayerMP) player);
+            Mekanism.packetHandler.sendTo(new TileEntityMessage(this, getNetworkedData(new TileNetworkList())), (EntityPlayerMP) player);
         }
     }
 
@@ -631,7 +631,7 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
 
             MekanismUtils.saveChunk(this);
             for (EntityPlayer player : playersUsing) {
-                Mekanism.packetHandler.sendTo(new TileEntityMessage(Coord4D.get(this), getGenericPacket(new TileNetworkList())), (EntityPlayerMP) player);
+                Mekanism.packetHandler.sendTo(new TileEntityMessage(this, getGenericPacket(new TileNetworkList())), (EntityPlayerMP) player);
             }
             return;
         }
@@ -809,7 +809,7 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
     public void setActive(boolean active) {
         isActive = active;
         if (clientActive != active) {
-            Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
+            Mekanism.packetHandler.sendToAllTracking(this);
             clientActive = active;
         }
     }
@@ -1001,7 +1001,7 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
             return new Object[]{searcher != null ? searcher.found : 0};
         }
         for (EntityPlayer player : playersUsing) {
-            Mekanism.packetHandler.sendTo(new TileEntityMessage(Coord4D.get(this), getGenericPacket(new TileNetworkList())), (EntityPlayerMP) player);
+            Mekanism.packetHandler.sendTo(new TileEntityMessage(this, getGenericPacket(new TileNetworkList())), (EntityPlayerMP) player);
         }
         return null;
     }

--- a/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
+++ b/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
@@ -521,7 +521,7 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
     public void openInventory(@Nonnull EntityPlayer player) {
         super.openInventory(player);
         if (!world.isRemote) {
-            Mekanism.packetHandler.sendTo(new TileEntityMessage(this, getNetworkedData(new TileNetworkList())), (EntityPlayerMP) player);
+            Mekanism.packetHandler.sendTo(new TileEntityMessage(this), (EntityPlayerMP) player);
         }
     }
 

--- a/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
+++ b/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
@@ -809,7 +809,7 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
     public void setActive(boolean active) {
         isActive = active;
         if (clientActive != active) {
-            Mekanism.packetHandler.sendToAllTracking(this);
+            Mekanism.packetHandler.sendUpdatePacket(this);
             clientActive = active;
         }
     }

--- a/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
+++ b/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
@@ -809,7 +809,7 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
     public void setActive(boolean active) {
         isActive = active;
         if (clientActive != active) {
-            Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), new Range4D(Coord4D.get(this)));
+            Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
             clientActive = active;
         }
     }

--- a/src/main/java/mekanism/common/tile/TileEntityDynamicTank.java
+++ b/src/main/java/mekanism/common/tile/TileEntityDynamicTank.java
@@ -103,7 +103,7 @@ public class TileEntityDynamicTank extends TileEntityMultiblock<SynchronizedTank
         int needed = (structure.volume * TankUpdateProtocol.FLUID_PER_TANK) - (structure.fluidStored != null ? structure.fluidStored.amount : 0);
         if (FluidContainerUtils.isFluidContainer(structure.inventory.get(0))) {
             structure.fluidStored = FluidContainerUtils.handleContainerItem(this, structure.inventory, structure.editMode, structure.fluidStored, needed, 0, 1, null);
-            Mekanism.packetHandler.sendToAllTracking(this);
+            Mekanism.packetHandler.sendUpdatePacket(this);
         }
     }
 
@@ -111,7 +111,7 @@ public class TileEntityDynamicTank extends TileEntityMultiblock<SynchronizedTank
     public boolean onActivate(EntityPlayer player, EnumHand hand, ItemStack stack) {
         if (!player.isSneaking() && structure != null) {
             if (!BlockBasic.manageInventory(player, this, hand, stack)) {
-                Mekanism.packetHandler.sendToAllTracking(this);
+                Mekanism.packetHandler.sendUpdatePacket(this);
                 player.openGui(Mekanism.instance, 18, world, getPos().getX(), getPos().getY(), getPos().getZ());
             } else {
                 player.inventory.markDirty();

--- a/src/main/java/mekanism/common/tile/TileEntityDynamicTank.java
+++ b/src/main/java/mekanism/common/tile/TileEntityDynamicTank.java
@@ -14,7 +14,6 @@ import mekanism.common.content.tank.SynchronizedTankData.ValveData;
 import mekanism.common.content.tank.TankCache;
 import mekanism.common.content.tank.TankUpdateProtocol;
 import mekanism.common.multiblock.MultiblockManager;
-import mekanism.common.network.PacketTileEntity.TileEntityMessage;
 import mekanism.common.util.FluidContainerUtils;
 import mekanism.common.util.FluidContainerUtils.ContainerEditMode;
 import mekanism.common.util.InventoryUtils;
@@ -104,7 +103,7 @@ public class TileEntityDynamicTank extends TileEntityMultiblock<SynchronizedTank
         int needed = (structure.volume * TankUpdateProtocol.FLUID_PER_TANK) - (structure.fluidStored != null ? structure.fluidStored.amount : 0);
         if (FluidContainerUtils.isFluidContainer(structure.inventory.get(0))) {
             structure.fluidStored = FluidContainerUtils.handleContainerItem(this, structure.inventory, structure.editMode, structure.fluidStored, needed, 0, 1, null);
-            Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
+            Mekanism.packetHandler.sendToAllTracking(this);
         }
     }
 
@@ -112,7 +111,7 @@ public class TileEntityDynamicTank extends TileEntityMultiblock<SynchronizedTank
     public boolean onActivate(EntityPlayer player, EnumHand hand, ItemStack stack) {
         if (!player.isSneaking() && structure != null) {
             if (!BlockBasic.manageInventory(player, this, hand, stack)) {
-                Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
+                Mekanism.packetHandler.sendToAllTracking(this);
                 player.openGui(Mekanism.instance, 18, world, getPos().getX(), getPos().getY(), getPos().getZ());
             } else {
                 player.inventory.markDirty();

--- a/src/main/java/mekanism/common/tile/TileEntityDynamicTank.java
+++ b/src/main/java/mekanism/common/tile/TileEntityDynamicTank.java
@@ -5,7 +5,6 @@ import java.util.HashSet;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import mekanism.api.Coord4D;
-import mekanism.api.Range4D;
 import mekanism.api.TileNetworkList;
 import mekanism.common.Mekanism;
 import mekanism.common.base.IFluidContainerManager;
@@ -105,7 +104,7 @@ public class TileEntityDynamicTank extends TileEntityMultiblock<SynchronizedTank
         int needed = (structure.volume * TankUpdateProtocol.FLUID_PER_TANK) - (structure.fluidStored != null ? structure.fluidStored.amount : 0);
         if (FluidContainerUtils.isFluidContainer(structure.inventory.get(0))) {
             structure.fluidStored = FluidContainerUtils.handleContainerItem(this, structure.inventory, structure.editMode, structure.fluidStored, needed, 0, 1, null);
-            Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), new Range4D(Coord4D.get(this)));
+            Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
         }
     }
 
@@ -113,7 +112,7 @@ public class TileEntityDynamicTank extends TileEntityMultiblock<SynchronizedTank
     public boolean onActivate(EntityPlayer player, EnumHand hand, ItemStack stack) {
         if (!player.isSneaking() && structure != null) {
             if (!BlockBasic.manageInventory(player, this, hand, stack)) {
-                Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), new Range4D(Coord4D.get(this)));
+                Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
                 player.openGui(Mekanism.instance, 18, world, getPos().getX(), getPos().getY(), getPos().getZ());
             } else {
                 player.inventory.markDirty();

--- a/src/main/java/mekanism/common/tile/TileEntityEnergyCube.java
+++ b/src/main/java/mekanism/common/tile/TileEntityEnergyCube.java
@@ -5,7 +5,6 @@ import javax.annotation.Nonnull;
 import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
 import mekanism.api.IConfigCardAccess;
-import mekanism.api.Range4D;
 import mekanism.api.TileNetworkList;
 import mekanism.api.transmitters.TransmissionType;
 import mekanism.common.Mekanism;
@@ -92,7 +91,7 @@ public class TileEntityEnergyCube extends TileEntityElectricBlock implements ICo
             }
             int newScale = getScaledEnergyLevel(20);
             if (newScale != prevScale) {
-                Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), new Range4D(Coord4D.get(this)));
+                Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
             }
             prevScale = newScale;
         }
@@ -104,7 +103,7 @@ public class TileEntityEnergyCube extends TileEntityElectricBlock implements ICo
             return false;
         }
         tier = EnergyCubeTier.values()[upgradeTier.ordinal()];
-        Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), new Range4D(Coord4D.get(this)));
+        Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
         markDirty();
         return true;
     }

--- a/src/main/java/mekanism/common/tile/TileEntityEnergyCube.java
+++ b/src/main/java/mekanism/common/tile/TileEntityEnergyCube.java
@@ -2,7 +2,6 @@ package mekanism.common.tile;
 
 import io.netty.buffer.ByteBuf;
 import javax.annotation.Nonnull;
-import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
 import mekanism.api.IConfigCardAccess;
 import mekanism.api.TileNetworkList;
@@ -15,7 +14,6 @@ import mekanism.common.base.ISideConfiguration;
 import mekanism.common.base.ITierUpgradeable;
 import mekanism.common.capabilities.Capabilities;
 import mekanism.common.integration.computer.IComputerIntegration;
-import mekanism.common.network.PacketTileEntity.TileEntityMessage;
 import mekanism.common.security.ISecurityTile;
 import mekanism.common.tier.BaseTier;
 import mekanism.common.tier.EnergyCubeTier;
@@ -91,7 +89,7 @@ public class TileEntityEnergyCube extends TileEntityElectricBlock implements ICo
             }
             int newScale = getScaledEnergyLevel(20);
             if (newScale != prevScale) {
-                Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
+                Mekanism.packetHandler.sendToAllTracking(this);
             }
             prevScale = newScale;
         }
@@ -103,7 +101,7 @@ public class TileEntityEnergyCube extends TileEntityElectricBlock implements ICo
             return false;
         }
         tier = EnergyCubeTier.values()[upgradeTier.ordinal()];
-        Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
+        Mekanism.packetHandler.sendToAllTracking(this);
         markDirty();
         return true;
     }

--- a/src/main/java/mekanism/common/tile/TileEntityEnergyCube.java
+++ b/src/main/java/mekanism/common/tile/TileEntityEnergyCube.java
@@ -89,7 +89,7 @@ public class TileEntityEnergyCube extends TileEntityElectricBlock implements ICo
             }
             int newScale = getScaledEnergyLevel(20);
             if (newScale != prevScale) {
-                Mekanism.packetHandler.sendToAllTracking(this);
+                Mekanism.packetHandler.sendUpdatePacket(this);
             }
             prevScale = newScale;
         }
@@ -101,7 +101,7 @@ public class TileEntityEnergyCube extends TileEntityElectricBlock implements ICo
             return false;
         }
         tier = EnergyCubeTier.values()[upgradeTier.ordinal()];
-        Mekanism.packetHandler.sendToAllTracking(this);
+        Mekanism.packetHandler.sendUpdatePacket(this);
         markDirty();
         return true;
     }

--- a/src/main/java/mekanism/common/tile/TileEntityFactory.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFactory.java
@@ -219,7 +219,7 @@ public class TileEntityFactory extends TileEntityMachine implements IComputerInt
 
         factory.upgraded = true;
         factory.markDirty();
-        Mekanism.packetHandler.sendToAllTracking(factory);
+        Mekanism.packetHandler.sendUpdatePacket(factory);
         return true;
     }
 

--- a/src/main/java/mekanism/common/tile/TileEntityFactory.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFactory.java
@@ -4,7 +4,6 @@ import io.netty.buffer.ByteBuf;
 import java.util.Arrays;
 import java.util.Objects;
 import javax.annotation.Nonnull;
-import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
 import mekanism.api.IConfigCardAccess.ISpecialConfigData;
 import mekanism.api.TileNetworkList;
@@ -33,7 +32,6 @@ import mekanism.common.base.ITierUpgradeable;
 import mekanism.common.block.states.BlockStateMachine.MachineType;
 import mekanism.common.capabilities.Capabilities;
 import mekanism.common.integration.computer.IComputerIntegration;
-import mekanism.common.network.PacketTileEntity.TileEntityMessage;
 import mekanism.common.recipe.RecipeHandler;
 import mekanism.common.recipe.inputs.AdvancedMachineInput;
 import mekanism.common.recipe.inputs.DoubleMachineInput;
@@ -221,7 +219,7 @@ public class TileEntityFactory extends TileEntityMachine implements IComputerInt
 
         factory.upgraded = true;
         factory.markDirty();
-        Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(factory), factory.getNetworkedData(new TileNetworkList())), factory);
+        Mekanism.packetHandler.sendToAllTracking(factory);
         return true;
     }
 

--- a/src/main/java/mekanism/common/tile/TileEntityFactory.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFactory.java
@@ -7,7 +7,6 @@ import javax.annotation.Nonnull;
 import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
 import mekanism.api.IConfigCardAccess.ISpecialConfigData;
-import mekanism.api.Range4D;
 import mekanism.api.TileNetworkList;
 import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasStack;
@@ -222,7 +221,7 @@ public class TileEntityFactory extends TileEntityMachine implements IComputerInt
 
         factory.upgraded = true;
         factory.markDirty();
-        Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(factory), factory.getNetworkedData(new TileNetworkList())), new Range4D(Coord4D.get(factory)));
+        Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(factory), factory.getNetworkedData(new TileNetworkList())), factory);
         return true;
     }
 

--- a/src/main/java/mekanism/common/tile/TileEntityFluidTank.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFluidTank.java
@@ -91,7 +91,7 @@ public class TileEntityFluidTank extends TileEntityContainerBlock implements IAc
         }
         tier = FluidTankTier.values()[upgradeTier.ordinal()];
         fluidTank.setCapacity(tier.getStorage());
-        Mekanism.packetHandler.sendToAllTracking(this);
+        Mekanism.packetHandler.sendUpdatePacket(this);
         markDirty();
         return true;
     }
@@ -332,7 +332,7 @@ public class TileEntityFluidTank extends TileEntityContainerBlock implements IAc
     public void setActive(boolean active) {
         isActive = active;
         if (clientActive != active && updateDelay == 0) {
-            Mekanism.packetHandler.sendToAllTracking(this);
+            Mekanism.packetHandler.sendUpdatePacket(this);
             updateDelay = 10;
             clientActive = active;
         }

--- a/src/main/java/mekanism/common/tile/TileEntityFluidTank.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFluidTank.java
@@ -151,7 +151,7 @@ public class TileEntityFluidTank extends TileEntityContainerBlock implements IAc
                 currentRedstoneLevel = newRedstoneLevel;
             }
             if (needsPacket) {
-                Mekanism.packetHandler.sendToAllAround(new TileEntityMessage(this, getNetworkedData(new TileNetworkList())), Coord4D.get(this).getTargetPoint(50));
+                Mekanism.packetHandler.sendToAllAround(new TileEntityMessage(this), Coord4D.get(this).getTargetPoint(50));
             }
             needsPacket = false;
         }

--- a/src/main/java/mekanism/common/tile/TileEntityFluidTank.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFluidTank.java
@@ -5,7 +5,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import mekanism.api.Coord4D;
 import mekanism.api.IConfigurable;
-import mekanism.api.Range4D;
 import mekanism.api.TileNetworkList;
 import mekanism.common.Mekanism;
 import mekanism.common.base.FluidHandlerWrapper;
@@ -92,7 +91,7 @@ public class TileEntityFluidTank extends TileEntityContainerBlock implements IAc
         }
         tier = FluidTankTier.values()[upgradeTier.ordinal()];
         fluidTank.setCapacity(tier.getStorage());
-        Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), new Range4D(Coord4D.get(this)));
+        Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
         markDirty();
         return true;
     }
@@ -334,7 +333,7 @@ public class TileEntityFluidTank extends TileEntityContainerBlock implements IAc
     public void setActive(boolean active) {
         isActive = active;
         if (clientActive != active && updateDelay == 0) {
-            Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), new Range4D(Coord4D.get(this)));
+            Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
             updateDelay = 10;
             clientActive = active;
         }

--- a/src/main/java/mekanism/common/tile/TileEntityFluidTank.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFluidTank.java
@@ -91,7 +91,7 @@ public class TileEntityFluidTank extends TileEntityContainerBlock implements IAc
         }
         tier = FluidTankTier.values()[upgradeTier.ordinal()];
         fluidTank.setCapacity(tier.getStorage());
-        Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
+        Mekanism.packetHandler.sendToAllTracking(this);
         markDirty();
         return true;
     }
@@ -151,8 +151,7 @@ public class TileEntityFluidTank extends TileEntityContainerBlock implements IAc
                 currentRedstoneLevel = newRedstoneLevel;
             }
             if (needsPacket) {
-                Mekanism.packetHandler.sendToAllAround(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())),
-                      Coord4D.get(this).getTargetPoint(50));
+                Mekanism.packetHandler.sendToAllAround(new TileEntityMessage(this, getNetworkedData(new TileNetworkList())), Coord4D.get(this).getTargetPoint(50));
             }
             needsPacket = false;
         }
@@ -333,7 +332,7 @@ public class TileEntityFluidTank extends TileEntityContainerBlock implements IAc
     public void setActive(boolean active) {
         isActive = active;
         if (clientActive != active && updateDelay == 0) {
-            Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
+            Mekanism.packetHandler.sendToAllTracking(this);
             updateDelay = 10;
             clientActive = active;
         }

--- a/src/main/java/mekanism/common/tile/TileEntityFuelwoodHeater.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFuelwoodHeater.java
@@ -9,7 +9,6 @@ import mekanism.common.Mekanism;
 import mekanism.common.base.IActiveState;
 import mekanism.common.capabilities.Capabilities;
 import mekanism.common.config.MekanismConfig;
-import mekanism.common.network.PacketTileEntity.TileEntityMessage;
 import mekanism.common.security.ISecurityTile;
 import mekanism.common.tile.component.TileComponentSecurity;
 import mekanism.common.tile.prefab.TileEntityContainerBlock;
@@ -71,7 +70,7 @@ public class TileEntityFuelwoodHeater extends TileEntityContainerBlock implement
             if (updateDelay > 0) {
                 updateDelay--;
                 if (updateDelay == 0 && clientActive != isActive) {
-                    Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
+                    Mekanism.packetHandler.sendToAllTracking(this);
                 }
             }
 
@@ -175,7 +174,7 @@ public class TileEntityFuelwoodHeater extends TileEntityContainerBlock implement
     public void setActive(boolean active) {
         isActive = active;
         if (clientActive != active && updateDelay == 0) {
-            Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
+            Mekanism.packetHandler.sendToAllTracking(this);
             updateDelay = 10;
             clientActive = active;
         }

--- a/src/main/java/mekanism/common/tile/TileEntityFuelwoodHeater.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFuelwoodHeater.java
@@ -4,7 +4,6 @@ import io.netty.buffer.ByteBuf;
 import javax.annotation.Nonnull;
 import mekanism.api.Coord4D;
 import mekanism.api.IHeatTransfer;
-import mekanism.api.Range4D;
 import mekanism.api.TileNetworkList;
 import mekanism.common.Mekanism;
 import mekanism.common.base.IActiveState;
@@ -72,7 +71,7 @@ public class TileEntityFuelwoodHeater extends TileEntityContainerBlock implement
             if (updateDelay > 0) {
                 updateDelay--;
                 if (updateDelay == 0 && clientActive != isActive) {
-                    Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), new Range4D(Coord4D.get(this)));
+                    Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
                 }
             }
 
@@ -176,7 +175,7 @@ public class TileEntityFuelwoodHeater extends TileEntityContainerBlock implement
     public void setActive(boolean active) {
         isActive = active;
         if (clientActive != active && updateDelay == 0) {
-            Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), new Range4D(Coord4D.get(this)));
+            Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
             updateDelay = 10;
             clientActive = active;
         }

--- a/src/main/java/mekanism/common/tile/TileEntityFuelwoodHeater.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFuelwoodHeater.java
@@ -70,7 +70,7 @@ public class TileEntityFuelwoodHeater extends TileEntityContainerBlock implement
             if (updateDelay > 0) {
                 updateDelay--;
                 if (updateDelay == 0 && clientActive != isActive) {
-                    Mekanism.packetHandler.sendToAllTracking(this);
+                    Mekanism.packetHandler.sendUpdatePacket(this);
                 }
             }
 
@@ -174,7 +174,7 @@ public class TileEntityFuelwoodHeater extends TileEntityContainerBlock implement
     public void setActive(boolean active) {
         isActive = active;
         if (clientActive != active && updateDelay == 0) {
-            Mekanism.packetHandler.sendToAllTracking(this);
+            Mekanism.packetHandler.sendUpdatePacket(this);
             updateDelay = 10;
             clientActive = active;
         }

--- a/src/main/java/mekanism/common/tile/TileEntityGasTank.java
+++ b/src/main/java/mekanism/common/tile/TileEntityGasTank.java
@@ -241,7 +241,7 @@ public class TileEntityGasTank extends TileEntityContainerBlock implements IGasH
                 dumping = GasMode.values()[index];
             }
             for (EntityPlayer player : playersUsing) {
-                Mekanism.packetHandler.sendTo(new TileEntityMessage(this, getNetworkedData(new TileNetworkList())), (EntityPlayerMP) player);
+                Mekanism.packetHandler.sendTo(new TileEntityMessage(this), (EntityPlayerMP) player);
             }
 
             return;

--- a/src/main/java/mekanism/common/tile/TileEntityGasTank.java
+++ b/src/main/java/mekanism/common/tile/TileEntityGasTank.java
@@ -4,7 +4,6 @@ import io.netty.buffer.ByteBuf;
 import javax.annotation.Nonnull;
 import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
-import mekanism.api.Range4D;
 import mekanism.api.TileNetworkList;
 import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasStack;
@@ -135,7 +134,7 @@ public class TileEntityGasTank extends TileEntityContainerBlock implements IGasH
         }
         tier = GasTankTier.values()[upgradeTier.ordinal()];
         gasTank.setMaxGas(tier.getStorage());
-        Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), new Range4D(Coord4D.get(this)));
+        Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
         markDirty();
         return true;
     }

--- a/src/main/java/mekanism/common/tile/TileEntityGasTank.java
+++ b/src/main/java/mekanism/common/tile/TileEntityGasTank.java
@@ -133,7 +133,7 @@ public class TileEntityGasTank extends TileEntityContainerBlock implements IGasH
         }
         tier = GasTankTier.values()[upgradeTier.ordinal()];
         gasTank.setMaxGas(tier.getStorage());
-        Mekanism.packetHandler.sendToAllTracking(this);
+        Mekanism.packetHandler.sendUpdatePacket(this);
         markDirty();
         return true;
     }

--- a/src/main/java/mekanism/common/tile/TileEntityGasTank.java
+++ b/src/main/java/mekanism/common/tile/TileEntityGasTank.java
@@ -2,7 +2,6 @@ package mekanism.common.tile;
 
 import io.netty.buffer.ByteBuf;
 import javax.annotation.Nonnull;
-import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
 import mekanism.api.TileNetworkList;
 import mekanism.api.gas.Gas;
@@ -134,7 +133,7 @@ public class TileEntityGasTank extends TileEntityContainerBlock implements IGasH
         }
         tier = GasTankTier.values()[upgradeTier.ordinal()];
         gasTank.setMaxGas(tier.getStorage());
-        Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
+        Mekanism.packetHandler.sendToAllTracking(this);
         markDirty();
         return true;
     }
@@ -242,7 +241,7 @@ public class TileEntityGasTank extends TileEntityContainerBlock implements IGasH
                 dumping = GasMode.values()[index];
             }
             for (EntityPlayer player : playersUsing) {
-                Mekanism.packetHandler.sendTo(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), (EntityPlayerMP) player);
+                Mekanism.packetHandler.sendTo(new TileEntityMessage(this, getNetworkedData(new TileNetworkList())), (EntityPlayerMP) player);
             }
 
             return;

--- a/src/main/java/mekanism/common/tile/TileEntityInductionCasing.java
+++ b/src/main/java/mekanism/common/tile/TileEntityInductionCasing.java
@@ -3,7 +3,6 @@ package mekanism.common.tile;
 import io.netty.buffer.ByteBuf;
 import javax.annotation.Nonnull;
 import mekanism.api.Coord4D;
-import mekanism.api.Range4D;
 import mekanism.api.TileNetworkList;
 import mekanism.api.energy.IStrictEnergyStorage;
 import mekanism.common.Mekanism;
@@ -57,7 +56,7 @@ public class TileEntityInductionCasing extends TileEntityMultiblock<Synchronized
     @Override
     public boolean onActivate(EntityPlayer player, EnumHand hand, ItemStack stack) {
         if (!player.isSneaking() && structure != null) {
-            Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), new Range4D(Coord4D.get(this)));
+            Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
             player.openGui(Mekanism.instance, 49, world, getPos().getX(), getPos().getY(), getPos().getZ());
             return true;
         }

--- a/src/main/java/mekanism/common/tile/TileEntityInductionCasing.java
+++ b/src/main/java/mekanism/common/tile/TileEntityInductionCasing.java
@@ -2,7 +2,6 @@ package mekanism.common.tile;
 
 import io.netty.buffer.ByteBuf;
 import javax.annotation.Nonnull;
-import mekanism.api.Coord4D;
 import mekanism.api.TileNetworkList;
 import mekanism.api.energy.IStrictEnergyStorage;
 import mekanism.common.Mekanism;
@@ -12,7 +11,6 @@ import mekanism.common.content.matrix.MatrixUpdateProtocol;
 import mekanism.common.content.matrix.SynchronizedMatrixData;
 import mekanism.common.integration.computer.IComputerIntegration;
 import mekanism.common.multiblock.MultiblockManager;
-import mekanism.common.network.PacketTileEntity.TileEntityMessage;
 import mekanism.common.util.ChargeUtils;
 import mekanism.common.util.InventoryUtils;
 import mekanism.common.util.LangUtils;
@@ -56,7 +54,7 @@ public class TileEntityInductionCasing extends TileEntityMultiblock<Synchronized
     @Override
     public boolean onActivate(EntityPlayer player, EnumHand hand, ItemStack stack) {
         if (!player.isSneaking() && structure != null) {
-            Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
+            Mekanism.packetHandler.sendToAllTracking(this);
             player.openGui(Mekanism.instance, 49, world, getPos().getX(), getPos().getY(), getPos().getZ());
             return true;
         }

--- a/src/main/java/mekanism/common/tile/TileEntityInductionCasing.java
+++ b/src/main/java/mekanism/common/tile/TileEntityInductionCasing.java
@@ -54,7 +54,7 @@ public class TileEntityInductionCasing extends TileEntityMultiblock<Synchronized
     @Override
     public boolean onActivate(EntityPlayer player, EnumHand hand, ItemStack stack) {
         if (!player.isSneaking() && structure != null) {
-            Mekanism.packetHandler.sendToAllTracking(this);
+            Mekanism.packetHandler.sendUpdatePacket(this);
             player.openGui(Mekanism.instance, 49, world, getPos().getX(), getPos().getY(), getPos().getZ());
             return true;
         }

--- a/src/main/java/mekanism/common/tile/TileEntityInductionPort.java
+++ b/src/main/java/mekanism/common/tile/TileEntityInductionPort.java
@@ -12,7 +12,6 @@ import javax.annotation.Nonnull;
 import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
 import mekanism.api.IConfigurable;
-import mekanism.api.Range4D;
 import mekanism.api.TileNetworkList;
 import mekanism.common.Mekanism;
 import mekanism.common.base.IActiveState;
@@ -349,7 +348,7 @@ public class TileEntityInductionPort extends TileEntityInductionCasing implement
             String modeText = " " + (mode ? EnumColor.DARK_RED : EnumColor.DARK_GREEN) + LangUtils.transOutputInput(mode) + ".";
             player.sendMessage(new TextComponentString(EnumColor.DARK_BLUE + Mekanism.LOG_TAG + " " + EnumColor.GREY +
                                                        LangUtils.localize("tooltip.configurator.inductionPortMode") + modeText));
-            Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), new Range4D(Coord4D.get(this)));
+            Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
             markDirty();
         }
         return EnumActionResult.SUCCESS;

--- a/src/main/java/mekanism/common/tile/TileEntityInductionPort.java
+++ b/src/main/java/mekanism/common/tile/TileEntityInductionPort.java
@@ -347,7 +347,7 @@ public class TileEntityInductionPort extends TileEntityInductionCasing implement
             String modeText = " " + (mode ? EnumColor.DARK_RED : EnumColor.DARK_GREEN) + LangUtils.transOutputInput(mode) + ".";
             player.sendMessage(new TextComponentString(EnumColor.DARK_BLUE + Mekanism.LOG_TAG + " " + EnumColor.GREY +
                                                        LangUtils.localize("tooltip.configurator.inductionPortMode") + modeText));
-            Mekanism.packetHandler.sendToAllTracking(this);
+            Mekanism.packetHandler.sendUpdatePacket(this);
             markDirty();
         }
         return EnumActionResult.SUCCESS;

--- a/src/main/java/mekanism/common/tile/TileEntityInductionPort.java
+++ b/src/main/java/mekanism/common/tile/TileEntityInductionPort.java
@@ -23,7 +23,6 @@ import mekanism.common.config.MekanismConfig;
 import mekanism.common.integration.MekanismHooks;
 import mekanism.common.integration.forgeenergy.ForgeEnergyIntegration;
 import mekanism.common.integration.tesla.TeslaIntegration;
-import mekanism.common.network.PacketTileEntity.TileEntityMessage;
 import mekanism.common.util.CableUtils;
 import mekanism.common.util.CapabilityUtils;
 import mekanism.common.util.ChargeUtils;
@@ -348,7 +347,7 @@ public class TileEntityInductionPort extends TileEntityInductionCasing implement
             String modeText = " " + (mode ? EnumColor.DARK_RED : EnumColor.DARK_GREEN) + LangUtils.transOutputInput(mode) + ".";
             player.sendMessage(new TextComponentString(EnumColor.DARK_BLUE + Mekanism.LOG_TAG + " " + EnumColor.GREY +
                                                        LangUtils.localize("tooltip.configurator.inductionPortMode") + modeText));
-            Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
+            Mekanism.packetHandler.sendToAllTracking(this);
             markDirty();
         }
         return EnumActionResult.SUCCESS;

--- a/src/main/java/mekanism/common/tile/TileEntityLaserAmplifier.java
+++ b/src/main/java/mekanism/common/tile/TileEntityLaserAmplifier.java
@@ -106,8 +106,7 @@ public class TileEntityLaserAmplifier extends TileEntityContainerBlock implement
                 if (!on || firing != lastFired) {
                     on = true;
                     lastFired = firing;
-                    Mekanism.packetHandler.sendToAllAround(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())),
-                          Coord4D.get(this).getTargetPoint(50D));
+                    Mekanism.packetHandler.sendToAllAround(new TileEntityMessage(this, getNetworkedData(new TileNetworkList())), Coord4D.get(this).getTargetPoint(50D));
                 }
 
                 LaserInfo info = LaserManager.fireLaser(this, facing, firing, world);
@@ -135,8 +134,7 @@ public class TileEntityLaserAmplifier extends TileEntityContainerBlock implement
             } else if (on) {
                 on = false;
                 diggingProgress = 0;
-                Mekanism.packetHandler.sendToAllAround(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())),
-                      Coord4D.get(this).getTargetPoint(50D));
+                Mekanism.packetHandler.sendToAllAround(new TileEntityMessage(this, getNetworkedData(new TileNetworkList())), Coord4D.get(this).getTargetPoint(50D));
             }
 
             if (outputMode != RedstoneOutput.ENTITY_DETECTION) {

--- a/src/main/java/mekanism/common/tile/TileEntityLaserAmplifier.java
+++ b/src/main/java/mekanism/common/tile/TileEntityLaserAmplifier.java
@@ -106,7 +106,7 @@ public class TileEntityLaserAmplifier extends TileEntityContainerBlock implement
                 if (!on || firing != lastFired) {
                     on = true;
                     lastFired = firing;
-                    Mekanism.packetHandler.sendToAllAround(new TileEntityMessage(this, getNetworkedData(new TileNetworkList())), Coord4D.get(this).getTargetPoint(50D));
+                    Mekanism.packetHandler.sendToAllAround(new TileEntityMessage(this), Coord4D.get(this).getTargetPoint(50D));
                 }
 
                 LaserInfo info = LaserManager.fireLaser(this, facing, firing, world);
@@ -134,7 +134,7 @@ public class TileEntityLaserAmplifier extends TileEntityContainerBlock implement
             } else if (on) {
                 on = false;
                 diggingProgress = 0;
-                Mekanism.packetHandler.sendToAllAround(new TileEntityMessage(this, getNetworkedData(new TileNetworkList())), Coord4D.get(this).getTargetPoint(50D));
+                Mekanism.packetHandler.sendToAllAround(new TileEntityMessage(this), Coord4D.get(this).getTargetPoint(50D));
             }
 
             if (outputMode != RedstoneOutput.ENTITY_DETECTION) {

--- a/src/main/java/mekanism/common/tile/TileEntityLaserTractorBeam.java
+++ b/src/main/java/mekanism/common/tile/TileEntityLaserTractorBeam.java
@@ -84,7 +84,7 @@ public class TileEntityLaserTractorBeam extends TileEntityContainerBlock impleme
             if (!on || firing != lastFired) {
                 on = true;
                 lastFired = firing;
-                Mekanism.packetHandler.sendToAllAround(new TileEntityMessage(this, getNetworkedData(new TileNetworkList())), Coord4D.get(this).getTargetPoint(50D));
+                Mekanism.packetHandler.sendToAllAround(new TileEntityMessage(this), Coord4D.get(this).getTargetPoint(50D));
             }
 
             LaserInfo info = LaserManager.fireLaser(this, facing, firing, world);
@@ -115,7 +115,7 @@ public class TileEntityLaserTractorBeam extends TileEntityContainerBlock impleme
         } else if (on) {
             on = false;
             diggingProgress = 0;
-            Mekanism.packetHandler.sendToAllAround(new TileEntityMessage(this, getNetworkedData(new TileNetworkList())), Coord4D.get(this).getTargetPoint(50D));
+            Mekanism.packetHandler.sendToAllAround(new TileEntityMessage(this), Coord4D.get(this).getTargetPoint(50D));
         }
     }
 

--- a/src/main/java/mekanism/common/tile/TileEntityLaserTractorBeam.java
+++ b/src/main/java/mekanism/common/tile/TileEntityLaserTractorBeam.java
@@ -84,8 +84,7 @@ public class TileEntityLaserTractorBeam extends TileEntityContainerBlock impleme
             if (!on || firing != lastFired) {
                 on = true;
                 lastFired = firing;
-                Mekanism.packetHandler.sendToAllAround(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())),
-                      Coord4D.get(this).getTargetPoint(50D));
+                Mekanism.packetHandler.sendToAllAround(new TileEntityMessage(this, getNetworkedData(new TileNetworkList())), Coord4D.get(this).getTargetPoint(50D));
             }
 
             LaserInfo info = LaserManager.fireLaser(this, facing, firing, world);
@@ -116,8 +115,7 @@ public class TileEntityLaserTractorBeam extends TileEntityContainerBlock impleme
         } else if (on) {
             on = false;
             diggingProgress = 0;
-            Mekanism.packetHandler.sendToAllAround(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())),
-                  Coord4D.get(this).getTargetPoint(50D));
+            Mekanism.packetHandler.sendToAllAround(new TileEntityMessage(this, getNetworkedData(new TileNetworkList())), Coord4D.get(this).getTargetPoint(50D));
         }
     }
 

--- a/src/main/java/mekanism/common/tile/TileEntityLogisticalSorter.java
+++ b/src/main/java/mekanism/common/tile/TileEntityLogisticalSorter.java
@@ -384,7 +384,7 @@ public class TileEntityLogisticalSorter extends TileEntityEffectsBlock implement
     @Override
     public void openInventory(@Nonnull EntityPlayer player) {
         if (!world.isRemote) {
-            Mekanism.packetHandler.sendToAllTracking(this);
+            Mekanism.packetHandler.sendUpdatePacket(this);
         }
     }
 

--- a/src/main/java/mekanism/common/tile/TileEntityLogisticalSorter.java
+++ b/src/main/java/mekanism/common/tile/TileEntityLogisticalSorter.java
@@ -134,7 +134,7 @@ public class TileEntityLogisticalSorter extends TileEntityEffectsBlock implement
             }
             if (playersUsing.size() > 0) {
                 for (EntityPlayer player : playersUsing) {
-                    Mekanism.packetHandler.sendTo(new TileEntityMessage(Coord4D.get(this), getGenericPacket(new TileNetworkList())), (EntityPlayerMP) player);
+                    Mekanism.packetHandler.sendTo(new TileEntityMessage(this, getGenericPacket(new TileNetworkList())), (EntityPlayerMP) player);
                 }
             }
 
@@ -384,7 +384,7 @@ public class TileEntityLogisticalSorter extends TileEntityEffectsBlock implement
     @Override
     public void openInventory(@Nonnull EntityPlayer player) {
         if (!world.isRemote) {
-            Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getFilterPacket(new TileNetworkList())), this);
+            Mekanism.packetHandler.sendToAllTracking(this);
         }
     }
 
@@ -607,7 +607,7 @@ public class TileEntityLogisticalSorter extends TileEntityEffectsBlock implement
         }
 
         for (EntityPlayer player : playersUsing) {
-            Mekanism.packetHandler.sendTo(new TileEntityMessage(Coord4D.get(this), getGenericPacket(new TileNetworkList())), (EntityPlayerMP) player);
+            Mekanism.packetHandler.sendTo(new TileEntityMessage(this, getGenericPacket(new TileNetworkList())), (EntityPlayerMP) player);
         }
         return null;
     }

--- a/src/main/java/mekanism/common/tile/TileEntityLogisticalSorter.java
+++ b/src/main/java/mekanism/common/tile/TileEntityLogisticalSorter.java
@@ -6,7 +6,6 @@ import javax.annotation.Nonnull;
 import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
 import mekanism.api.IConfigCardAccess.ISpecialConfigData;
-import mekanism.api.Range4D;
 import mekanism.api.TileNetworkList;
 import mekanism.common.HashList;
 import mekanism.common.Mekanism;
@@ -385,7 +384,7 @@ public class TileEntityLogisticalSorter extends TileEntityEffectsBlock implement
     @Override
     public void openInventory(@Nonnull EntityPlayer player) {
         if (!world.isRemote) {
-            Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(this), getFilterPacket(new TileNetworkList())), new Range4D(Coord4D.get(this)));
+            Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getFilterPacket(new TileNetworkList())), this);
         }
     }
 

--- a/src/main/java/mekanism/common/tile/TileEntityMultiblock.java
+++ b/src/main/java/mekanism/common/tile/TileEntityMultiblock.java
@@ -119,7 +119,7 @@ public abstract class TileEntityMultiblock<T extends SynchronizedData<T>> extend
                     }
                 }
 
-                Mekanism.packetHandler.sendToAllTracking(this);
+                Mekanism.packetHandler.sendUpdatePacket(this);
             }
 
             prevStructure = structure != null;
@@ -150,7 +150,7 @@ public abstract class TileEntityMultiblock<T extends SynchronizedData<T>> extend
             for (Coord4D obj : structure.locations) {
                 TileEntityMultiblock<T> tileEntity = (TileEntityMultiblock<T>) obj.getTileEntity(world);
                 if (tileEntity != null && tileEntity.isRendering) {
-                    Mekanism.packetHandler.sendToAllTracking(tileEntity);
+                    Mekanism.packetHandler.sendUpdatePacket(tileEntity);
                 }
             }
         }

--- a/src/main/java/mekanism/common/tile/TileEntityMultiblock.java
+++ b/src/main/java/mekanism/common/tile/TileEntityMultiblock.java
@@ -13,7 +13,6 @@ import mekanism.common.multiblock.MultiblockCache;
 import mekanism.common.multiblock.MultiblockManager;
 import mekanism.common.multiblock.SynchronizedData;
 import mekanism.common.multiblock.UpdateProtocol;
-import mekanism.common.network.PacketTileEntity.TileEntityMessage;
 import mekanism.common.tile.prefab.TileEntityContainerBlock;
 import mekanism.common.util.MekanismUtils;
 import net.minecraft.entity.player.EntityPlayer;
@@ -120,7 +119,7 @@ public abstract class TileEntityMultiblock<T extends SynchronizedData<T>> extend
                     }
                 }
 
-                Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(thisCoord, getNetworkedData(new TileNetworkList())), thisCoord);
+                Mekanism.packetHandler.sendToAllTracking(this);
             }
 
             prevStructure = structure != null;
@@ -151,7 +150,7 @@ public abstract class TileEntityMultiblock<T extends SynchronizedData<T>> extend
             for (Coord4D obj : structure.locations) {
                 TileEntityMultiblock<T> tileEntity = (TileEntityMultiblock<T>) obj.getTileEntity(world);
                 if (tileEntity != null && tileEntity.isRendering) {
-                    Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(tileEntity), tileEntity.getNetworkedData(new TileNetworkList())), tileEntity);
+                    Mekanism.packetHandler.sendToAllTracking(tileEntity);
                 }
             }
         }

--- a/src/main/java/mekanism/common/tile/TileEntityMultiblock.java
+++ b/src/main/java/mekanism/common/tile/TileEntityMultiblock.java
@@ -4,7 +4,6 @@ import io.netty.buffer.ByteBuf;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import mekanism.api.Coord4D;
-import mekanism.api.Range4D;
 import mekanism.api.TileNetworkList;
 import mekanism.common.Mekanism;
 import mekanism.common.PacketHandler;
@@ -121,7 +120,7 @@ public abstract class TileEntityMultiblock<T extends SynchronizedData<T>> extend
                     }
                 }
 
-                Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(thisCoord, getNetworkedData(new TileNetworkList())), new Range4D(thisCoord));
+                Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(thisCoord, getNetworkedData(new TileNetworkList())), thisCoord);
             }
 
             prevStructure = structure != null;
@@ -152,8 +151,7 @@ public abstract class TileEntityMultiblock<T extends SynchronizedData<T>> extend
             for (Coord4D obj : structure.locations) {
                 TileEntityMultiblock<T> tileEntity = (TileEntityMultiblock<T>) obj.getTileEntity(world);
                 if (tileEntity != null && tileEntity.isRendering) {
-                    Coord4D tileCoord = Coord4D.get(tileEntity);
-                    Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(tileCoord, tileEntity.getNetworkedData(new TileNetworkList())), new Range4D(tileCoord));
+                    Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(tileEntity), tileEntity.getNetworkedData(new TileNetworkList())), tileEntity);
                 }
             }
         }

--- a/src/main/java/mekanism/common/tile/TileEntityOredictionificator.java
+++ b/src/main/java/mekanism/common/tile/TileEntityOredictionificator.java
@@ -234,7 +234,7 @@ public class TileEntityOredictionificator extends TileEntityContainerBlock imple
     @Override
     public void openInventory(@Nonnull EntityPlayer player) {
         if (!world.isRemote) {
-            Mekanism.packetHandler.sendToAllTracking(this);
+            Mekanism.packetHandler.sendUpdatePacket(this);
         }
     }
 

--- a/src/main/java/mekanism/common/tile/TileEntityOredictionificator.java
+++ b/src/main/java/mekanism/common/tile/TileEntityOredictionificator.java
@@ -4,7 +4,6 @@ import io.netty.buffer.ByteBuf;
 import java.util.Arrays;
 import java.util.List;
 import javax.annotation.Nonnull;
-import mekanism.api.Coord4D;
 import mekanism.api.IConfigCardAccess.ISpecialConfigData;
 import mekanism.api.TileNetworkList;
 import mekanism.common.HashList;
@@ -60,7 +59,7 @@ public class TileEntityOredictionificator extends TileEntityContainerBlock imple
         if (!world.isRemote) {
             if (playersUsing.size() > 0) {
                 for (EntityPlayer player : playersUsing) {
-                    Mekanism.packetHandler.sendTo(new TileEntityMessage(Coord4D.get(this), getGenericPacket(new TileNetworkList())), (EntityPlayerMP) player);
+                    Mekanism.packetHandler.sendTo(new TileEntityMessage(this, getGenericPacket(new TileNetworkList())), (EntityPlayerMP) player);
                 }
             }
 
@@ -235,7 +234,7 @@ public class TileEntityOredictionificator extends TileEntityContainerBlock imple
     @Override
     public void openInventory(@Nonnull EntityPlayer player) {
         if (!world.isRemote) {
-            Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getFilterPacket(new TileNetworkList())), this);
+            Mekanism.packetHandler.sendToAllTracking(this);
         }
     }
 

--- a/src/main/java/mekanism/common/tile/TileEntityOredictionificator.java
+++ b/src/main/java/mekanism/common/tile/TileEntityOredictionificator.java
@@ -6,7 +6,6 @@ import java.util.List;
 import javax.annotation.Nonnull;
 import mekanism.api.Coord4D;
 import mekanism.api.IConfigCardAccess.ISpecialConfigData;
-import mekanism.api.Range4D;
 import mekanism.api.TileNetworkList;
 import mekanism.common.HashList;
 import mekanism.common.Mekanism;
@@ -236,7 +235,7 @@ public class TileEntityOredictionificator extends TileEntityContainerBlock imple
     @Override
     public void openInventory(@Nonnull EntityPlayer player) {
         if (!world.isRemote) {
-            Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(this), getFilterPacket(new TileNetworkList())), new Range4D(Coord4D.get(this)));
+            Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getFilterPacket(new TileNetworkList())), this);
         }
     }
 

--- a/src/main/java/mekanism/common/tile/TileEntityResistiveHeater.java
+++ b/src/main/java/mekanism/common/tile/TileEntityResistiveHeater.java
@@ -4,7 +4,6 @@ import io.netty.buffer.ByteBuf;
 import javax.annotation.Nonnull;
 import mekanism.api.Coord4D;
 import mekanism.api.IHeatTransfer;
-import mekanism.api.Range4D;
 import mekanism.api.TileNetworkList;
 import mekanism.common.Mekanism;
 import mekanism.common.base.IRedstoneControl;
@@ -97,7 +96,7 @@ public class TileEntityResistiveHeater extends TileEntityEffectsBlock implements
 
             soundScale = newSoundScale;
             if (packet) {
-                Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), new Range4D(Coord4D.get(this)));
+                Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
             }
         }
     }
@@ -241,7 +240,7 @@ public class TileEntityResistiveHeater extends TileEntityEffectsBlock implements
     public void setActive(boolean active) {
         isActive = active;
         if (clientActive != active && updateDelay == 0) {
-            Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), new Range4D(Coord4D.get(this)));
+            Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
             updateDelay = 10;
             clientActive = active;
         }

--- a/src/main/java/mekanism/common/tile/TileEntityResistiveHeater.java
+++ b/src/main/java/mekanism/common/tile/TileEntityResistiveHeater.java
@@ -95,7 +95,7 @@ public class TileEntityResistiveHeater extends TileEntityEffectsBlock implements
 
             soundScale = newSoundScale;
             if (packet) {
-                Mekanism.packetHandler.sendToAllTracking(this);
+                Mekanism.packetHandler.sendUpdatePacket(this);
             }
         }
     }
@@ -239,7 +239,7 @@ public class TileEntityResistiveHeater extends TileEntityEffectsBlock implements
     public void setActive(boolean active) {
         isActive = active;
         if (clientActive != active && updateDelay == 0) {
-            Mekanism.packetHandler.sendToAllTracking(this);
+            Mekanism.packetHandler.sendUpdatePacket(this);
             updateDelay = 10;
             clientActive = active;
         }

--- a/src/main/java/mekanism/common/tile/TileEntityResistiveHeater.java
+++ b/src/main/java/mekanism/common/tile/TileEntityResistiveHeater.java
@@ -11,7 +11,6 @@ import mekanism.common.block.states.BlockStateMachine.MachineType;
 import mekanism.common.capabilities.Capabilities;
 import mekanism.common.config.MekanismConfig;
 import mekanism.common.integration.computer.IComputerIntegration;
-import mekanism.common.network.PacketTileEntity.TileEntityMessage;
 import mekanism.common.security.ISecurityTile;
 import mekanism.common.tile.component.TileComponentSecurity;
 import mekanism.common.tile.prefab.TileEntityEffectsBlock;
@@ -96,7 +95,7 @@ public class TileEntityResistiveHeater extends TileEntityEffectsBlock implements
 
             soundScale = newSoundScale;
             if (packet) {
-                Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
+                Mekanism.packetHandler.sendToAllTracking(this);
             }
         }
     }
@@ -240,7 +239,7 @@ public class TileEntityResistiveHeater extends TileEntityEffectsBlock implements
     public void setActive(boolean active) {
         isActive = active;
         if (clientActive != active && updateDelay == 0) {
-            Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
+            Mekanism.packetHandler.sendToAllTracking(this);
             updateDelay = 10;
             clientActive = active;
         }

--- a/src/main/java/mekanism/common/tile/TileEntityRotaryCondensentrator.java
+++ b/src/main/java/mekanism/common/tile/TileEntityRotaryCondensentrator.java
@@ -4,7 +4,6 @@ import io.netty.buffer.ByteBuf;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import mekanism.api.Coord4D;
 import mekanism.api.TileNetworkList;
 import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasRegistry;
@@ -160,7 +159,7 @@ public class TileEntityRotaryCondensentrator extends TileEntityMachine implement
                 mode = mode == 0 ? 1 : 0;
             }
             for (EntityPlayer player : playersUsing) {
-                Mekanism.packetHandler.sendTo(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), (EntityPlayerMP) player);
+                Mekanism.packetHandler.sendTo(new TileEntityMessage(this, getNetworkedData(new TileNetworkList())), (EntityPlayerMP) player);
             }
 
             return;

--- a/src/main/java/mekanism/common/tile/TileEntityRotaryCondensentrator.java
+++ b/src/main/java/mekanism/common/tile/TileEntityRotaryCondensentrator.java
@@ -159,7 +159,7 @@ public class TileEntityRotaryCondensentrator extends TileEntityMachine implement
                 mode = mode == 0 ? 1 : 0;
             }
             for (EntityPlayer player : playersUsing) {
-                Mekanism.packetHandler.sendTo(new TileEntityMessage(this, getNetworkedData(new TileNetworkList())), (EntityPlayerMP) player);
+                Mekanism.packetHandler.sendTo(new TileEntityMessage(this), (EntityPlayerMP) player);
             }
 
             return;

--- a/src/main/java/mekanism/common/tile/TileEntitySeismicVibrator.java
+++ b/src/main/java/mekanism/common/tile/TileEntitySeismicVibrator.java
@@ -10,7 +10,6 @@ import mekanism.common.base.IBoundingBlock;
 import mekanism.common.base.IRedstoneControl;
 import mekanism.common.block.states.BlockStateMachine.MachineType;
 import mekanism.common.config.MekanismConfig;
-import mekanism.common.network.PacketTileEntity.TileEntityMessage;
 import mekanism.common.security.ISecurityTile;
 import mekanism.common.tile.component.TileComponentSecurity;
 import mekanism.common.tile.prefab.TileEntityElectricBlock;
@@ -66,7 +65,7 @@ public class TileEntitySeismicVibrator extends TileEntityElectricBlock implement
             if (updateDelay > 0) {
                 updateDelay--;
                 if (updateDelay == 0 && clientActive != isActive) {
-                    Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
+                    Mekanism.packetHandler.sendToAllTracking(this);
                 }
             }
 
@@ -138,7 +137,7 @@ public class TileEntitySeismicVibrator extends TileEntityElectricBlock implement
     public void setActive(boolean active) {
         isActive = active;
         if (clientActive != active && updateDelay == 0) {
-            Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
+            Mekanism.packetHandler.sendToAllTracking(this);
             updateDelay = 10;
             clientActive = active;
         }

--- a/src/main/java/mekanism/common/tile/TileEntitySeismicVibrator.java
+++ b/src/main/java/mekanism/common/tile/TileEntitySeismicVibrator.java
@@ -3,7 +3,6 @@ package mekanism.common.tile;
 import io.netty.buffer.ByteBuf;
 import javax.annotation.Nonnull;
 import mekanism.api.Coord4D;
-import mekanism.api.Range4D;
 import mekanism.api.TileNetworkList;
 import mekanism.common.Mekanism;
 import mekanism.common.base.IActiveState;
@@ -67,7 +66,7 @@ public class TileEntitySeismicVibrator extends TileEntityElectricBlock implement
             if (updateDelay > 0) {
                 updateDelay--;
                 if (updateDelay == 0 && clientActive != isActive) {
-                    Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), new Range4D(Coord4D.get(this)));
+                    Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
                 }
             }
 
@@ -139,7 +138,7 @@ public class TileEntitySeismicVibrator extends TileEntityElectricBlock implement
     public void setActive(boolean active) {
         isActive = active;
         if (clientActive != active && updateDelay == 0) {
-            Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), new Range4D(Coord4D.get(this)));
+            Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
             updateDelay = 10;
             clientActive = active;
         }

--- a/src/main/java/mekanism/common/tile/TileEntitySeismicVibrator.java
+++ b/src/main/java/mekanism/common/tile/TileEntitySeismicVibrator.java
@@ -65,7 +65,7 @@ public class TileEntitySeismicVibrator extends TileEntityElectricBlock implement
             if (updateDelay > 0) {
                 updateDelay--;
                 if (updateDelay == 0 && clientActive != isActive) {
-                    Mekanism.packetHandler.sendToAllTracking(this);
+                    Mekanism.packetHandler.sendUpdatePacket(this);
                 }
             }
 
@@ -137,7 +137,7 @@ public class TileEntitySeismicVibrator extends TileEntityElectricBlock implement
     public void setActive(boolean active) {
         isActive = active;
         if (clientActive != active && updateDelay == 0) {
-            Mekanism.packetHandler.sendToAllTracking(this);
+            Mekanism.packetHandler.sendUpdatePacket(this);
             updateDelay = 10;
             clientActive = active;
         }

--- a/src/main/java/mekanism/common/tile/TileEntitySolarNeutronActivator.java
+++ b/src/main/java/mekanism/common/tile/TileEntitySolarNeutronActivator.java
@@ -4,7 +4,6 @@ import io.netty.buffer.ByteBuf;
 import java.util.List;
 import javax.annotation.Nonnull;
 import mekanism.api.Coord4D;
-import mekanism.api.Range4D;
 import mekanism.api.TileNetworkList;
 import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasStack;
@@ -107,7 +106,7 @@ public class TileEntitySolarNeutronActivator extends TileEntityContainerBlock im
             // Every 20 ticks (once a second), send update to client. Note that this is a 50% reduction in network
             // traffic from previous implementation that send the update every 10 ticks.
             if (world.getTotalWorldTime() % 20 == 0) {
-                Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), new Range4D(Coord4D.get(this)));
+                Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
             }
 
             int newRedstoneLevel = getRedstoneLevel();
@@ -301,7 +300,7 @@ public class TileEntitySolarNeutronActivator extends TileEntityContainerBlock im
         boolean stateChange = isActive != active;
         if (stateChange) {
             isActive = active;
-            Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), new Range4D(Coord4D.get(this)));
+            Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
         }
     }
 

--- a/src/main/java/mekanism/common/tile/TileEntitySolarNeutronActivator.java
+++ b/src/main/java/mekanism/common/tile/TileEntitySolarNeutronActivator.java
@@ -105,7 +105,7 @@ public class TileEntitySolarNeutronActivator extends TileEntityContainerBlock im
             // Every 20 ticks (once a second), send update to client. Note that this is a 50% reduction in network
             // traffic from previous implementation that send the update every 10 ticks.
             if (world.getTotalWorldTime() % 20 == 0) {
-                Mekanism.packetHandler.sendToAllTracking(this);
+                Mekanism.packetHandler.sendUpdatePacket(this);
             }
 
             int newRedstoneLevel = getRedstoneLevel();
@@ -299,7 +299,7 @@ public class TileEntitySolarNeutronActivator extends TileEntityContainerBlock im
         boolean stateChange = isActive != active;
         if (stateChange) {
             isActive = active;
-            Mekanism.packetHandler.sendToAllTracking(this);
+            Mekanism.packetHandler.sendUpdatePacket(this);
         }
     }
 

--- a/src/main/java/mekanism/common/tile/TileEntitySolarNeutronActivator.java
+++ b/src/main/java/mekanism/common/tile/TileEntitySolarNeutronActivator.java
@@ -22,7 +22,6 @@ import mekanism.common.base.ISustainedData;
 import mekanism.common.base.ITankManager;
 import mekanism.common.base.IUpgradeTile;
 import mekanism.common.capabilities.Capabilities;
-import mekanism.common.network.PacketTileEntity.TileEntityMessage;
 import mekanism.common.recipe.RecipeHandler;
 import mekanism.common.recipe.inputs.GasInput;
 import mekanism.common.recipe.machines.SolarNeutronRecipe;
@@ -106,7 +105,7 @@ public class TileEntitySolarNeutronActivator extends TileEntityContainerBlock im
             // Every 20 ticks (once a second), send update to client. Note that this is a 50% reduction in network
             // traffic from previous implementation that send the update every 10 ticks.
             if (world.getTotalWorldTime() % 20 == 0) {
-                Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
+                Mekanism.packetHandler.sendToAllTracking(this);
             }
 
             int newRedstoneLevel = getRedstoneLevel();
@@ -300,7 +299,7 @@ public class TileEntitySolarNeutronActivator extends TileEntityContainerBlock im
         boolean stateChange = isActive != active;
         if (stateChange) {
             isActive = active;
-            Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
+            Mekanism.packetHandler.sendToAllTracking(this);
         }
     }
 

--- a/src/main/java/mekanism/common/tile/TileEntitySuperheatingElement.java
+++ b/src/main/java/mekanism/common/tile/TileEntitySuperheatingElement.java
@@ -28,7 +28,7 @@ public class TileEntitySuperheatingElement extends TileEntityInternalMultiblock 
         super.setMultiblock(id);
 
         if (packet && !world.isRemote) {
-            Mekanism.packetHandler.sendToAllTracking(this);
+            Mekanism.packetHandler.sendUpdatePacket(this);
         }
     }
 

--- a/src/main/java/mekanism/common/tile/TileEntitySuperheatingElement.java
+++ b/src/main/java/mekanism/common/tile/TileEntitySuperheatingElement.java
@@ -1,7 +1,6 @@
 package mekanism.common.tile;
 
 import mekanism.api.Coord4D;
-import mekanism.api.Range4D;
 import mekanism.api.TileNetworkList;
 import mekanism.common.Mekanism;
 import mekanism.common.content.boiler.SynchronizedBoilerData;
@@ -32,7 +31,7 @@ public class TileEntitySuperheatingElement extends TileEntityInternalMultiblock 
         super.setMultiblock(id);
 
         if (packet && !world.isRemote) {
-            Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), new Range4D(Coord4D.get(this)));
+            Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
         }
     }
 

--- a/src/main/java/mekanism/common/tile/TileEntitySuperheatingElement.java
+++ b/src/main/java/mekanism/common/tile/TileEntitySuperheatingElement.java
@@ -1,11 +1,8 @@
 package mekanism.common.tile;
 
-import mekanism.api.Coord4D;
-import mekanism.api.TileNetworkList;
 import mekanism.common.Mekanism;
 import mekanism.common.content.boiler.SynchronizedBoilerData;
 import mekanism.common.multiblock.TileEntityInternalMultiblock;
-import mekanism.common.network.PacketTileEntity.TileEntityMessage;
 import mekanism.common.util.MekanismUtils;
 import net.minecraft.util.ITickable;
 
@@ -31,7 +28,7 @@ public class TileEntitySuperheatingElement extends TileEntityInternalMultiblock 
         super.setMultiblock(id);
 
         if (packet && !world.isRemote) {
-            Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
+            Mekanism.packetHandler.sendToAllTracking(this);
         }
     }
 

--- a/src/main/java/mekanism/common/tile/TileEntityTeleporter.java
+++ b/src/main/java/mekanism/common/tile/TileEntityTeleporter.java
@@ -162,8 +162,7 @@ public class TileEntityTeleporter extends TileEntityElectricBlock implements ICo
 
             shouldRender = status == 1 || status > 4;
             if (shouldRender != prevShouldRender) {
-                Mekanism.packetHandler.sendToAllAround(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())),
-                      Coord4D.get(this).getTargetPoint(40D));
+                Mekanism.packetHandler.sendToAllAround(new TileEntityMessage(this, getNetworkedData(new TileNetworkList())), Coord4D.get(this).getTargetPoint(40D));
                 //This also means the comparator output changed so notify the neighbors we have a change
                 MekanismUtils.notifyLoadedNeighborsOfTileChange(world, Coord4D.get(this));
             }

--- a/src/main/java/mekanism/common/tile/TileEntityTeleporter.java
+++ b/src/main/java/mekanism/common/tile/TileEntityTeleporter.java
@@ -162,7 +162,7 @@ public class TileEntityTeleporter extends TileEntityElectricBlock implements ICo
 
             shouldRender = status == 1 || status > 4;
             if (shouldRender != prevShouldRender) {
-                Mekanism.packetHandler.sendToAllAround(new TileEntityMessage(this, getNetworkedData(new TileNetworkList())), Coord4D.get(this).getTargetPoint(40D));
+                Mekanism.packetHandler.sendToAllAround(new TileEntityMessage(this), Coord4D.get(this).getTargetPoint(40D));
                 //This also means the comparator output changed so notify the neighbors we have a change
                 MekanismUtils.notifyLoadedNeighborsOfTileChange(world, Coord4D.get(this));
             }

--- a/src/main/java/mekanism/common/tile/TileEntityTeleporter.java
+++ b/src/main/java/mekanism/common/tile/TileEntityTeleporter.java
@@ -9,7 +9,6 @@ import java.util.UUID;
 import javax.annotation.Nonnull;
 import mekanism.api.Chunk3D;
 import mekanism.api.Coord4D;
-import mekanism.api.Range4D;
 import mekanism.api.TileNetworkList;
 import mekanism.common.Mekanism;
 import mekanism.common.MekanismBlocks;
@@ -334,7 +333,7 @@ public class TileEntityTeleporter extends TileEntityElectricBlock implements ICo
             entity.changeDimension(coord.dimensionId, (world, entity2, yaw) -> entity2.setPositionAndUpdate(coord.x + 0.5, coord.y + 1, coord.z + 0.5));
         } else {
             entity.setPositionAndUpdate(coord.x + 0.5, coord.y + 1, coord.z + 0.5);
-            Mekanism.packetHandler.sendToReceivers(new EntityMoveMessage(entity), new Range4D(new Coord4D(entity)));
+            Mekanism.packetHandler.sendToAllTracking(new EntityMoveMessage(entity), new Coord4D(entity));
         }
     }
 

--- a/src/main/java/mekanism/common/tile/TileEntityThermalEvaporationController.java
+++ b/src/main/java/mekanism/common/tile/TileEntityThermalEvaporationController.java
@@ -132,7 +132,7 @@ public class TileEntityThermalEvaporationController extends TileEntityThermalEva
             }
             if (structured) {
                 if (Math.abs((float) inputTank.getFluidAmount() / inputTank.getCapacity() - prevScale) > 0.01) {
-                    Mekanism.packetHandler.sendToAllTracking(this);
+                    Mekanism.packetHandler.sendUpdatePacket(this);
                     prevScale = (float) inputTank.getFluidAmount() / inputTank.getCapacity();
                 }
             }
@@ -168,7 +168,7 @@ public class TileEntityThermalEvaporationController extends TileEntityThermalEva
                 clearStructure();
                 structured = buildStructure();
                 if (structured != clientStructured) {
-                    Mekanism.packetHandler.sendToAllTracking(this);
+                    Mekanism.packetHandler.sendUpdatePacket(this);
                     clientStructured = structured;
                 }
 

--- a/src/main/java/mekanism/common/tile/TileEntityThermalEvaporationController.java
+++ b/src/main/java/mekanism/common/tile/TileEntityThermalEvaporationController.java
@@ -6,7 +6,6 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import mekanism.api.Coord4D;
 import mekanism.api.IEvaporationSolar;
-import mekanism.api.Range4D;
 import mekanism.api.TileNetworkList;
 import mekanism.common.Mekanism;
 import mekanism.common.base.IActiveState;
@@ -134,7 +133,7 @@ public class TileEntityThermalEvaporationController extends TileEntityThermalEva
             }
             if (structured) {
                 if (Math.abs((float) inputTank.getFluidAmount() / inputTank.getCapacity() - prevScale) > 0.01) {
-                    Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), new Range4D(Coord4D.get(this)));
+                    Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
                     prevScale = (float) inputTank.getFluidAmount() / inputTank.getCapacity();
                 }
             }
@@ -170,7 +169,7 @@ public class TileEntityThermalEvaporationController extends TileEntityThermalEva
                 clearStructure();
                 structured = buildStructure();
                 if (structured != clientStructured) {
-                    Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), new Range4D(Coord4D.get(this)));
+                    Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
                     clientStructured = structured;
                 }
 

--- a/src/main/java/mekanism/common/tile/TileEntityThermalEvaporationController.java
+++ b/src/main/java/mekanism/common/tile/TileEntityThermalEvaporationController.java
@@ -13,7 +13,6 @@ import mekanism.common.base.ITankManager;
 import mekanism.common.capabilities.Capabilities;
 import mekanism.common.config.MekanismConfig;
 import mekanism.common.content.tank.TankUpdateProtocol;
-import mekanism.common.network.PacketTileEntity.TileEntityMessage;
 import mekanism.common.recipe.RecipeHandler;
 import mekanism.common.recipe.RecipeHandler.Recipe;
 import mekanism.common.recipe.inputs.FluidInput;
@@ -133,7 +132,7 @@ public class TileEntityThermalEvaporationController extends TileEntityThermalEva
             }
             if (structured) {
                 if (Math.abs((float) inputTank.getFluidAmount() / inputTank.getCapacity() - prevScale) > 0.01) {
-                    Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
+                    Mekanism.packetHandler.sendToAllTracking(this);
                     prevScale = (float) inputTank.getFluidAmount() / inputTank.getCapacity();
                 }
             }
@@ -169,7 +168,7 @@ public class TileEntityThermalEvaporationController extends TileEntityThermalEva
                 clearStructure();
                 structured = buildStructure();
                 if (structured != clientStructured) {
-                    Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
+                    Mekanism.packetHandler.sendToAllTracking(this);
                     clientStructured = structured;
                 }
 

--- a/src/main/java/mekanism/common/tile/component/TileComponentUpgrade.java
+++ b/src/main/java/mekanism/common/tile/component/TileComponentUpgrade.java
@@ -64,7 +64,7 @@ public class TileComponentUpgrade implements ITileComponent {
                         upgradeTicks = 0;
                         addUpgrade(type);
                         tileEntity.inventory.get(upgradeSlot).shrink(1);
-                        Mekanism.packetHandler.sendToAllTracking(tileEntity);
+                        Mekanism.packetHandler.sendUpdatePacket(tileEntity);
                         tileEntity.markDirty();
                     }
                 } else {

--- a/src/main/java/mekanism/common/tile/component/TileComponentUpgrade.java
+++ b/src/main/java/mekanism/common/tile/component/TileComponentUpgrade.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import mekanism.api.Coord4D;
-import mekanism.api.Range4D;
 import mekanism.api.TileNetworkList;
 import mekanism.common.Mekanism;
 import mekanism.common.Upgrade;
@@ -67,8 +66,7 @@ public class TileComponentUpgrade implements ITileComponent {
                         upgradeTicks = 0;
                         addUpgrade(type);
                         tileEntity.inventory.get(upgradeSlot).shrink(1);
-                        Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(tileEntity), tileEntity.getNetworkedData(new TileNetworkList())),
-                              new Range4D(Coord4D.get(tileEntity)));
+                        Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(tileEntity), tileEntity.getNetworkedData(new TileNetworkList())), tileEntity);
                         tileEntity.markDirty();
                     }
                 } else {

--- a/src/main/java/mekanism/common/tile/component/TileComponentUpgrade.java
+++ b/src/main/java/mekanism/common/tile/component/TileComponentUpgrade.java
@@ -6,13 +6,11 @@ import java.util.EnumSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import mekanism.api.Coord4D;
 import mekanism.api.TileNetworkList;
 import mekanism.common.Mekanism;
 import mekanism.common.Upgrade;
 import mekanism.common.base.ITileComponent;
 import mekanism.common.base.IUpgradeItem;
-import mekanism.common.network.PacketTileEntity.TileEntityMessage;
 import mekanism.common.tile.prefab.TileEntityContainerBlock;
 import net.minecraft.nbt.NBTTagCompound;
 
@@ -66,7 +64,7 @@ public class TileComponentUpgrade implements ITileComponent {
                         upgradeTicks = 0;
                         addUpgrade(type);
                         tileEntity.inventory.get(upgradeSlot).shrink(1);
-                        Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(tileEntity), tileEntity.getNetworkedData(new TileNetworkList())), tileEntity);
+                        Mekanism.packetHandler.sendToAllTracking(tileEntity);
                         tileEntity.markDirty();
                     }
                 } else {

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityBasicBlock.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityBasicBlock.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import mekanism.api.Coord4D;
-import mekanism.api.Range4D;
 import mekanism.api.TileNetworkList;
 import mekanism.common.Mekanism;
 import mekanism.common.base.ITileComponent;
@@ -201,7 +200,7 @@ public abstract class TileEntityBasicBlock extends TileEntity implements ITileNe
             facing = EnumFacing.byIndex(direction);
         }
         if (!(facing == clientFacing || world.isRemote)) {
-            Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), new Range4D(Coord4D.get(this)));
+            Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
             markDirty();
             clientFacing = facing;
         }
@@ -239,7 +238,7 @@ public abstract class TileEntityBasicBlock extends TileEntity implements ITileNe
         boolean power = world.getRedstonePowerFromNeighbors(getPos()) > 0;
         if (redstone != power) {
             redstone = power;
-            Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), new Range4D(Coord4D.get(this)));
+            Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
             onPowerChange();
         }
     }

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityBasicBlock.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityBasicBlock.java
@@ -87,7 +87,7 @@ public abstract class TileEntityBasicBlock extends TileEntity implements ITileNe
         if (!world.isRemote) {
             if (doAutoSync && playersUsing.size() > 0) {
                 for (EntityPlayer player : playersUsing) {
-                    Mekanism.packetHandler.sendTo(new TileEntityMessage(this, getNetworkedData(new TileNetworkList())), (EntityPlayerMP) player);
+                    Mekanism.packetHandler.sendTo(new TileEntityMessage(this), (EntityPlayerMP) player);
                 }
             }
         }

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityBasicBlock.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityBasicBlock.java
@@ -87,7 +87,7 @@ public abstract class TileEntityBasicBlock extends TileEntity implements ITileNe
         if (!world.isRemote) {
             if (doAutoSync && playersUsing.size() > 0) {
                 for (EntityPlayer player : playersUsing) {
-                    Mekanism.packetHandler.sendTo(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), (EntityPlayerMP) player);
+                    Mekanism.packetHandler.sendTo(new TileEntityMessage(this, getNetworkedData(new TileNetworkList())), (EntityPlayerMP) player);
                 }
             }
         }
@@ -200,7 +200,7 @@ public abstract class TileEntityBasicBlock extends TileEntity implements ITileNe
             facing = EnumFacing.byIndex(direction);
         }
         if (!(facing == clientFacing || world.isRemote)) {
-            Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
+            Mekanism.packetHandler.sendToAllTracking(this);
             markDirty();
             clientFacing = facing;
         }
@@ -238,7 +238,7 @@ public abstract class TileEntityBasicBlock extends TileEntity implements ITileNe
         boolean power = world.getRedstonePowerFromNeighbors(getPos()) > 0;
         if (redstone != power) {
             redstone = power;
-            Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
+            Mekanism.packetHandler.sendToAllTracking(this);
             onPowerChange();
         }
     }

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityBasicBlock.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityBasicBlock.java
@@ -200,7 +200,7 @@ public abstract class TileEntityBasicBlock extends TileEntity implements ITileNe
             facing = EnumFacing.byIndex(direction);
         }
         if (!(facing == clientFacing || world.isRemote)) {
-            Mekanism.packetHandler.sendToAllTracking(this);
+            Mekanism.packetHandler.sendUpdatePacket(this);
             markDirty();
             clientFacing = facing;
         }
@@ -238,7 +238,7 @@ public abstract class TileEntityBasicBlock extends TileEntity implements ITileNe
         boolean power = world.getRedstonePowerFromNeighbors(getPos()) > 0;
         if (redstone != power) {
             redstone = power;
-            Mekanism.packetHandler.sendToAllTracking(this);
+            Mekanism.packetHandler.sendUpdatePacket(this);
             onPowerChange();
         }
     }

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityEffectsBlock.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityEffectsBlock.java
@@ -2,7 +2,6 @@ package mekanism.common.tile.prefab;
 
 import io.netty.buffer.ByteBuf;
 import javax.annotation.Nonnull;
-import mekanism.api.Coord4D;
 import mekanism.api.TileNetworkList;
 import mekanism.client.sound.SoundHandler;
 import mekanism.common.Mekanism;
@@ -10,7 +9,6 @@ import mekanism.common.Upgrade;
 import mekanism.common.base.IActiveState;
 import mekanism.common.base.IUpgradeTile;
 import mekanism.common.config.MekanismConfig;
-import mekanism.common.network.PacketTileEntity.TileEntityMessage;
 import mekanism.common.util.MekanismUtils;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.audio.ISound;
@@ -144,7 +142,7 @@ public abstract class TileEntityEffectsBlock extends TileEntityElectricBlock imp
         boolean stateChange = isActive != active;
         if (stateChange) {
             isActive = active;
-            Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
+            Mekanism.packetHandler.sendToAllTracking(this);
         }
     }
 

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityEffectsBlock.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityEffectsBlock.java
@@ -3,7 +3,6 @@ package mekanism.common.tile.prefab;
 import io.netty.buffer.ByteBuf;
 import javax.annotation.Nonnull;
 import mekanism.api.Coord4D;
-import mekanism.api.Range4D;
 import mekanism.api.TileNetworkList;
 import mekanism.client.sound.SoundHandler;
 import mekanism.common.Mekanism;
@@ -145,7 +144,7 @@ public abstract class TileEntityEffectsBlock extends TileEntityElectricBlock imp
         boolean stateChange = isActive != active;
         if (stateChange) {
             isActive = active;
-            Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), new Range4D(Coord4D.get(this)));
+            Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
         }
     }
 

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityEffectsBlock.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityEffectsBlock.java
@@ -142,7 +142,7 @@ public abstract class TileEntityEffectsBlock extends TileEntityElectricBlock imp
         boolean stateChange = isActive != active;
         if (stateChange) {
             isActive = active;
-            Mekanism.packetHandler.sendToAllTracking(this);
+            Mekanism.packetHandler.sendUpdatePacket(this);
         }
     }
 

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityDiversionTransporter.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityDiversionTransporter.java
@@ -10,7 +10,6 @@ import mekanism.api.TileNetworkList;
 import mekanism.common.Mekanism;
 import mekanism.common.block.states.BlockStateTransmitter.TransmitterType;
 import mekanism.common.content.transporter.TransporterStack;
-import mekanism.common.network.PacketTileEntity.TileEntityMessage;
 import mekanism.common.util.LangUtils;
 import mekanism.common.util.MekanismUtils;
 import net.minecraft.entity.player.EntityPlayer;
@@ -108,7 +107,7 @@ public class TileEntityDiversionTransporter extends TileEntityLogisticalTranspor
         notifyTileChange();
         player.sendMessage(new TextComponentString(EnumColor.DARK_BLUE + Mekanism.LOG_TAG + EnumColor.GREY + " " +
                                                    LangUtils.localize("tooltip.configurator.toggleDiverter") + ": " + EnumColor.RED + description));
-        Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
+        Mekanism.packetHandler.sendToAllTracking(this);
         return EnumActionResult.SUCCESS;
     }
 

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityDiversionTransporter.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityDiversionTransporter.java
@@ -6,7 +6,6 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
-import mekanism.api.Range4D;
 import mekanism.api.TileNetworkList;
 import mekanism.common.Mekanism;
 import mekanism.common.block.states.BlockStateTransmitter.TransmitterType;
@@ -109,8 +108,7 @@ public class TileEntityDiversionTransporter extends TileEntityLogisticalTranspor
         notifyTileChange();
         player.sendMessage(new TextComponentString(EnumColor.DARK_BLUE + Mekanism.LOG_TAG + EnumColor.GREY + " " +
                                                    LangUtils.localize("tooltip.configurator.toggleDiverter") + ": " + EnumColor.RED + description));
-        Coord4D coord = new Coord4D(getPos(), getWorld());
-        Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(coord, getNetworkedData(new TileNetworkList())), new Range4D(coord));
+        Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
         return EnumActionResult.SUCCESS;
     }
 

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityDiversionTransporter.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityDiversionTransporter.java
@@ -107,7 +107,7 @@ public class TileEntityDiversionTransporter extends TileEntityLogisticalTranspor
         notifyTileChange();
         player.sendMessage(new TextComponentString(EnumColor.DARK_BLUE + Mekanism.LOG_TAG + EnumColor.GREY + " " +
                                                    LangUtils.localize("tooltip.configurator.toggleDiverter") + ": " + EnumColor.RED + description));
-        Mekanism.packetHandler.sendToAllTracking(this);
+        Mekanism.packetHandler.sendUpdatePacket(this);
         return EnumActionResult.SUCCESS;
     }
 

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityLogisticalTransporter.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityLogisticalTransporter.java
@@ -283,7 +283,7 @@ public class TileEntityLogisticalTransporter extends TileEntityTransmitter<TileE
         TransporterUtils.incrementColor(getTransmitter());
         onPartChanged(null);
         PathfinderCache.onChanged(new Coord4D(getPos(), getWorld()));
-        Mekanism.packetHandler.sendToAllTracking(this);
+        Mekanism.packetHandler.sendUpdatePacket(this);
         TextComponentGroup msg = new TextComponentGroup(TextFormatting.GRAY).string(Mekanism.LOG_TAG + " ", TextFormatting.DARK_BLUE)
               .translation("tooltip.configurator.toggleColor").string(": ");
 

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityLogisticalTransporter.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityLogisticalTransporter.java
@@ -8,7 +8,6 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
-import mekanism.api.Range4D;
 import mekanism.api.TileNetworkList;
 import mekanism.api.transmitters.TransmissionType;
 import mekanism.common.Mekanism;
@@ -285,8 +284,7 @@ public class TileEntityLogisticalTransporter extends TileEntityTransmitter<TileE
         TransporterUtils.incrementColor(getTransmitter());
         onPartChanged(null);
         PathfinderCache.onChanged(new Coord4D(getPos(), getWorld()));
-        Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(new Coord4D(getPos(), getWorld()), getNetworkedData(new TileNetworkList())),
-              new Range4D(new Coord4D(getPos(), getWorld())));
+        Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
         TextComponentGroup msg = new TextComponentGroup(TextFormatting.GRAY).string(Mekanism.LOG_TAG + " ", TextFormatting.DARK_BLUE)
               .translation("tooltip.configurator.toggleColor").string(": ");
 

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityLogisticalTransporter.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityLogisticalTransporter.java
@@ -20,7 +20,6 @@ import mekanism.common.content.transporter.TransitRequest;
 import mekanism.common.content.transporter.TransitRequest.TransitResponse;
 import mekanism.common.content.transporter.TransporterStack;
 import mekanism.common.integration.multipart.MultipartTileNetworkJoiner;
-import mekanism.common.network.PacketTileEntity.TileEntityMessage;
 import mekanism.common.tier.BaseTier;
 import mekanism.common.tier.TransporterTier;
 import mekanism.common.transmitters.TransporterImpl;
@@ -284,7 +283,7 @@ public class TileEntityLogisticalTransporter extends TileEntityTransmitter<TileE
         TransporterUtils.incrementColor(getTransmitter());
         onPartChanged(null);
         PathfinderCache.onChanged(new Coord4D(getPos(), getWorld()));
-        Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
+        Mekanism.packetHandler.sendToAllTracking(this);
         TextComponentGroup msg = new TextComponentGroup(TextFormatting.GRAY).string(Mekanism.LOG_TAG + " ", TextFormatting.DARK_BLUE)
               .translation("tooltip.configurator.toggleColor").string(": ");
 

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntitySidedPipe.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntitySidedPipe.java
@@ -9,7 +9,6 @@ import mcmultipart.api.multipart.IMultipart;
 import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
 import mekanism.api.IConfigurable;
-import mekanism.api.Range4D;
 import mekanism.api.TileNetworkList;
 import mekanism.api.transmitters.IBlockableConnection;
 import mekanism.api.transmitters.ITransmitter;
@@ -104,7 +103,7 @@ public abstract class TileEntitySidedPipe extends TileEntity implements ITileNet
                 forceUpdate = false;
             }
             if (sendDesc) {
-                Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), new Range4D(Coord4D.get(this)));
+                Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
                 sendDesc = false;
             }
         }

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntitySidedPipe.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntitySidedPipe.java
@@ -22,7 +22,6 @@ import mekanism.common.block.states.BlockStateTransmitter.TransmitterType.Size;
 import mekanism.common.capabilities.Capabilities;
 import mekanism.common.integration.multipart.MultipartMekanism;
 import mekanism.common.integration.multipart.MultipartTileNetworkJoiner;
-import mekanism.common.network.PacketTileEntity.TileEntityMessage;
 import mekanism.common.tier.BaseTier;
 import mekanism.common.util.CapabilityUtils;
 import mekanism.common.util.MekanismUtils;
@@ -103,7 +102,7 @@ public abstract class TileEntitySidedPipe extends TileEntity implements ITileNet
                 forceUpdate = false;
             }
             if (sendDesc) {
-                Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
+                Mekanism.packetHandler.sendToAllTracking(this);
                 sendDesc = false;
             }
         }

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntitySidedPipe.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntitySidedPipe.java
@@ -102,7 +102,7 @@ public abstract class TileEntitySidedPipe extends TileEntity implements ITileNet
                 forceUpdate = false;
             }
             if (sendDesc) {
-                Mekanism.packetHandler.sendToAllTracking(this);
+                Mekanism.packetHandler.sendUpdatePacket(this);
                 sendDesc = false;
             }
         }

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityThermodynamicConductor.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityThermodynamicConductor.java
@@ -3,7 +3,6 @@ package mekanism.common.tile.transmitter;
 import io.netty.buffer.ByteBuf;
 import java.util.Collection;
 import javax.annotation.Nonnull;
-import mekanism.api.Coord4D;
 import mekanism.api.IHeatTransfer;
 import mekanism.api.TileNetworkList;
 import mekanism.api.transmitters.TransmissionType;
@@ -11,7 +10,6 @@ import mekanism.common.ColourRGBA;
 import mekanism.common.Mekanism;
 import mekanism.common.block.states.BlockStateTransmitter.TransmitterType;
 import mekanism.common.capabilities.Capabilities;
-import mekanism.common.network.PacketTileEntity.TileEntityMessage;
 import mekanism.common.tier.BaseTier;
 import mekanism.common.tier.ConductorTier;
 import mekanism.common.transmitters.grid.HeatNetwork;
@@ -106,8 +104,7 @@ public class TileEntityThermodynamicConductor extends TileEntityTransmitter<IHea
     }
 
     public void sendTemp() {
-        Coord4D coord = new Coord4D(getPos(), getWorld());
-        Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(coord, getNetworkedData(new TileNetworkList())), coord);
+        Mekanism.packetHandler.sendToAllTracking(this);
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityThermodynamicConductor.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityThermodynamicConductor.java
@@ -5,7 +5,6 @@ import java.util.Collection;
 import javax.annotation.Nonnull;
 import mekanism.api.Coord4D;
 import mekanism.api.IHeatTransfer;
-import mekanism.api.Range4D;
 import mekanism.api.TileNetworkList;
 import mekanism.api.transmitters.TransmissionType;
 import mekanism.common.ColourRGBA;
@@ -108,7 +107,7 @@ public class TileEntityThermodynamicConductor extends TileEntityTransmitter<IHea
 
     public void sendTemp() {
         Coord4D coord = new Coord4D(getPos(), getWorld());
-        Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(coord, getNetworkedData(new TileNetworkList())), new Range4D(coord));
+        Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(coord, getNetworkedData(new TileNetworkList())), coord);
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityThermodynamicConductor.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityThermodynamicConductor.java
@@ -104,7 +104,7 @@ public class TileEntityThermodynamicConductor extends TileEntityTransmitter<IHea
     }
 
     public void sendTemp() {
-        Mekanism.packetHandler.sendToAllTracking(this);
+        Mekanism.packetHandler.sendUpdatePacket(this);
     }
 
     @Override

--- a/src/main/java/mekanism/common/transmitters/TransporterImpl.java
+++ b/src/main/java/mekanism/common/transmitters/TransporterImpl.java
@@ -11,7 +11,6 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
-import mekanism.api.Range4D;
 import mekanism.api.TileNetworkList;
 import mekanism.common.Mekanism;
 import mekanism.common.base.ILogisticalTransporter;
@@ -186,7 +185,7 @@ public class TransporterImpl extends TransmitterImpl<TileEntity, InventoryNetwor
                 needsSync.clear();
 
                 // Finally, notify clients and mark chunk for save
-                Mekanism.packetHandler.sendToReceivers(msg, new Range4D(coord));
+                Mekanism.packetHandler.sendToAllTracking(msg, coord);
                 MekanismUtils.saveChunk(getTileEntity());
             }
         }
@@ -244,7 +243,7 @@ public class TransporterImpl extends TransmitterImpl<TileEntity, InventoryNetwor
                 int stackId = nextId++;
                 transit.put(stackId, stack);
                 Coord4D coord = coord();
-                Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(coord, getTileEntity().makeSyncPacket(stackId, stack)), new Range4D(coord));
+                Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(coord, getTileEntity().makeSyncPacket(stackId, stack)), coord);
                 MekanismUtils.saveChunk(getTileEntity());
             }
             return response;

--- a/src/main/java/mekanism/generators/client/gui/GuiIndustrialTurbine.java
+++ b/src/main/java/mekanism/generators/client/gui/GuiIndustrialTurbine.java
@@ -2,7 +2,6 @@ package mekanism.generators.client.gui;
 
 import java.io.IOException;
 import java.util.Arrays;
-import mekanism.api.Coord4D;
 import mekanism.api.TileNetworkList;
 import mekanism.client.gui.GuiEmbeddedGaugeTile;
 import mekanism.client.gui.element.GuiEnergyInfo;
@@ -120,7 +119,7 @@ public class GuiIndustrialTurbine extends GuiEmbeddedGaugeTile<TileEntityTurbine
         int yAxis = y - (height - ySize) / 2;
         if (xAxis > 160 && xAxis < 169 && yAxis > 73 && yAxis < 82) {
             TileNetworkList data = TileNetworkList.withContents((byte) 0);
-            Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), data));
+            Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, data));
             SoundHandler.playSound(SoundEvents.UI_BUTTON_CLICK);
         }
     }

--- a/src/main/java/mekanism/generators/client/gui/GuiReactorFuel.java
+++ b/src/main/java/mekanism/generators/client/gui/GuiReactorFuel.java
@@ -135,7 +135,7 @@ public class GuiReactorFuel extends GuiMekanismTile<TileEntityReactorController>
             int toUse = Math.max(0, Integer.parseInt(injectionRateField.getText()));
             toUse -= toUse % 2;
             TileNetworkList data = TileNetworkList.withContents(0, toUse);
-            Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), data));
+            Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, data));
             injectionRateField.setText("");
         }
     }

--- a/src/main/java/mekanism/generators/client/gui/GuiReactorLogicAdapter.java
+++ b/src/main/java/mekanism/generators/client/gui/GuiReactorLogicAdapter.java
@@ -1,7 +1,6 @@
 package mekanism.generators.client.gui;
 
 import java.io.IOException;
-import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
 import mekanism.api.TileNetworkList;
 import mekanism.client.gui.GuiMekanismTile;
@@ -91,7 +90,7 @@ public class GuiReactorLogicAdapter extends GuiMekanismTile<TileEntityReactorLog
             if (xAxis >= 23 && xAxis <= 34 && yAxis >= 19 && yAxis <= 30) {
                 SoundHandler.playSound(SoundEvents.UI_BUTTON_CLICK);
                 TileNetworkList data = TileNetworkList.withContents(0);
-                Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), data));
+                Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, data));
                 return;
             }
             for (ReactorLogic type : ReactorLogic.values()) {
@@ -99,7 +98,7 @@ public class GuiReactorLogicAdapter extends GuiMekanismTile<TileEntityReactorLog
                     if (type != tileEntity.logicType) {
                         SoundHandler.playSound(SoundEvents.UI_BUTTON_CLICK);
                         TileNetworkList data = TileNetworkList.withContents(1, type.ordinal());
-                        Mekanism.packetHandler.sendToServer(new TileEntityMessage(Coord4D.get(tileEntity), data));
+                        Mekanism.packetHandler.sendToServer(new TileEntityMessage(tileEntity, data));
                         return;
                     }
                 }

--- a/src/main/java/mekanism/generators/common/FusionReactor.java
+++ b/src/main/java/mekanism/generators/common/FusionReactor.java
@@ -249,7 +249,7 @@ public class FusionReactor {
         burning = burning && keepBurning;
 
         if (!controller.getWorld().isRemote) {
-            Mekanism.packetHandler.sendToDimension(new TileEntityMessage(Coord4D.get(controller), controller.getNetworkedData(new TileNetworkList())),
+            Mekanism.packetHandler.sendToDimension(new TileEntityMessage(controller, controller.getNetworkedData(new TileNetworkList())),
                   controller.getWorld().provider.getDimension());
         }
     }
@@ -269,7 +269,7 @@ public class FusionReactor {
         formed = true;
 
         if (!controller.getWorld().isRemote) {
-            Mekanism.packetHandler.sendToDimension(new TileEntityMessage(Coord4D.get(controller), controller.getNetworkedData(new TileNetworkList())),
+            Mekanism.packetHandler.sendToDimension(new TileEntityMessage(controller, controller.getNetworkedData(new TileNetworkList())),
                   controller.getWorld().provider.getDimension());
         }
     }

--- a/src/main/java/mekanism/generators/common/FusionReactor.java
+++ b/src/main/java/mekanism/generators/common/FusionReactor.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.Set;
 import mekanism.api.Coord4D;
 import mekanism.api.IHeatTransfer;
-import mekanism.api.TileNetworkList;
 import mekanism.api.gas.GasStack;
 import mekanism.api.gas.GasTank;
 import mekanism.common.LaserManager;
@@ -249,8 +248,7 @@ public class FusionReactor {
         burning = burning && keepBurning;
 
         if (!controller.getWorld().isRemote) {
-            Mekanism.packetHandler.sendToDimension(new TileEntityMessage(controller, controller.getNetworkedData(new TileNetworkList())),
-                  controller.getWorld().provider.getDimension());
+            Mekanism.packetHandler.sendToDimension(new TileEntityMessage(controller), controller.getWorld().provider.getDimension());
         }
     }
 
@@ -269,8 +267,7 @@ public class FusionReactor {
         formed = true;
 
         if (!controller.getWorld().isRemote) {
-            Mekanism.packetHandler.sendToDimension(new TileEntityMessage(controller, controller.getNetworkedData(new TileNetworkList())),
-                  controller.getWorld().provider.getDimension());
+            Mekanism.packetHandler.sendToDimension(new TileEntityMessage(controller), controller.getWorld().provider.getDimension());
         }
     }
 

--- a/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorController.java
+++ b/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorController.java
@@ -101,7 +101,7 @@ public class TileEntityReactorController extends TileEntityReactorBlock implemen
         if (isFormed()) {
             getReactor().simulate();
             if (!world.isRemote && (getReactor().isBurning() != clientBurning || Math.abs(getReactor().getPlasmaTemp() - clientTemp) > 1000000)) {
-                Mekanism.packetHandler.sendToAllAround(new TileEntityMessage(this, getNetworkedData(new TileNetworkList())), Coord4D.get(this).getTargetPoint(50D));
+                Mekanism.packetHandler.sendToAllAround(new TileEntityMessage(this), Coord4D.get(this).getTargetPoint(50D));
                 clientBurning = getReactor().isBurning();
                 clientTemp = getReactor().getPlasmaTemp();
             }

--- a/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorController.java
+++ b/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorController.java
@@ -101,7 +101,7 @@ public class TileEntityReactorController extends TileEntityReactorBlock implemen
         if (isFormed()) {
             getReactor().simulate();
             if (!world.isRemote && (getReactor().isBurning() != clientBurning || Math.abs(getReactor().getPlasmaTemp() - clientTemp) > 1000000)) {
-                Mekanism.packetHandler.sendToAllAround(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), Coord4D.get(this).getTargetPoint(50D));
+                Mekanism.packetHandler.sendToAllAround(new TileEntityMessage(this, getNetworkedData(new TileNetworkList())), Coord4D.get(this).getTargetPoint(50D));
                 clientBurning = getReactor().isBurning();
                 clientTemp = getReactor().getPlasmaTemp();
             }

--- a/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorPort.java
+++ b/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorPort.java
@@ -382,7 +382,7 @@ public class TileEntityReactorPort extends TileEntityReactorBlock implements IFl
             String modeText = " " + (fluidEject ? EnumColor.DARK_RED : EnumColor.DARK_GREEN) + LangUtils.transOutputInput(fluidEject) + ".";
             player.sendMessage(new TextComponentString(EnumColor.DARK_BLUE + Mekanism.LOG_TAG + " " + EnumColor.GREY +
                                                        LangUtils.localize("tooltip.configurator.reactorPortEject") + modeText));
-            Mekanism.packetHandler.sendToAllTracking(this);
+            Mekanism.packetHandler.sendUpdatePacket(this);
             markDirty();
         }
         return EnumActionResult.SUCCESS;

--- a/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorPort.java
+++ b/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorPort.java
@@ -7,7 +7,6 @@ import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
 import mekanism.api.IConfigurable;
 import mekanism.api.IHeatTransfer;
-import mekanism.api.Range4D;
 import mekanism.api.TileNetworkList;
 import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasStack;
@@ -384,7 +383,7 @@ public class TileEntityReactorPort extends TileEntityReactorBlock implements IFl
             String modeText = " " + (fluidEject ? EnumColor.DARK_RED : EnumColor.DARK_GREEN) + LangUtils.transOutputInput(fluidEject) + ".";
             player.sendMessage(new TextComponentString(EnumColor.DARK_BLUE + Mekanism.LOG_TAG + " " + EnumColor.GREY +
                                                        LangUtils.localize("tooltip.configurator.reactorPortEject") + modeText));
-            Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), new Range4D(Coord4D.get(this)));
+            Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
             markDirty();
         }
         return EnumActionResult.SUCCESS;

--- a/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorPort.java
+++ b/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorPort.java
@@ -17,7 +17,6 @@ import mekanism.common.MekanismFluids;
 import mekanism.common.base.FluidHandlerWrapper;
 import mekanism.common.base.IFluidHandlerWrapper;
 import mekanism.common.capabilities.Capabilities;
-import mekanism.common.network.PacketTileEntity.TileEntityMessage;
 import mekanism.common.util.CableUtils;
 import mekanism.common.util.CapabilityUtils;
 import mekanism.common.util.HeatUtils;
@@ -383,7 +382,7 @@ public class TileEntityReactorPort extends TileEntityReactorBlock implements IFl
             String modeText = " " + (fluidEject ? EnumColor.DARK_RED : EnumColor.DARK_GREEN) + LangUtils.transOutputInput(fluidEject) + ".";
             player.sendMessage(new TextComponentString(EnumColor.DARK_BLUE + Mekanism.LOG_TAG + " " + EnumColor.GREY +
                                                        LangUtils.localize("tooltip.configurator.reactorPortEject") + modeText));
-            Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
+            Mekanism.packetHandler.sendToAllTracking(this);
             markDirty();
         }
         return EnumActionResult.SUCCESS;

--- a/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineCasing.java
+++ b/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineCasing.java
@@ -112,7 +112,7 @@ public class TileEntityTurbineCasing extends TileEntityMultiblock<SynchronizedTu
     @Override
     public boolean onActivate(EntityPlayer player, EnumHand hand, ItemStack stack) {
         if (!player.isSneaking() && structure != null) {
-            Mekanism.packetHandler.sendToAllTracking(this);
+            Mekanism.packetHandler.sendUpdatePacket(this);
             player.openGui(MekanismGenerators.instance, 6, world, getPos().getX(), getPos().getY(), getPos().getZ());
             return true;
         }

--- a/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineCasing.java
+++ b/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineCasing.java
@@ -3,7 +3,6 @@ package mekanism.generators.common.tile.turbine;
 import io.netty.buffer.ByteBuf;
 import javax.annotation.Nonnull;
 import mekanism.api.Coord4D;
-import mekanism.api.Range4D;
 import mekanism.api.TileNetworkList;
 import mekanism.api.energy.IStrictEnergyStorage;
 import mekanism.common.Mekanism;
@@ -114,7 +113,7 @@ public class TileEntityTurbineCasing extends TileEntityMultiblock<SynchronizedTu
     @Override
     public boolean onActivate(EntityPlayer player, EnumHand hand, ItemStack stack) {
         if (!player.isSneaking() && structure != null) {
-            Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), new Range4D(Coord4D.get(this)));
+            Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
             player.openGui(MekanismGenerators.instance, 6, world, getPos().getX(), getPos().getY(), getPos().getZ());
             return true;
         }

--- a/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineCasing.java
+++ b/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineCasing.java
@@ -10,7 +10,6 @@ import mekanism.common.config.MekanismConfig;
 import mekanism.common.multiblock.MultiblockCache;
 import mekanism.common.multiblock.MultiblockManager;
 import mekanism.common.multiblock.UpdateProtocol;
-import mekanism.common.network.PacketTileEntity.TileEntityMessage;
 import mekanism.common.tile.TileEntityGasTank.GasMode;
 import mekanism.common.tile.TileEntityMultiblock;
 import mekanism.common.util.InventoryUtils;
@@ -113,7 +112,7 @@ public class TileEntityTurbineCasing extends TileEntityMultiblock<SynchronizedTu
     @Override
     public boolean onActivate(EntityPlayer player, EnumHand hand, ItemStack stack) {
         if (!player.isSneaking() && structure != null) {
-            Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
+            Mekanism.packetHandler.sendToAllTracking(this);
             player.openGui(MekanismGenerators.instance, 6, world, getPos().getX(), getPos().getY(), getPos().getZ());
             return true;
         }

--- a/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineRotor.java
+++ b/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineRotor.java
@@ -3,7 +3,6 @@ package mekanism.generators.common.tile.turbine;
 import io.netty.buffer.ByteBuf;
 import javax.annotation.Nonnull;
 import mekanism.api.Coord4D;
-import mekanism.api.Range4D;
 import mekanism.api.TileNetworkList;
 import mekanism.common.Mekanism;
 import mekanism.common.multiblock.TileEntityInternalMultiblock;
@@ -129,7 +128,7 @@ public class TileEntityTurbineRotor extends TileEntityInternalMultiblock {
     }
 
     private void sendUpdatePacket() {
-        Mekanism.packetHandler.sendToReceivers(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), new Range4D(Coord4D.get(this)));
+        Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
     }
 
     @Override

--- a/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineRotor.java
+++ b/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineRotor.java
@@ -126,7 +126,7 @@ public class TileEntityTurbineRotor extends TileEntityInternalMultiblock {
     }
 
     private void sendUpdatePacket() {
-        Mekanism.packetHandler.sendToAllTracking(this);
+        Mekanism.packetHandler.sendUpdatePacket(this);
     }
 
     @Override

--- a/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineRotor.java
+++ b/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineRotor.java
@@ -2,11 +2,9 @@ package mekanism.generators.common.tile.turbine;
 
 import io.netty.buffer.ByteBuf;
 import javax.annotation.Nonnull;
-import mekanism.api.Coord4D;
 import mekanism.api.TileNetworkList;
 import mekanism.common.Mekanism;
 import mekanism.common.multiblock.TileEntityInternalMultiblock;
-import mekanism.common.network.PacketTileEntity.TileEntityMessage;
 import net.minecraft.block.Block;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
@@ -128,7 +126,7 @@ public class TileEntityTurbineRotor extends TileEntityInternalMultiblock {
     }
 
     private void sendUpdatePacket() {
-        Mekanism.packetHandler.sendToAllTracking(new TileEntityMessage(Coord4D.get(this), getNetworkedData(new TileNetworkList())), this);
+        Mekanism.packetHandler.sendToAllTracking(this);
     }
 
     @Override


### PR DESCRIPTION
## Changes proposed in this pull request:
- Switch to using SimpleImpl sendToAllTracking for update packets, rather than calculating a bunch of the stuff ourselves.
- Add helper methods to cleanup readability when it comes to sending update packets

## To be looked at
- [ ] The networks (GasNetwork, EnergyNetwork, etc) still use the old `sendToReceivers` method. Not sure if we should just continue with how this PR is and ignore the Y for them, or if there is some good way to switch it over. (If some way is decided upon that switches it over then we do not need to bump the API version as no changes/additions to Range4D will have been made from an API standpoint.)