### PR TITLE
Simulate amount the network has room for, rather than the amount that rate it can transfer at

### DIFF
--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityMechanicalPipe.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityMechanicalPipe.java
@@ -57,7 +57,7 @@ public class TileEntityMechanicalPipe extends TileEntityTransmitter<IFluidHandle
                 if (connectedAcceptors[side.ordinal()] != null) {
                     IFluidHandler container = connectedAcceptors[side.ordinal()];
                     if (container != null) {
-                        FluidStack received = container.drain(getPullAmount(), false);
+                        FluidStack received = container.drain(getAvailablePull(), false);
                         if (received != null && received.amount != 0) {
                             container.drain(takeFluid(received, true), true);
                         }
@@ -251,6 +251,13 @@ public class TileEntityMechanicalPipe extends TileEntityTransmitter<IFluidHandle
             return CapabilityUtils.getCapability(tile, CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, side.getOpposite());
         }
         return null;
+    }
+
+    public int getAvailablePull() {
+        if (getTransmitter().hasTransmitterNetwork()) {
+            return Math.min(getPullAmount(), getTransmitter().getTransmitterNetwork().getFluidNeeded());
+        }
+        return Math.min(getPullAmount(), buffer.getCapacity() - buffer.getFluidAmount());
     }
 
     public int takeFluid(FluidStack fluid, boolean doEmit) {

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityMechanicalPipe.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityMechanicalPipe.java
@@ -58,7 +58,7 @@ public class TileEntityMechanicalPipe extends TileEntityTransmitter<IFluidHandle
                     IFluidHandler container = connectedAcceptors[side.ordinal()];
                     if (container != null) {
                         FluidStack received = container.drain(getAvailablePull(), false);
-                        if (received != null && received.amount != 0) {
+                        if (received != null && received.amount != 0 && takeFluid(received, false) == received.amount) {
                             container.drain(takeFluid(received, true), true);
                         }
                     }

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityPressurizedTube.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityPressurizedTube.java
@@ -83,7 +83,7 @@ public class TileEntityPressurizedTube extends TileEntityTransmitter<IGasHandler
                     IGasHandler container = connectedAcceptors[side.ordinal()];
                     if (container != null) {
                         GasStack received = container.drawGas(side.getOpposite(), getAvailablePull(), false);
-                        if (received != null && received.amount != 0) {
+                        if (received != null && received.amount != 0 && takeGas(received, false) == received.amount) {
                             container.drawGas(side.getOpposite(), takeGas(received, true), true);
                         }
                     }

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityPressurizedTube.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityPressurizedTube.java
@@ -82,7 +82,7 @@ public class TileEntityPressurizedTube extends TileEntityTransmitter<IGasHandler
                 if (connectedAcceptors[side.ordinal()] != null) {
                     IGasHandler container = connectedAcceptors[side.ordinal()];
                     if (container != null) {
-                        GasStack received = container.drawGas(side.getOpposite(), tier.getTubePullAmount(), false);
+                        GasStack received = container.drawGas(side.getOpposite(), getAvailablePull(), false);
                         if (received != null && received.amount != 0) {
                             container.drawGas(side.getOpposite(), takeGas(received, true), true);
                         }
@@ -96,6 +96,13 @@ public class TileEntityPressurizedTube extends TileEntityTransmitter<IGasHandler
             }
         }
         super.update();
+    }
+
+    public int getAvailablePull() {
+        if (getTransmitter().hasTransmitterNetwork()) {
+            return Math.min(tier.getTubePullAmount(), getTransmitter().getTransmitterNetwork().getGasNeeded());
+        }
+        return Math.min(tier.getTubePullAmount(), buffer.getNeeded());
     }
 
     @Override


### PR DESCRIPTION
## Changes proposed in this pull request:
Makes it so that we do not simulate draining more fluid than we have room for, in case there are things such as shown in #5512 where a liquid is only accepted in stages. This goes against the previous assumption that if we can take `x` units of something that means we can also take `x - 1` units.

I also made this change to pressurized tubes even though I do not believe there is anything that goes against this assumption for gas networks, but in case anyone ever decides to do something like that with our API, at least it will support it properly.