### PR TITLE
Reworked PipeUtils and GasUtils side access

### DIFF
--- a/src/main/java/mekanism/common/util/CapabilityUtils.java
+++ b/src/main/java/mekanism/common/util/CapabilityUtils.java
@@ -21,6 +21,22 @@ public final class CapabilityUtils {
         return provider.getCapability(cap, side);
     }
 
+    /**
+     * Runs an action on a capability if it exists
+     *
+     * @param provider - provider hosting the capability
+     * @param cap      - capability type
+     * @param side     - side to access
+     * @param action   - handler for completing the action on the capability
+     * @param <T>      - type to return
+     */
+    public static <T> void runIfCap(ICapabilityProvider provider, Capability<T> cap, EnumFacing side, Consumer<T> action) {
+        final T capability = getCapability(provider, cap, side);
+        if (capability != null) {
+            action.accept(capability);
+        }
+    }
+
     public static <T> OptionalCapability withCapability(ICapabilityProvider provider, Capability<T> cap, EnumFacing side, Consumer<T> consumer) {
         return new OptionalCapability(provider).orElseWith(cap, side, consumer);
     }

--- a/src/main/java/mekanism/common/util/EmitUtils.java
+++ b/src/main/java/mekanism/common/util/EmitUtils.java
@@ -1,11 +1,16 @@
 package mekanism.common.util;
 
 import java.util.Set;
+import java.util.function.BiConsumer;
 import mekanism.common.base.SplitInfo;
 import mekanism.common.base.SplitInfo.DoubleSplitInfo;
 import mekanism.common.base.SplitInfo.IntegerSplitInfo;
 import mekanism.common.base.target.EnergyAcceptorTarget;
 import mekanism.common.base.target.Target;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
 
 public class EmitUtils {
 
@@ -69,5 +74,30 @@ public class EmitUtils {
      */
     public static double sendToAcceptors(Set<EnergyAcceptorTarget> availableTargets, int totalTargets, double amountToSplit) {
         return sendToAcceptors(availableTargets, totalTargets, new DoubleSplitInfo(amountToSplit, totalTargets), amountToSplit);
+    }
+
+    /**
+     * Simple helper to loop over each side of the block and complete an action for each tile found
+     *
+     * @param world  - world to access
+     * @param center - location to center search on
+     * @param sides  - sides to search
+     * @param action - action to complete
+     */
+    public static void forEachSide(World world, BlockPos center, Iterable<EnumFacing> sides, BiConsumer<TileEntity, EnumFacing> action) {
+        if (sides != null) {
+            //Loop provided sides
+            for (EnumFacing side : sides) {
+                //Validate we have a block loaded in world, prevents ghost chunk loading
+                final BlockPos pos = center.offset(side);
+                if (world.isBlockLoaded(pos)) {
+                    //Get tile and provide if not null
+                    final TileEntity tileEntity = world.getTileEntity(pos);
+                    if (tileEntity != null) {
+                        action.accept(tileEntity, side);
+                    }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Rewrote pipe and gas utilities orginally to fix chunk loading ghosting. In which accessing a block in another chunk would ghost load the chunk. While I was in the methods I rewrote them to be more reusable in terms of code. Replacing existing loops and calls with lambda driven versions. This makes the code easier to read and recycles common implementation. While at the same time not costing anything in terms of performance. 