### PR TITLE
Ignore amounts for inputItemMatches

### DIFF
--- a/src/main/java/mekanism/common/recipe/inputs/MachineInput.java
+++ b/src/main/java/mekanism/common/recipe/inputs/MachineInput.java
@@ -41,6 +41,9 @@ public abstract class MachineInput<INPUT extends MachineInput<INPUT>> {
      */
     public abstract boolean testEquality(INPUT other);
 
+    /**
+     * Checks if the two item stacks match (IGNORES AMOUNTS)
+     */
     public static boolean inputItemMatches(ItemStack container, ItemStack contained) {
         return ITEM_MATCHER_OVERRIDES.getOrDefault(container.getItem().getClass(), DEFAULT_MATCHER).test(container, contained);
     }
@@ -49,7 +52,7 @@ public abstract class MachineInput<INPUT extends MachineInput<INPUT>> {
         if (OreDictCache.getOreDictName(container).contains("treeSapling")) {
             return StackUtils.equalsWildcard(container, contained);
         }
-        return StackUtils.equalsWildcardWithNBT(container, contained) && container.getCount() >= contained.getCount();
+        return StackUtils.equalsWildcardWithNBT(container, contained);
     }
 
     @Override


### PR DESCRIPTION
## Changes proposed in this pull request:
Ignores the amount check for the default check. In commit https://github.com/mekanism/Mekanism/commit/7704846128290996717363bbdb51a180547757a2 the testEquality method started caring about the input stack size. As everywhere that uses `inputItemMatches` is part of a testEquality method (ignores stack size), I have gone ahead and removed the extra check. The one place the stack size mattered was `MachineInput#inputContains` which already has an additional check for the stack size anyways.

This should fix #5521 