### PR TITLE
Added checks for is block loaded to several methods

### DIFF
--- a/src/main/java/mekanism/common/block/BlockBounding.java
+++ b/src/main/java/mekanism/common/block/BlockBounding.java
@@ -27,8 +27,8 @@ public class BlockBounding extends Block {
     @Nullable
     private static BlockPos getMainBlockPos(IBlockAccess world, BlockPos thisPos) {
         TileEntity te = world.getTileEntity(thisPos);
-        if (te instanceof TileEntityBoundingBlock && !thisPos.equals(((TileEntityBoundingBlock) te).mainPos)) {
-            return ((TileEntityBoundingBlock) te).mainPos;
+        if (te instanceof TileEntityBoundingBlock && !thisPos.equals(((TileEntityBoundingBlock) te).getMainPos())) {
+            return ((TileEntityBoundingBlock) te).getMainPos();
         }
         return null;
     }

--- a/src/main/java/mekanism/common/tile/TileEntityAdvancedBoundingBlock.java
+++ b/src/main/java/mekanism/common/tile/TileEntityAdvancedBoundingBlock.java
@@ -5,7 +5,6 @@ import cofh.redstoneflux.api.IEnergyReceiver;
 import ic2.api.energy.tile.IEnergyEmitter;
 import ic2.api.energy.tile.IEnergySink;
 import javax.annotation.Nonnull;
-import mekanism.api.Coord4D;
 import mekanism.api.IConfigCardAccess.ISpecialConfigData;
 import mekanism.api.energy.IStrictEnergyAcceptor;
 import mekanism.common.Mekanism;
@@ -310,20 +309,16 @@ public class TileEntityAdvancedBoundingBlock extends TileEntityBoundingBlock imp
     }
 
     public IAdvancedBoundingBlock getInv() {
-        if (!receivedCoords || !world.isBlockLoaded(mainPos)) {
-            return null;
-        }
-
         // Return the inventory/main tile; note that it's possible, esp. when chunks are
         // loading that the inventory/main tile has not yet loaded and thus is null.
-        TileEntity tile = new Coord4D(mainPos, world).getTileEntity(world);
+        final TileEntity tile = getMainTile();
         if (tile == null) {
             return null;
         }
         if (!(tile instanceof IAdvancedBoundingBlock)) {
             // On the off chance that another block got placed there (which seems only likely with corruption,
             // go ahead and log what we found.
-            Mekanism.logger.error("Found tile {} instead of an IAdvancedBoundingBlock, at {}. Multiblock cannot function", tile, mainPos);
+            Mekanism.logger.error("Found tile {} instead of an IAdvancedBoundingBlock, at {}. Multiblock cannot function", tile, getMainPos());
             //world.setBlockToAir(mainPos);
             return null;
         }
@@ -402,7 +397,7 @@ public class TileEntityAdvancedBoundingBlock extends TileEntityBoundingBlock imp
         if (inv == null) {
             return super.hasCapability(capability, facing);
         }
-        return inv.hasOffsetCapability(capability, facing, pos.subtract(mainPos));
+        return inv.hasOffsetCapability(capability, facing, pos.subtract(getMainPos()));
     }
 
     @Override
@@ -414,6 +409,6 @@ public class TileEntityAdvancedBoundingBlock extends TileEntityBoundingBlock imp
         if (inv == null) {
             return super.getCapability(capability, facing);
         }
-        return inv.getOffsetCapability(capability, facing, pos.subtract(mainPos));
+        return inv.getOffsetCapability(capability, facing, pos.subtract(getMainPos()));
     }
 }

--- a/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
+++ b/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
@@ -448,8 +448,12 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
     }
 
     public TileEntity getEjectInv() {
-        EnumFacing side = facing.getOpposite();
-        return world.getTileEntity(getPos().up().offset(side, 2));
+        final EnumFacing side = facing.getOpposite();
+        final BlockPos pos = getPos().up().offset(side, 2);
+        if(world.isBlockLoaded(pos)) {
+            return world.getTileEntity(pos);
+        }
+        return null;
     }
 
     public void add(List<ItemStack> stacks) {
@@ -876,8 +880,12 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
     }
 
     public TileEntity getEjectTile() {
-        EnumFacing side = facing.getOpposite();
-        return world.getTileEntity(getPos().up().offset(side));
+        final EnumFacing side = facing.getOpposite();
+        final BlockPos pos = getPos().up().offset(side);
+        if(world.isBlockLoaded(pos)) {
+            return world.getTileEntity(pos);
+        }
+        return null;
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/TileEntityFluidTank.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFluidTank.java
@@ -431,8 +431,8 @@ public class TileEntityFluidTank extends TileEntityContainerBlock implements IAc
 
     @Override
     public boolean canFill(EnumFacing from, @Nullable FluidStack fluid) {
-        TileEntity tile = world.getTileEntity(getPos().offset(EnumFacing.DOWN));
-        if (from == EnumFacing.DOWN && world != null) {
+        TileEntity tile = MekanismUtils.getTileEntity(world, getPos().offset(EnumFacing.DOWN));
+        if (from == EnumFacing.DOWN) {
             if (isActive && !(tile instanceof TileEntityFluidTank)) {
                 return false;
             }

--- a/src/main/java/mekanism/common/tile/TileEntityInductionPort.java
+++ b/src/main/java/mekanism/common/tile/TileEntityInductionPort.java
@@ -317,7 +317,7 @@ public class TileEntityInductionPort extends TileEntityInductionCasing implement
     @Override
     @Method(modid = MekanismHooks.IC2_MOD_ID)
     public double injectEnergy(EnumFacing direction, double amount, double voltage) {
-        TileEntity tile = getWorld().getTileEntity(getPos().offset(direction));
+        TileEntity tile = MekanismUtils.getTileEntity(world, getPos().offset(direction));
         if (tile == null || CapabilityUtils.hasCapability(tile, Capabilities.GRID_TRANSMITTER_CAPABILITY, direction.getOpposite())) {
             return amount;
         }

--- a/src/main/java/mekanism/common/tile/TileEntityThermalEvaporationBlock.java
+++ b/src/main/java/mekanism/common/tile/TileEntityThermalEvaporationBlock.java
@@ -9,6 +9,7 @@ import mekanism.api.Coord4D;
 import mekanism.common.integration.computer.IComputerIntegration;
 import mekanism.common.tile.prefab.TileEntityContainerBlock;
 import mekanism.common.util.InventoryUtils;
+import mekanism.common.util.MekanismUtils;
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
@@ -78,8 +79,8 @@ public class TileEntityThermalEvaporationBlock extends TileEntityContainerBlock 
         if (!(this instanceof TileEntityThermalEvaporationController)) {
             for (EnumFacing side : EnumFacing.values()) {
                 BlockPos checkPos = pos.offset(side);
-                TileEntity check;
-                if (world.isBlockLoaded(checkPos) && (check = world.getTileEntity(checkPos)) instanceof TileEntityThermalEvaporationBlock) {
+                TileEntity check = MekanismUtils.getTileEntity(world, checkPos);
+                if (check instanceof TileEntityThermalEvaporationBlock) {
                     if (check instanceof TileEntityThermalEvaporationController) {
                         ((TileEntityThermalEvaporationController) check).refresh();
                         return;
@@ -161,19 +162,19 @@ public class TileEntityThermalEvaporationBlock extends TileEntityContainerBlock 
                     continue;
                 }
                 iterated.add(checkPos);
-                if (world.isBlockLoaded(checkPos)) {
-                    TileEntity te = world.getTileEntity(checkPos);
-                    if (te instanceof TileEntityThermalEvaporationController) {
-                        found = (TileEntityThermalEvaporationController) te;
-                        return;
-                    }
-                    if (te instanceof TileEntityThermalEvaporationBlock) {
-                        ((TileEntityThermalEvaporationBlock) te).attempted = true;
-                        for (EnumFacing side : EnumFacing.VALUES) {
-                            BlockPos coord = checkPos.offset(side);
-                            if (!iterated.contains(coord)) {
-                                checkQueue.addLast(coord);
-                            }
+
+                TileEntity te = MekanismUtils.getTileEntity(world, checkPos);
+                if (te instanceof TileEntityThermalEvaporationController) {
+                    found = (TileEntityThermalEvaporationController) te;
+                    return;
+                }
+
+                if (te instanceof TileEntityThermalEvaporationBlock) {
+                    ((TileEntityThermalEvaporationBlock) te).attempted = true;
+                    for (EnumFacing side : EnumFacing.VALUES) {
+                        BlockPos coord = checkPos.offset(side);
+                        if (!iterated.contains(coord)) {
+                            checkQueue.addLast(coord);
                         }
                     }
                 }

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityElectricBlock.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityElectricBlock.java
@@ -316,7 +316,7 @@ public abstract class TileEntityElectricBlock extends TileEntityContainerBlock i
     @Method(modid = MekanismHooks.IC2_MOD_ID)
     public double injectEnergy(EnumFacing pushDirection, double amount, double voltage) {
         // nb: the facing param contains the side relative to the pushing block
-        TileEntity tile = getWorld().getTileEntity(getPos().offset(pushDirection.getOpposite()));
+        TileEntity tile = MekanismUtils.getTileEntity(world, getPos().offset(pushDirection.getOpposite()));
         if (MekanismConfig.current().general.blacklistIC2.val() || CapabilityUtils.hasCapability(tile, Capabilities.GRID_TRANSMITTER_CAPABILITY, pushDirection)) {
             return amount;
         }

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityLogisticalTransporter.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityLogisticalTransporter.java
@@ -125,22 +125,24 @@ public class TileEntityLogisticalTransporter extends TileEntityTransmitter<TileE
 
         // Attempt to pull
         for (EnumFacing side : getConnections(ConnectionType.PULL)) {
-            TileEntity tile = getWorld().getTileEntity(getPos().offset(side));
-            TransitRequest request = TransitRequest.buildInventoryMap(tile, side, tier.getPullAmount());
+            final TileEntity tile = MekanismUtils.getTileEntity(world, getPos().offset(side));
+            if (tile != null) {
+                TransitRequest request = TransitRequest.buildInventoryMap(tile, side, tier.getPullAmount());
 
-            // There's a stack available to insert into the network...
-            if (!request.isEmpty()) {
-                TransitResponse response = TransporterUtils.insert(tile, getTransmitter(), request, getTransmitter().getColor(), true, 0);
+                // There's a stack available to insert into the network...
+                if (!request.isEmpty()) {
+                    TransitResponse response = TransporterUtils.insert(tile, getTransmitter(), request, getTransmitter().getColor(), true, 0);
 
-                // If the insert succeeded, remove the inserted count and try again for another 10 ticks
-                if (!response.isEmpty()) {
-                    response.getInvStack(tile, side.getOpposite()).use(response.getSendingAmount());
-                    delay = 10;
-                } else {
-                    // Insert failed; increment the backoff and calculate delay. Note that we cap retries
-                    // at a max of 40 ticks (2 seocnds), which would be 4 consecutive retries
-                    delayCount++;
-                    delay = Math.min(40, (int) Math.exp(delayCount));
+                    // If the insert succeeded, remove the inserted count and try again for another 10 ticks
+                    if (!response.isEmpty()) {
+                        response.getInvStack(tile, side.getOpposite()).use(response.getSendingAmount());
+                        delay = 10;
+                    } else {
+                        // Insert failed; increment the backoff and calculate delay. Note that we cap retries
+                        // at a max of 40 ticks (2 seocnds), which would be 4 consecutive retries
+                        delayCount++;
+                        delay = Math.min(40, (int) Math.exp(delayCount));
+                    }
                 }
             }
         }

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntitySidedPipe.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntitySidedPipe.java
@@ -130,7 +130,7 @@ public abstract class TileEntitySidedPipe extends TileEntity implements ITileNet
         }
         for (EnumFacing side : EnumFacing.values()) {
             if (canConnectMutual(side)) {
-                TileEntity tileEntity = getWorld().getTileEntity(getPos().offset(side));
+                TileEntity tileEntity = MekanismUtils.getTileEntity(world, getPos().offset(side));
                 if (CapabilityUtils.hasCapability(tileEntity, Capabilities.GRID_TRANSMITTER_CAPABILITY, side.getOpposite())
                     && TransmissionType.checkTransmissionType(CapabilityUtils.getCapability(tileEntity, Capabilities.GRID_TRANSMITTER_CAPABILITY, side.getOpposite()),
                       getTransmitterType().getTransmission()) && isValidTransmitter(tileEntity)) {
@@ -146,7 +146,7 @@ public abstract class TileEntitySidedPipe extends TileEntity implements ITileNet
             return false;
         }
         if (canConnectMutual(side)) {
-            TileEntity tileEntity = getWorld().getTileEntity(getPos().offset(side));
+            TileEntity tileEntity = MekanismUtils.getTileEntity(world, getPos().offset(side));
             if (isValidAcceptor(tileEntity, side)) {
                 if (cachedAcceptors[side.ordinal()] != tileEntity) {
                     cachedAcceptors[side.ordinal()] = tileEntity;
@@ -167,7 +167,7 @@ public abstract class TileEntitySidedPipe extends TileEntity implements ITileNet
             return false;
         }
         if (canConnectMutual(side)) {
-            TileEntity tileEntity = getWorld().getTileEntity(getPos().offset(side));
+            TileEntity tileEntity = MekanismUtils.getTileEntity(world, getPos().offset(side));
             return CapabilityUtils.hasCapability(tileEntity, Capabilities.GRID_TRANSMITTER_CAPABILITY, side.getOpposite())
                    && TransmissionType.checkTransmissionType(CapabilityUtils.getCapability(tileEntity, Capabilities.GRID_TRANSMITTER_CAPABILITY, side.getOpposite()),
                   getTransmitterType().getTransmission()) && isValidTransmitter(tileEntity);
@@ -254,11 +254,11 @@ public abstract class TileEntitySidedPipe extends TileEntity implements ITileNet
 
     @Override
     public boolean canConnectMutual(EnumFacing side) {
-        BlockPos testPos = getPos().offset(side);
-        if (!world.isBlockLoaded(testPos) || !canConnect(side)) {
+        if (!canConnect(side)) {
             return false;
         }
-        TileEntity tile = getWorld().getTileEntity(testPos);
+        final BlockPos testPos = getPos().offset(side);
+        final TileEntity tile = MekanismUtils.getTileEntity(world, testPos);
         if (!CapabilityUtils.hasCapability(tile, Capabilities.BLOCKABLE_CONNECTION_CAPABILITY, side.getOpposite())) {
             return true;
         }

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityThermodynamicConductor.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityThermodynamicConductor.java
@@ -15,6 +15,7 @@ import mekanism.common.tier.ConductorTier;
 import mekanism.common.transmitters.grid.HeatNetwork;
 import mekanism.common.util.CapabilityUtils;
 import mekanism.common.util.HeatUtils;
+import mekanism.common.util.MekanismUtils;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
@@ -179,7 +180,7 @@ public class TileEntityThermodynamicConductor extends TileEntityTransmitter<IHea
     @Override
     public IHeatTransfer getAdjacent(EnumFacing side) {
         if (connectionMapContainsSide(getAllCurrentConnections(), side)) {
-            TileEntity adj = getWorld().getTileEntity(getPos().offset(side));
+            TileEntity adj = MekanismUtils.getTileEntity(world, getPos().offset(side));
             if (CapabilityUtils.hasCapability(adj, Capabilities.HEAT_TRANSFER_CAPABILITY, side.getOpposite())) {
                 return CapabilityUtils.getCapability(adj, Capabilities.HEAT_TRANSFER_CAPABILITY, side.getOpposite());
             }

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityTransmitter.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityTransmitter.java
@@ -13,6 +13,7 @@ import mekanism.api.transmitters.IGridTransmitter;
 import mekanism.api.transmitters.TransmitterNetworkRegistry;
 import mekanism.common.capabilities.Capabilities;
 import mekanism.common.transmitters.TransmitterImpl;
+import mekanism.common.util.MekanismUtils;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
@@ -158,9 +159,9 @@ public abstract class TileEntityTransmitter<A, N extends DynamicNetwork<A, N, BU
     }
 
     private boolean recheckConnectionPrechecked(EnumFacing side) {
-        N network = getTransmitter().getTransmitterNetwork();
-        TileEntity tileEntity = getWorld().getTileEntity(getPos().offset(side));
+        final TileEntity tileEntity = MekanismUtils.getTileEntity(world, getPos().offset(side));
         if (tileEntity instanceof TileEntityTransmitter) {
+            N network = getTransmitter().getTransmitterNetwork();
             TileEntityTransmitter other = (TileEntityTransmitter) tileEntity;
             //The other one should always have the same incompatible networks state as us
             // But just in case it doesn't just check the boolean

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityUniversalCable.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityUniversalCable.java
@@ -186,7 +186,7 @@ public class TileEntityUniversalCable extends TileEntityTransmitter<EnergyAccept
 
     @Override
     public boolean isValidAcceptor(TileEntity acceptor, EnumFacing side) {
-        return CableUtils.isValidAcceptorOnSide(getWorld().getTileEntity(getPos()), acceptor, side);
+        return CableUtils.isValidAcceptorOnSide( MekanismUtils.getTileEntity(world, getPos()), acceptor, side);
     }
 
     @Override

--- a/src/main/java/mekanism/common/util/CableUtils.java
+++ b/src/main/java/mekanism/common/util/CableUtils.java
@@ -64,7 +64,7 @@ public final class CableUtils {
     public static TileEntity[] getConnectedOutputters(BlockPos pos, World world) {
         TileEntity[] outputters = new TileEntity[]{null, null, null, null, null, null};
         for (EnumFacing orientation : EnumFacing.VALUES) {
-            TileEntity outputter = world.getTileEntity(pos.offset(orientation));
+            final TileEntity outputter =  MekanismUtils.getTileEntity(world, pos.offset(orientation));
             if (isOutputter(outputter, orientation)) {
                 outputters[orientation.ordinal()] = outputter;
             }

--- a/src/main/java/mekanism/common/util/MekanismUtils.java
+++ b/src/main/java/mekanism/common/util/MekanismUtils.java
@@ -512,6 +512,9 @@ public final class MekanismUtils {
      * @param pos   Position of the block
      */
     public static void updateBlock(World world, BlockPos pos) {
+        if(!world.isBlockLoaded(pos)) {
+            return;
+        }
         //Schedule a render update regardless of it is an IActiveState with IActiveState#renderUpdate() as true
         // This is because that is mainly used for rendering machine effects, but we need to run a render update
         // anyways here in case IActiveState#renderUpdate() is false and we just had the block rotate.
@@ -1071,6 +1074,20 @@ public final class MekanismUtils {
     public static TileEntity getTileEntitySafe(IBlockAccess worldIn, BlockPos pos) {
         return worldIn instanceof ChunkCache ? ((ChunkCache) worldIn).getTileEntity(pos, Chunk.EnumCreateEntityType.CHECK) : worldIn.getTileEntity(pos);
     }
+
+    /**
+     * Gets a tile entity if the location is loaded
+     * @param world - world
+     * @param pos - position
+     * @return tile entity if found, null if either not found or not loaded
+     */
+    public static TileEntity getTileEntity(World world, BlockPos pos) {
+        if(world != null && world.isBlockLoaded(pos)) {
+            return world.getTileEntity(pos);
+        }
+        return null;
+    }
+
 
     /**
      * Dismantles a block, dropping it and removing it from the world.

--- a/src/main/java/mekanism/generators/common/block/BlockGenerator.java
+++ b/src/main/java/mekanism/generators/common/block/BlockGenerator.java
@@ -128,7 +128,7 @@ public abstract class BlockGenerator extends BlockMekanismContainer {
     @Deprecated
     public void neighborChanged(IBlockState state, World world, BlockPos pos, Block neighborBlock, BlockPos neighborPos) {
         if (!world.isRemote) {
-            TileEntity tileEntity = world.getTileEntity(pos);
+            final TileEntity tileEntity = MekanismUtils.getTileEntity(world, pos);
             if (tileEntity instanceof IMultiblock) {
                 ((IMultiblock<?>) tileEntity).doUpdate();
             }


### PR DESCRIPTION
Searched for usage of World#getTileEntity(BlockPos) replacing any instance that looked close to accessing another block with a check for isBlockLoaded. 