### PR TITLE
Optimized Component Ejector

### DIFF
--- a/src/main/java/mekanism/common/tile/TileEntityChanceMachine.java
+++ b/src/main/java/mekanism/common/tile/TileEntityChanceMachine.java
@@ -101,7 +101,6 @@ public abstract class TileEntityChanceMachine<RECIPE extends ChanceMachineRecipe
     public void operate(RECIPE recipe) {
         recipe.operate(inventory, 0, 2, 4);
         markDirty();
-        ejectorComponent.outputItems();
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/TileEntityChemicalCrystallizer.java
+++ b/src/main/java/mekanism/common/tile/TileEntityChemicalCrystallizer.java
@@ -116,7 +116,6 @@ public class TileEntityChemicalCrystallizer extends TileEntityOperationalMachine
     public void operate(CrystallizerRecipe recipe) {
         recipe.operate(inputTank, inventory);
         markDirty();
-        ejectorComponent.outputItems();
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
+++ b/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
@@ -21,6 +21,7 @@ import mekanism.common.Mekanism;
 import mekanism.common.Upgrade;
 import mekanism.common.base.IActiveState;
 import mekanism.common.base.IAdvancedBoundingBlock;
+import mekanism.common.base.ILogisticalTransporter;
 import mekanism.common.base.IRedstoneControl;
 import mekanism.common.base.ISustainedData;
 import mekanism.common.base.IUpgradeTile;
@@ -85,7 +86,6 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
 
     private static final int[] INV_SLOTS = IntStream.range(0, 28).toArray();
 
-    public static int[] EJECT_INV;
     public Map<Chunk3D, BitSet> oresToMine = new HashMap<>();
     public Map<Integer, MinerFilter> replaceMap = new HashMap<>();
     public HashList<MinerFilter> filters = new HashList<>();
@@ -261,12 +261,12 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
                 TileEntity ejectInv = getEjectInv();
                 TileEntity ejectTile = getEjectTile();
                 if (ejectInv != null && ejectTile != null) {
+                    ILogisticalTransporter capability = CapabilityUtils.getCapability(ejectInv, Capabilities.LOGISTICAL_TRANSPORTER_CAPABILITY, facing.getOpposite());
                     TransitResponse response;
-                    if (CapabilityUtils.hasCapability(ejectInv, Capabilities.LOGISTICAL_TRANSPORTER_CAPABILITY, facing.getOpposite())) {
-                        response = TransporterUtils.insert(ejectTile, CapabilityUtils.getCapability(ejectInv, Capabilities.LOGISTICAL_TRANSPORTER_CAPABILITY, facing.getOpposite()),
-                              ejectMap, null, true, 0);
-                    } else {
+                    if (capability == null) {
                         response = InventoryUtils.putStackInInventory(ejectInv, ejectMap, facing.getOpposite(), false);
+                    } else {
+                        response = TransporterUtils.insert(ejectTile, capability, ejectMap, null, true, 0);
                     }
                     if (!response.isEmpty()) {
                         response.getInvStack(ejectTile, facing.getOpposite()).use();
@@ -401,13 +401,8 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
         TransitRequest request = new TransitRequest();
         for (int i = 27 - 1; i >= 0; i--) {
             ItemStack stack = inventory.get(i);
-            if (!stack.isEmpty()) {
-                if (isReplaceStack(stack)) {
-                    continue;
-                }
-                if (!request.hasType(stack)) {
-                    request.addItem(stack, i);
-                }
+            if (!stack.isEmpty() && !isReplaceStack(stack)) {
+                request.addItem(stack, i);
             }
         }
         return request;

--- a/src/main/java/mekanism/common/tile/TileEntityFactory.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFactory.java
@@ -680,7 +680,6 @@ public class TileEntityFactory extends TileEntityMachine implements IComputerInt
         }
 
         markDirty();
-        ejectorComponent.outputItems();
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/TileEntityFactory.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFactory.java
@@ -333,7 +333,6 @@ public class TileEntityFactory extends TileEntityMachine implements IComputerInt
             //Append the "extra" slot to the available slots
             data.availableSlots = Arrays.copyOf(data.availableSlots, data.availableSlots.length + 1);
             data.availableSlots[data.availableSlots.length - 1] = 4;
-            ejectorComponent.trackers.put(TransmissionType.ITEM, Arrays.copyOf(ejectorComponent.trackers.get(TransmissionType.ITEM), data.availableSlots.length));
         }
 
         for (Upgrade upgrade : upgradeComponent.getSupportedTypes()) {

--- a/src/main/java/mekanism/common/tile/TileEntityFormulaicAssemblicator.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFormulaicAssemblicator.java
@@ -139,7 +139,6 @@ public class TileEntityFormulaicAssemblicator extends TileEntityElectricBlock im
                             if (pulseOperations > 0) {
                                 pulseOperations--;
                             }
-                            ejectorComponent.outputItems();
                         }
                     } else if (getEnergy() >= energyPerTick) {
                         operatingTicks++;

--- a/src/main/java/mekanism/common/tile/TileEntityMetallurgicInfuser.java
+++ b/src/main/java/mekanism/common/tile/TileEntityMetallurgicInfuser.java
@@ -214,7 +214,6 @@ public class TileEntityMetallurgicInfuser extends TileEntityOperationalMachine i
     public void operate(MetallurgicInfuserRecipe recipe) {
         recipe.output(inventory, 2, 3, infuseStored);
         markDirty();
-        ejectorComponent.outputItems();
     }
 
     @Contract("null -> false")

--- a/src/main/java/mekanism/common/tile/TileEntityPRC.java
+++ b/src/main/java/mekanism/common/tile/TileEntityPRC.java
@@ -152,7 +152,6 @@ public class TileEntityPRC extends TileEntityBasicMachine<PressurizedInput, Pres
     public void operate(PressurizedRecipe recipe) {
         recipe.operate(inventory, inputFluidTank, inputGasTank, outputGasTank);
         markDirty();
-        ejectorComponent.outputItems();
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/component/TileComponentEjector.java
+++ b/src/main/java/mekanism/common/tile/component/TileComponentEjector.java
@@ -132,7 +132,7 @@ public class TileComponentEjector implements ITileComponent {
         TransitRequest ejectMap = null;
         for (EnumFacing side : outputs) {
             if (ejectMap == null) {
-                ejectMap = getEjectItemMap();
+                ejectMap = getEjectItemMap(data);
                 if (ejectMap.isEmpty()) {
                     break;
                 }
@@ -148,19 +148,17 @@ public class TileComponentEjector implements ITileComponent {
 
             if (!response.isEmpty()) {
                 response.getInvStack(tileEntity, side).use();
-                ejectMap = null;
                 //Set map to null so next loop recalculates the eject map so that all sides get a chance to be ejected to
                 // assuming that there is still any left
-                //TODO: Optimize by making use() return if it used all that it expected to use
-                // This way it won't have to recheck
+                //TODO: Eventually make some way to just directly update the TransitRequest with remaining parts
+                ejectMap = null;
             }
         }
         tickDelay = 20;
     }
 
-    private TransitRequest getEjectItemMap() {
+    private TransitRequest getEjectItemMap(SideData data) {
         TransitRequest request = new TransitRequest();
-        SideData data = sideData.get(TransmissionType.ITEM);
         for (int index = 0; index < data.availableSlots.length; index++) {
             int slotID = data.availableSlots[index];
             ItemStack stack = tileEntity.getStackInSlot(slotID);

--- a/src/main/java/mekanism/common/tile/component/TileComponentEjector.java
+++ b/src/main/java/mekanism/common/tile/component/TileComponentEjector.java
@@ -136,6 +136,10 @@ public class TileComponentEjector implements ITileComponent {
                 }
             }
             TileEntity tile = MekanismUtils.getTileEntity(tileEntity.getWorld(), tileEntity.getPos().offset(side));
+            if (tile == null) {
+                //If the spot is not loaded just skip trying to eject to it
+                continue;
+            }
             ILogisticalTransporter capability = CapabilityUtils.getCapability(tile, Capabilities.LOGISTICAL_TRANSPORTER_CAPABILITY, side.getOpposite());
             TransitResponse response;
             if (capability == null) {

--- a/src/main/java/mekanism/common/tile/component/TileComponentEjector.java
+++ b/src/main/java/mekanism/common/tile/component/TileComponentEjector.java
@@ -5,7 +5,6 @@ import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
@@ -45,7 +44,6 @@ public class TileComponentEjector implements ITileComponent {
     private EnumColor[] inputColors = new EnumColor[]{null, null, null, null, null, null};
     private int tickDelay = 0;
     private Map<TransmissionType, SideData> sideData = new EnumMap<>(TransmissionType.class);
-    public Map<TransmissionType, int[]> trackers = new EnumMap<>(TransmissionType.class);
 
     public TileComponentEjector(TileEntityContainerBlock tile) {
         tileEntity = tile;
@@ -54,7 +52,6 @@ public class TileComponentEjector implements ITileComponent {
 
     public TileComponentEjector setOutputData(TransmissionType type, SideData data) {
         sideData.put(type, data);
-        trackers.put(type, new int[data.availableSlots.length]);
         return this;
     }
 
@@ -64,19 +61,6 @@ public class TileComponentEjector implements ITileComponent {
         inputColors = ejector.inputColors;
         tickDelay = ejector.tickDelay;
         sideData = ejector.sideData;
-    }
-
-    //TODO: Figure out if trackers can just be removed or what the goal of it was and reimplement if needed
-    private Set<EnumFacing> getTrackedOutputs(TransmissionType type, int index, Set<EnumFacing> dirs) {
-        Set<EnumFacing> sides = EnumSet.noneOf(EnumFacing.class);
-        int tracker = trackers.get(type)[index];
-        for (int i = tracker + 1; i <= tracker + 6; i++) {
-            EnumFacing side = EnumFacing.byIndex(i % 6);
-            if (dirs.contains(side)) {
-                sides.add(side);
-            }
-        }
-        return sides;
     }
 
     @Override
@@ -220,13 +204,6 @@ public class TileComponentEjector implements ITileComponent {
         if (nbtTags.hasKey("ejectColor")) {
             outputColor = readColor(nbtTags.getInteger("ejectColor"));
         }
-        for (Entry<TransmissionType, SideData> entry : sideData.entrySet()) {
-            TransmissionType type = entry.getKey();
-            SideData data = entry.getValue();
-            for (int i = 0; i < data.availableSlots.length; i++) {
-                trackers.get(type)[i] = nbtTags.getInteger("tracker" + type.getTransmission() + i);
-            }
-        }
         for (int i = 0; i < 6; i++) {
             if (nbtTags.hasKey("inputColors" + i)) {
                 inputColors[i] = readColor(nbtTags.getInteger("inputColors" + i));
@@ -248,13 +225,6 @@ public class TileComponentEjector implements ITileComponent {
         nbtTags.setBoolean("strictInput", strictInput);
         if (outputColor != null) {
             nbtTags.setInteger("ejectColor", getColorIndex(outputColor));
-        }
-        for (Entry<TransmissionType, SideData> entry : sideData.entrySet()) {
-            TransmissionType type = entry.getKey();
-            SideData data = entry.getValue();
-            for (int i = 0; i < data.availableSlots.length; i++) {
-                nbtTags.setInteger("tracker" + type.getTransmission() + i, trackers.get(type)[i]);
-            }
         }
         for (int i = 0; i < 6; i++) {
             nbtTags.setInteger("inputColors" + i, getColorIndex(inputColors[i]));

--- a/src/main/java/mekanism/common/tile/component/TileComponentEjector.java
+++ b/src/main/java/mekanism/common/tile/component/TileComponentEjector.java
@@ -31,6 +31,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTank;
 
@@ -127,7 +128,6 @@ public class TileComponentEjector implements ITileComponent {
         if (data == null || !getEjecting(TransmissionType.ITEM)) {
             return;
         }
-        Coord4D tileCoord = Coord4D.get(tileEntity);
         Set<EnumFacing> outputs = getOutputSides(TransmissionType.ITEM, data);
         TransitRequest ejectMap = null;
         for (EnumFacing side : outputs) {
@@ -137,7 +137,8 @@ public class TileComponentEjector implements ITileComponent {
                     break;
                 }
             }
-            TileEntity tile = tileCoord.offset(side).getTileEntity(tileEntity.getWorld());
+            BlockPos offsetPos = tileEntity.getPos().offset(side);
+            TileEntity tile = tileEntity.getWorld().isBlockLoaded(offsetPos) ? tileEntity.getWorld().getTileEntity(offsetPos) : null;
             ILogisticalTransporter capability = CapabilityUtils.getCapability(tile, Capabilities.LOGISTICAL_TRANSPORTER_CAPABILITY, side.getOpposite());
             TransitResponse response;
             if (capability == null) {

--- a/src/main/java/mekanism/common/tile/component/TileComponentEjector.java
+++ b/src/main/java/mekanism/common/tile/component/TileComponentEjector.java
@@ -6,7 +6,6 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
 import mekanism.api.TileNetworkList;
 import mekanism.api.gas.GasStack;
@@ -31,7 +30,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
-import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTank;
 
@@ -137,8 +135,7 @@ public class TileComponentEjector implements ITileComponent {
                     break;
                 }
             }
-            BlockPos offsetPos = tileEntity.getPos().offset(side);
-            TileEntity tile = tileEntity.getWorld().isBlockLoaded(offsetPos) ? tileEntity.getWorld().getTileEntity(offsetPos) : null;
+            TileEntity tile = MekanismUtils.getTileEntity(tileEntity.getWorld(), tileEntity.getPos().offset(side));
             ILogisticalTransporter capability = CapabilityUtils.getCapability(tile, Capabilities.LOGISTICAL_TRANSPORTER_CAPABILITY, side.getOpposite());
             TransitResponse response;
             if (capability == null) {

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityAdvancedElectricMachine.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityAdvancedElectricMachine.java
@@ -221,7 +221,6 @@ public abstract class TileEntityAdvancedElectricMachine<RECIPE extends AdvancedM
     public void operate(RECIPE recipe) {
         recipe.operate(inventory, 0, 2, gasTank, secondaryEnergyThisTick);
         markDirty();
-        ejectorComponent.outputItems();
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityDoubleElectricMachine.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityDoubleElectricMachine.java
@@ -131,7 +131,6 @@ public abstract class TileEntityDoubleElectricMachine<RECIPE extends DoubleMachi
     public void operate(RECIPE recipe) {
         recipe.operate(inventory, 0, 1, 2);
         markDirty();
-        ejectorComponent.outputItems();
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityElectricMachine.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityElectricMachine.java
@@ -116,7 +116,6 @@ public abstract class TileEntityElectricMachine<RECIPE extends BasicMachineRecip
     public void operate(RECIPE recipe) {
         recipe.operate(inventory, 0, 2);
         markDirty();
-        ejectorComponent.outputItems();
     }
 
     @Override

--- a/src/main/java/mekanism/common/util/CapabilityUtils.java
+++ b/src/main/java/mekanism/common/util/CapabilityUtils.java
@@ -4,9 +4,11 @@ import java.util.function.Consumer;
 import net.minecraft.util.EnumFacing;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import org.jetbrains.annotations.Contract;
 
 public final class CapabilityUtils {
 
+    @Contract("null, _, _ -> false; _, null, _ -> false")
     public static boolean hasCapability(ICapabilityProvider provider, Capability<?> cap, EnumFacing side) {
         if (provider == null || cap == null) {
             return false;
@@ -14,6 +16,7 @@ public final class CapabilityUtils {
         return provider.hasCapability(cap, side);
     }
 
+    @Contract("null, _, _ -> null; _, null, _ -> null")
     public static <T> T getCapability(ICapabilityProvider provider, Capability<T> cap, EnumFacing side) {
         if (provider == null || cap == null) {
             return null;

--- a/src/main/java/mekanism/common/util/MekanismUtils.java
+++ b/src/main/java/mekanism/common/util/MekanismUtils.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import mekanism.api.Chunk3D;
 import mekanism.api.Coord4D;
 import mekanism.api.IMekWrench;
@@ -1081,6 +1082,7 @@ public final class MekanismUtils {
      * @param pos - position
      * @return tile entity if found, null if either not found or not loaded
      */
+    @Nullable
     public static TileEntity getTileEntity(World world, BlockPos pos) {
         if(world != null && world.isBlockLoaded(pos)) {
             return world.getTileEntity(pos);


### PR DESCRIPTION
## Changes proposed in this pull request:
- Fixes Digital miner not combining stacks for ejecting
- Combine TransitRequests for ComponentEjector where possible, and only eject once a second instead of also every time an operation occurs.
- Removed ComponentEjector trackers as from what I can tell they did not actually do anything

Some profiling hints from my test world:
Before: https://sparkprofiler.github.io/#hksdBcW8EO https://gyazo.com/32ac3e0956481b904fa2accc194d1990
After: https://sparkprofiler.github.io/#pUOsQgm7zP https://gyazo.com/497480ae84fdd6f1750139009877c230