### PR TITLE
Overwrite getBlockFaceShape for various blocks

### DIFF
--- a/src/main/java/mekanism/common/base/IBoundingBlock.java
+++ b/src/main/java/mekanism/common/base/IBoundingBlock.java
@@ -1,5 +1,10 @@
 package mekanism.common.base;
 
+import javax.annotation.Nonnull;
+import net.minecraft.block.state.BlockFaceShape;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.Vec3i;
+
 /**
  * Internal interface.  A bounding block is not actually a 'bounding' block, it is really just a fake block that is used to mimic actual block bounds.
  *
@@ -16,4 +21,17 @@ public interface IBoundingBlock {
      * Called when any part of the structure is broken.
      */
     void onBreak();
+
+    /**
+     * Used for getting the proper BlockFaceShape for the bounding block.
+     *
+     * @param face   The face of the block at the offset that the shape is needed for.
+     * @param offset Offset from the implementation of IBoundingBlock
+     *
+     * @return A BlockFaceShape
+     */
+    @Nonnull
+    default BlockFaceShape getOffsetBlockFaceShape(@Nonnull EnumFacing face, @Nonnull Vec3i offset) {
+        return BlockFaceShape.UNDEFINED;
+    }
 }

--- a/src/main/java/mekanism/common/block/BlockBounding.java
+++ b/src/main/java/mekanism/common/block/BlockBounding.java
@@ -8,6 +8,7 @@ import mekanism.common.tile.TileEntityBoundingBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockFlowerPot;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.state.BlockFaceShape;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayer;
@@ -199,6 +200,15 @@ public class BlockBounding extends Block {
     @Deprecated
     public boolean isFullCube(IBlockState state) {
         return false;
+    }
+
+    @Nonnull
+    @Override
+    @Deprecated
+    public BlockFaceShape getBlockFaceShape(IBlockAccess world, IBlockState state, BlockPos pos, EnumFacing face) {
+        //TODO: Add support so things like the center blocks of the digital miner can be marked as "solid"
+        // for now we have better overall accuracy if we just use undefined though
+        return BlockFaceShape.UNDEFINED;
     }
 
     @Override

--- a/src/main/java/mekanism/common/block/BlockBounding.java
+++ b/src/main/java/mekanism/common/block/BlockBounding.java
@@ -2,6 +2,7 @@ package mekanism.common.block;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import mekanism.common.base.IBoundingBlock;
 import mekanism.common.block.states.BlockStateBounding;
 import mekanism.common.tile.TileEntityAdvancedBoundingBlock;
 import mekanism.common.tile.TileEntityBoundingBlock;
@@ -206,8 +207,13 @@ public class BlockBounding extends Block {
     @Override
     @Deprecated
     public BlockFaceShape getBlockFaceShape(IBlockAccess world, IBlockState state, BlockPos pos, EnumFacing face) {
-        //TODO: Add support so things like the center blocks of the digital miner can be marked as "solid"
-        // for now we have better overall accuracy if we just use undefined though
+        BlockPos mainPos = getMainBlockPos(world, pos);
+        if (mainPos != null) {
+            TileEntity tile = world.getTileEntity(mainPos);
+            if (tile instanceof IBoundingBlock) {
+                return ((IBoundingBlock) tile).getOffsetBlockFaceShape(face, pos.subtract(mainPos));
+            }
+        }
         return BlockFaceShape.UNDEFINED;
     }
 

--- a/src/main/java/mekanism/common/block/BlockGasTank.java
+++ b/src/main/java/mekanism/common/block/BlockGasTank.java
@@ -20,6 +20,7 @@ import mekanism.common.util.MekanismUtils;
 import mekanism.common.util.SecurityUtils;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.state.BlockFaceShape;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.EntityLivingBase;
@@ -274,5 +275,12 @@ public class BlockGasTank extends BlockMekanismContainer {
     @Deprecated
     public boolean isFullCube(IBlockState state) {
         return false;
+    }
+
+    @Nonnull
+    @Override
+    @Deprecated
+    public BlockFaceShape getBlockFaceShape(IBlockAccess world, IBlockState state, BlockPos pos, EnumFacing face) {
+        return BlockFaceShape.UNDEFINED;
     }
 }

--- a/src/main/java/mekanism/common/block/BlockGasTank.java
+++ b/src/main/java/mekanism/common/block/BlockGasTank.java
@@ -281,6 +281,6 @@ public class BlockGasTank extends BlockMekanismContainer {
     @Override
     @Deprecated
     public BlockFaceShape getBlockFaceShape(IBlockAccess world, IBlockState state, BlockPos pos, EnumFacing face) {
-        return BlockFaceShape.UNDEFINED;
+        return face == EnumFacing.UP || face == EnumFacing.DOWN ? BlockFaceShape.CENTER_BIG : BlockFaceShape.UNDEFINED;
     }
 }

--- a/src/main/java/mekanism/common/block/BlockGlowPanel.java
+++ b/src/main/java/mekanism/common/block/BlockGlowPanel.java
@@ -14,6 +14,7 @@ import mekanism.common.util.MultipartUtils;
 import net.minecraft.block.Block;
 import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.state.BlockFaceShape;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.item.ItemStack;
@@ -189,5 +190,12 @@ public class BlockGlowPanel extends BlockTileDrops implements ITileEntityProvide
     @Deprecated
     public boolean isFullBlock(IBlockState state) {
         return false;
+    }
+
+    @Nonnull
+    @Override
+    @Deprecated
+    public BlockFaceShape getBlockFaceShape(IBlockAccess world, IBlockState state, BlockPos pos, EnumFacing face) {
+        return BlockFaceShape.UNDEFINED;
     }
 }

--- a/src/main/java/mekanism/common/block/BlockMachine.java
+++ b/src/main/java/mekanism/common/block/BlockMachine.java
@@ -54,6 +54,7 @@ import mekanism.common.util.StackUtils;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.PropertyEnum;
+import net.minecraft.block.state.BlockFaceShape;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.particle.ParticleManager;
@@ -708,15 +709,38 @@ public abstract class BlockMachine extends BlockMekanismContainer {
     @Deprecated
     public boolean isSideSolid(IBlockState state, @Nonnull IBlockAccess world, @Nonnull BlockPos pos, EnumFacing side) {
         MachineType type = MachineType.get(getMachineBlock(), state.getBlock().getMetaFromState(state));
-        switch (type) {
-            case CHARGEPAD:
-            case PERSONAL_CHEST:
-                return false;
-            case FLUID_TANK:
-                return side == EnumFacing.UP || side == EnumFacing.DOWN;
-            default:
-                return true;
+        if (type != null) {
+            switch (type) {
+                case CHARGEPAD:
+                case PERSONAL_CHEST:
+                    return false;
+                case FLUID_TANK:
+                    return side == EnumFacing.UP || side == EnumFacing.DOWN;
+            }
         }
+        return true;
+    }
+
+    @Nonnull
+    @Override
+    @Deprecated
+    public BlockFaceShape getBlockFaceShape(IBlockAccess world, IBlockState state, BlockPos pos, EnumFacing face) {
+        MachineType type = MachineType.get(getMachineBlock(), state.getBlock().getMetaFromState(state));
+        if (type != null) {
+            switch (type) {
+                case PERSONAL_CHEST:
+                case LOGISTICAL_SORTER:
+                case LASER:
+                case ELECTRIC_PUMP:
+                case FLUIDIC_PLENISHER:
+                    return BlockFaceShape.UNDEFINED;
+                case CHARGEPAD:
+                    return face == EnumFacing.DOWN ? BlockFaceShape.SOLID : BlockFaceShape.UNDEFINED;
+                case FLUID_TANK:
+                    return face != EnumFacing.UP && face != EnumFacing.DOWN ? BlockFaceShape.UNDEFINED : BlockFaceShape.SOLID;
+            }
+        }
+        return super.getBlockFaceShape(world, state, pos, face);
     }
 
     public PropertyEnum<MachineType> getTypeProperty() {

--- a/src/main/java/mekanism/common/block/BlockMachine.java
+++ b/src/main/java/mekanism/common/block/BlockMachine.java
@@ -731,9 +731,10 @@ public abstract class BlockMachine extends BlockMekanismContainer {
                 case PERSONAL_CHEST:
                 case LOGISTICAL_SORTER:
                 case LASER:
+                    return BlockFaceShape.UNDEFINED;
                 case ELECTRIC_PUMP:
                 case FLUIDIC_PLENISHER:
-                    return BlockFaceShape.UNDEFINED;
+                    return face == EnumFacing.UP || face == EnumFacing.DOWN ? BlockFaceShape.CENTER_BIG : BlockFaceShape.UNDEFINED;
                 case CHARGEPAD:
                     return face == EnumFacing.DOWN ? BlockFaceShape.SOLID : BlockFaceShape.UNDEFINED;
                 case FLUID_TANK:

--- a/src/main/java/mekanism/common/block/BlockTransmitter.java
+++ b/src/main/java/mekanism/common/block/BlockTransmitter.java
@@ -31,6 +31,7 @@ import mekanism.common.util.MultipartUtils.AdvancedRayTraceResult;
 import net.minecraft.block.Block;
 import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.state.BlockFaceShape;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.particle.ParticleManager;
@@ -345,6 +346,13 @@ public class BlockTransmitter extends BlockTileDrops implements ITileEntityProvi
     @Deprecated
     public boolean isFullBlock(IBlockState state) {
         return false;
+    }
+
+    @Nonnull
+    @Override
+    @Deprecated
+    public BlockFaceShape getBlockFaceShape(IBlockAccess world, IBlockState state, BlockPos pos, EnumFacing face) {
+        return BlockFaceShape.UNDEFINED;
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
+++ b/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
@@ -53,6 +53,7 @@ import mekanism.common.util.StackUtils;
 import mekanism.common.util.TransporterUtils;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockBush;
+import net.minecraft.block.state.BlockFaceShape;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
@@ -1178,8 +1179,7 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
     }
 
     @Override
-    public boolean isOffsetCapabilityDisabled(@Nonnull Capability<?> capability, EnumFacing side,
-          @Nonnull Vec3i offset) {
+    public boolean isOffsetCapabilityDisabled(@Nonnull Capability<?> capability, EnumFacing side, @Nonnull Vec3i offset) {
         if (capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
             //Input
             if (offset.equals(new Vec3i(0, 1, 0))) {
@@ -1235,5 +1235,18 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
             chunkSet = new Range4D(Coord4D.get(this)).expandFromCenter(radius).getIntersectingChunks().stream().map(Chunk3D::getPos).collect(Collectors.toSet());
         }
         return chunkSet;
+    }
+
+    @Nonnull
+    @Override
+    public BlockFaceShape getOffsetBlockFaceShape(@Nonnull EnumFacing face, @Nonnull Vec3i offset) {
+        if (offset.equals(new Vec3i(0, 1, 0))) {
+            return BlockFaceShape.SOLID;
+        }
+        EnumFacing back = facing.getOpposite();
+        if (offset.equals(new Vec3i(back.getXOffset(), 1, back.getZOffset()))) {
+            return BlockFaceShape.SOLID;
+        }
+        return BlockFaceShape.UNDEFINED;
     }
 }

--- a/src/main/java/mekanism/common/tile/TileEntitySeismicVibrator.java
+++ b/src/main/java/mekanism/common/tile/TileEntitySeismicVibrator.java
@@ -15,11 +15,13 @@ import mekanism.common.tile.component.TileComponentSecurity;
 import mekanism.common.tile.prefab.TileEntityElectricBlock;
 import mekanism.common.util.ChargeUtils;
 import mekanism.common.util.MekanismUtils;
+import net.minecraft.block.state.BlockFaceShape;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraft.util.math.Vec3i;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -211,5 +213,11 @@ public class TileEntitySeismicVibrator extends TileEntityElectricBlock implement
     @Override
     public boolean isItemValidForSlot(int slot, @Nonnull ItemStack stack) {
         return ChargeUtils.canBeDischarged(stack);
+    }
+
+    @Nonnull
+    @Override
+    public BlockFaceShape getOffsetBlockFaceShape(@Nonnull EnumFacing face, @Nonnull Vec3i offset) {
+        return BlockFaceShape.SOLID;
     }
 }

--- a/src/main/java/mekanism/generators/common/block/BlockGenerator.java
+++ b/src/main/java/mekanism/generators/common/block/BlockGenerator.java
@@ -35,6 +35,7 @@ import mekanism.generators.common.tile.turbine.TileEntityTurbineRotor;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.PropertyEnum;
+import net.minecraft.block.state.BlockFaceShape;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.creativetab.CreativeTabs;
@@ -409,6 +410,25 @@ public abstract class BlockGenerator extends BlockMekanismContainer {
     @Deprecated
     public boolean isFullCube(IBlockState state) {
         return false;
+    }
+
+    @Nonnull
+    @Override
+    @Deprecated
+    public BlockFaceShape getBlockFaceShape(IBlockAccess world, IBlockState state, BlockPos pos, EnumFacing face) {
+        GeneratorType type = GeneratorType.get(state);
+        if (type != null) {
+            switch (type) {
+                case SOLAR_GENERATOR:
+                    return BlockFaceShape.UNDEFINED;
+                case ADVANCED_SOLAR_GENERATOR:
+                case WIND_GENERATOR:
+                    return face == EnumFacing.DOWN ? BlockFaceShape.SOLID : BlockFaceShape.UNDEFINED;
+                case TURBINE_ROTOR:
+                    return face != EnumFacing.UP && face != EnumFacing.DOWN ? BlockFaceShape.MIDDLE_POLE : BlockFaceShape.CENTER;
+            }
+        }
+        return super.getBlockFaceShape(world, state, pos, face);
     }
 
     @SideOnly(Side.CLIENT)


### PR DESCRIPTION
## Changes proposed in this pull request:
Fixes how various blocks interact with:
- button placement
- redstone placement
- torch placement
- snow falling (#4838)
- fence/wall connections

There are still some blocks with "complex" models that return SOLID as their BlockFaceShape when potentially it would make more sense if they did not; however these are minor and for the most part any big outliers have been dealt with by this PR.

## To be done before merging
- [x] Make a system for BlockBounding to figure out if the offset block should be solid or not (parts of the digital miner, and also the seismic vibrator)