### PR TITLE
Assemblicator Fixes for Transforming recipes

### DIFF
--- a/src/main/java/mekanism/client/gui/GuiFormulaicAssemblicator.java
+++ b/src/main/java/mekanism/client/gui/GuiFormulaicAssemblicator.java
@@ -32,7 +32,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
-import net.minecraftforge.items.ItemHandlerHelper;
 
 @SideOnly(Side.CLIENT)
 public class GuiFormulaicAssemblicator extends GuiMekanismTile<TileEntityFormulaicAssemblicator> {
@@ -162,7 +161,7 @@ public class GuiFormulaicAssemblicator extends GuiMekanismTile<TileEntityFormula
 
                     int guiX = guiWidth + slot.xPos;
                     int guiY = guiHeight + slot.yPos;
-                    if (slot.getStack().isEmpty() || !ItemHandlerHelper.canItemStacksStack(slot.getStack(), stack)) {
+                    if (slot.getStack().isEmpty() || !tileEntity.formula.isIngredientInPos(tileEntity.getWorld(), slot.getStack(), i)) {
                         drawGradientRect(guiX, guiY, guiX + 16, guiY + 16, -2137456640, -2137456640);
                     }
 

--- a/src/main/java/mekanism/common/integration/OreDictManager.java
+++ b/src/main/java/mekanism/common/integration/OreDictManager.java
@@ -27,6 +27,7 @@ import net.minecraft.init.Items;
 import net.minecraft.inventory.Container;
 import net.minecraft.inventory.InventoryCrafting;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.CraftingManager;
 import net.minecraft.item.crafting.FurnaceRecipes;
 import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.util.NonNullList;
@@ -436,7 +437,8 @@ public final class OreDictManager {
 
     private static void addSawmillLog(InventoryCrafting tempCrafting, ItemStack log, DummyWorld world) {
         tempCrafting.setInventorySlotContents(0, log);
-        ItemStack resultEntry = MekanismUtils.findMatchingRecipe(tempCrafting, world);
+        IRecipe matchingRecipe = CraftingManager.findMatchingRecipe(tempCrafting, world);
+        ItemStack resultEntry = matchingRecipe != null ? matchingRecipe.getRecipeOutput() : ItemStack.EMPTY;
 
         if (!resultEntry.isEmpty()) {
             RecipeHandler.addPrecisionSawmillRecipe(log, StackUtils.size(resultEntry, 6), new ItemStack(MekanismItems.Sawdust),

--- a/src/main/java/mekanism/common/inventory/container/ContainerFormulaicAssemblicator.java
+++ b/src/main/java/mekanism/common/inventory/container/ContainerFormulaicAssemblicator.java
@@ -14,6 +14,16 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
+import static mekanism.common.tile.TileEntityFormulaicAssemblicator.SLOT_UPGRADE;
+import static mekanism.common.tile.TileEntityFormulaicAssemblicator.SLOT_ENERGY;
+import static mekanism.common.tile.TileEntityFormulaicAssemblicator.SLOT_FORMULA;
+import static mekanism.common.tile.TileEntityFormulaicAssemblicator.SLOT_INPUT_FIRST;
+import static mekanism.common.tile.TileEntityFormulaicAssemblicator.SLOT_INPUT_LAST;
+import static mekanism.common.tile.TileEntityFormulaicAssemblicator.SLOT_OUTPUT_FIRST;
+import static mekanism.common.tile.TileEntityFormulaicAssemblicator.SLOT_OUTPUT_LAST;
+import static mekanism.common.tile.TileEntityFormulaicAssemblicator.SLOT_CRAFT_MATRIX_FIRST;
+import static mekanism.common.tile.TileEntityFormulaicAssemblicator.SLOT_CRAFT_MATRIX_LAST;
+
 public class ContainerFormulaicAssemblicator extends ContainerMekanism<TileEntityFormulaicAssemblicator> {
 
     public ContainerFormulaicAssemblicator(InventoryPlayer inventory, TileEntityFormulaicAssemblicator tile) {
@@ -78,16 +88,16 @@ public class ContainerFormulaicAssemblicator extends ContainerMekanism<TileEntit
 
     @Override
     protected void addSlots() {
-        addSlotToContainer(new SlotDischarge(tileEntity, 1, 152, 76));
-        addSlotToContainer(new SlotSpecific(tileEntity, 2, 6, 26, ItemCraftingFormula.class));
+        addSlotToContainer(new SlotDischarge(tileEntity, SLOT_ENERGY, 152, 76));
+        addSlotToContainer(new SlotSpecific(tileEntity, SLOT_FORMULA, 6, 26, ItemCraftingFormula.class));
         for (int slotY = 0; slotY < 2; slotY++) {
             for (int slotX = 0; slotX < 9; slotX++) {
-                addSlotToContainer(new Slot(tileEntity, slotX + slotY * 9 + 3, 8 + slotX * 18, 98 + slotY * 18));
+                addSlotToContainer(new Slot(tileEntity, slotX + slotY * 9 + SLOT_INPUT_FIRST, 8 + slotX * 18, 98 + slotY * 18));
             }
         }
         for (int slotY = 0; slotY < 3; slotY++) {
             for (int slotX = 0; slotX < 3; slotX++) {
-                addSlotToContainer(new Slot(tileEntity, slotX + slotY * 3 + 27, 26 + slotX * 18, 17 + slotY * 18) {
+                addSlotToContainer(new Slot(tileEntity, slotX + slotY * 3 + SLOT_CRAFT_MATRIX_FIRST, 26 + slotX * 18, 17 + slotY * 18) {
                     @Override
                     public boolean isItemValid(ItemStack stack) {
                         return !tileEntity.autoMode;
@@ -109,7 +119,7 @@ public class ContainerFormulaicAssemblicator extends ContainerMekanism<TileEntit
 
         for (int slotY = 0; slotY < 3; slotY++) {
             for (int slotX = 0; slotX < 2; slotX++) {
-                addSlotToContainer(new SlotOutput(tileEntity, slotX + slotY * 2 + 21, 116 + slotX * 18, 17 + slotY * 18));
+                addSlotToContainer(new SlotOutput(tileEntity, slotX + slotY * 2 + SLOT_OUTPUT_FIRST, 116 + slotX * 18, 17 + slotY * 18));
             }
         }
     }

--- a/src/main/java/mekanism/common/tile/TileEntityFormulaicAssemblicator.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFormulaicAssemblicator.java
@@ -40,6 +40,15 @@ import net.minecraftforge.fml.common.FMLCommonHandler;
 public class TileEntityFormulaicAssemblicator extends TileEntityElectricBlock implements ISideConfiguration, IUpgradeTile, IRedstoneControl, IConfigCardAccess, ISecurityTile {
 
     private static final NonNullList<ItemStack> EMPTY_LIST = NonNullList.create();
+    public static final int SLOT_UPGRADE = 0;
+    public static final int SLOT_ENERGY = 1;
+    public static final int SLOT_FORMULA = 2;
+    public static final int SLOT_INPUT_FIRST = 3;
+    public static final int SLOT_INPUT_LAST = 20;
+    public static final int SLOT_OUTPUT_FIRST = 21;
+    public static final int SLOT_OUTPUT_LAST = 26;
+    public static final int SLOT_CRAFT_MATRIX_FIRST = 27;
+    public static final int SLOT_CRAFT_MATRIX_LAST = 35;
 
     public InventoryCrafting dummyInv = MekanismUtils.getDummyCraftingInv();
 
@@ -82,17 +91,17 @@ public class TileEntityFormulaicAssemblicator extends TileEntityElectricBlock im
         configComponent = new TileComponentConfig(this, TransmissionType.ITEM, TransmissionType.ENERGY);
 
         configComponent.addOutput(TransmissionType.ITEM, new SideData("None", EnumColor.GREY, InventoryUtils.EMPTY));
-        configComponent.addOutput(TransmissionType.ITEM, new SideData("Input", EnumColor.DARK_RED, new int[]{3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
-                                                                                                             20}));
-        configComponent.addOutput(TransmissionType.ITEM, new SideData("Output", EnumColor.DARK_BLUE, new int[]{21, 22, 23, 24, 25, 26}));
-        configComponent.addOutput(TransmissionType.ITEM, new SideData("Energy", EnumColor.DARK_GREEN, new int[]{1}));
+        configComponent.addOutput(TransmissionType.ITEM, new SideData("Input", EnumColor.DARK_RED, new int[]{SLOT_INPUT_FIRST, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+                                                                                                             SLOT_INPUT_LAST}));
+        configComponent.addOutput(TransmissionType.ITEM, new SideData("Output", EnumColor.DARK_BLUE, new int[]{SLOT_OUTPUT_FIRST, 22, 23, 24, 25, SLOT_OUTPUT_LAST}));
+        configComponent.addOutput(TransmissionType.ITEM, new SideData("Energy", EnumColor.DARK_GREEN, new int[]{SLOT_ENERGY}));
 
         configComponent.setConfig(TransmissionType.ITEM, new byte[]{0, 0, 0, 3, 1, 2});
         configComponent.setInputConfig(TransmissionType.ENERGY);
 
         inventory = NonNullList.withSize(36, ItemStack.EMPTY);
 
-        upgradeComponent = new TileComponentUpgrade(this, 0);
+        upgradeComponent = new TileComponentUpgrade(this, SLOT_UPGRADE);
 
         ejectorComponent = new TileComponentEjector(this);
         ejectorComponent.setOutputData(TransmissionType.ITEM, configComponent.getOutputs(TransmissionType.ITEM).get(2));
@@ -108,14 +117,14 @@ public class TileEntityFormulaicAssemblicator extends TileEntityElectricBlock im
                 needsOrganize = false;
                 organizeStock();
             }
-            ChargeUtils.discharge(1, this);
+            ChargeUtils.discharge(SLOT_ENERGY, this);
             if (controlType != RedstoneControl.PULSE) {
                 pulseOperations = 0;
             } else if (MekanismUtils.canFunction(this)) {
                 pulseOperations++;
             }
             RecipeFormula prev = formula;
-            ItemStack formulaStack = inventory.get(2);
+            ItemStack formulaStack = inventory.get(SLOT_FORMULA);
             if (!formulaStack.isEmpty() && formulaStack.getItem() instanceof ItemCraftingFormula) {
                 if (formula == null || lastFormulaStack != formulaStack) {
                     loadFormula();
@@ -161,7 +170,7 @@ public class TileEntityFormulaicAssemblicator extends TileEntityElectricBlock im
     }
 
     public void loadFormula() {
-        ItemStack formulaStack = inventory.get(2);
+        ItemStack formulaStack = inventory.get(SLOT_FORMULA);
         ItemCraftingFormula formulaItem = (ItemCraftingFormula) formulaStack.getItem();
         if (formulaItem.getInventory(formulaStack) != null && !formulaItem.isInvalid(formulaStack)) {
             RecipeFormula recipe = new RecipeFormula(world, formulaItem.getInventory(formulaStack));
@@ -191,7 +200,7 @@ public class TileEntityFormulaicAssemblicator extends TileEntityElectricBlock im
         if (world != null && !world.isRemote) {
             if (formula == null) {
                 for (int i = 0; i < 9; i++) {
-                    dummyInv.setInventorySlotContents(i, inventory.get(27 + i));
+                    dummyInv.setInventorySlotContents(i, inventory.get(SLOT_CRAFT_MATRIX_FIRST + i));
                 }
 
                 lastRemainingItems = EMPTY_LIST;
@@ -207,7 +216,7 @@ public class TileEntityFormulaicAssemblicator extends TileEntityElectricBlock im
                 }
                 isRecipe = !lastOutputStack.isEmpty();
             } else {
-                isRecipe = formula.matches(world, inventory, 27);
+                isRecipe = formula.matches(world, inventory, SLOT_CRAFT_MATRIX_FIRST);
                 if (isRecipe) {
                     lastOutputStack = formula.recipe.getCraftingResult(dummyInv);
                     lastRemainingItems = formula.recipe.getRemainingItems(dummyInv);
@@ -221,7 +230,7 @@ public class TileEntityFormulaicAssemblicator extends TileEntityElectricBlock im
 
     private boolean doSingleCraft() {
         for (int i = 0; i < 9; i++) {
-            dummyInv.setInventorySlotContents(i, inventory.get(27 + i));
+            dummyInv.setInventorySlotContents(i, inventory.get(SLOT_CRAFT_MATRIX_FIRST + i));
         }
         recalculateRecipe();
 
@@ -234,7 +243,7 @@ public class TileEntityFormulaicAssemblicator extends TileEntityElectricBlock im
                 }
             }
 
-            for (int i = 27; i <= 35; i++) {
+            for (int i = SLOT_CRAFT_MATRIX_FIRST; i <= SLOT_CRAFT_MATRIX_LAST; i++) {
                 ItemStack stack = inventory.get(i);
                 if (!stack.isEmpty()) {
                     ItemStack copy = stack.copy();
@@ -266,7 +275,7 @@ public class TileEntityFormulaicAssemblicator extends TileEntityElectricBlock im
     private boolean craftSingle() {
         if (formula != null) {
             boolean canOperate = true;
-            if (!formula.matches(world, inventory, 27)) {
+            if (!formula.matches(world, inventory, SLOT_CRAFT_MATRIX_FIRST)) {
                 canOperate = moveItemsToGrid();
             }
             if (canOperate) {
@@ -280,9 +289,9 @@ public class TileEntityFormulaicAssemblicator extends TileEntityElectricBlock im
 
     private boolean moveItemsToGrid() {
         boolean ret = true;
-        for (int i = 27; i <= 35; i++) {
+        for (int i = SLOT_CRAFT_MATRIX_FIRST; i <= SLOT_CRAFT_MATRIX_LAST; i++) {
             ItemStack recipeStack = inventory.get(i);
-            if (formula.isIngredientInPos(world, recipeStack, i - 27)) {
+            if (formula.isIngredientInPos(world, recipeStack, i - SLOT_CRAFT_MATRIX_FIRST)) {
                 continue;
             }
             if (!recipeStack.isEmpty()) {
@@ -294,10 +303,10 @@ public class TileEntityFormulaicAssemblicator extends TileEntityElectricBlock im
                 }
             } else {
                 boolean found = false;
-                for (int j = 20; j >= 3; j--) {
+                for (int j = SLOT_INPUT_LAST; j >= SLOT_INPUT_FIRST; j--) {
                     //The stack stored in the stock inventory
                     ItemStack stockStack = inventory.get(j);
-                    if (!stockStack.isEmpty() && formula.isIngredientInPos(world, stockStack, i - 27)) {
+                    if (!stockStack.isEmpty() && formula.isIngredientInPos(world, stockStack, i - SLOT_CRAFT_MATRIX_FIRST)) {
                         inventory.set(i, StackUtils.size(stockStack, 1));
                         stockStack.shrink(1);
                         markDirty();
@@ -319,9 +328,9 @@ public class TileEntityFormulaicAssemblicator extends TileEntityElectricBlock im
     }
 
     private void moveItemsToInput(boolean forcePush) {
-        for (int i = 27; i <= 35; i++) {
+        for (int i = SLOT_CRAFT_MATRIX_FIRST; i <= SLOT_CRAFT_MATRIX_LAST; i++) {
             ItemStack recipeStack = inventory.get(i);
-            if (!recipeStack.isEmpty() && (forcePush || (formula != null && !formula.isIngredientInPos(world, recipeStack, i - 27)))) {
+            if (!recipeStack.isEmpty() && (forcePush || (formula != null && !formula.isIngredientInPos(world, recipeStack, i - SLOT_CRAFT_MATRIX_FIRST)))) {
                 inventory.set(i, tryMoveToInput(recipeStack));
             }
         }
@@ -349,8 +358,8 @@ public class TileEntityFormulaicAssemblicator extends TileEntityElectricBlock im
     }
 
     private void organizeStock() {
-        for (int j = 3; j <= 20; j++) {
-            for (int i = 20; i > j; i--) {
+        for (int j = SLOT_INPUT_FIRST; j <= SLOT_INPUT_LAST; j++) {
+            for (int i = SLOT_INPUT_LAST; i > j; i--) {
                 ItemStack stockStack = inventory.get(i);
                 if (!stockStack.isEmpty()) {
                     ItemStack compareStack = inventory.get(j);
@@ -375,7 +384,7 @@ public class TileEntityFormulaicAssemblicator extends TileEntityElectricBlock im
 
     private ItemStack tryMoveToInput(ItemStack stack) {
         stack = stack.copy();
-        for (int i = 3; i <= 20; i++) {
+        for (int i = SLOT_INPUT_FIRST; i <= SLOT_INPUT_LAST; i++) {
             ItemStack stockStack = inventory.get(i);
             if (stockStack.isEmpty()) {
                 inventory.set(i, stack);
@@ -394,7 +403,7 @@ public class TileEntityFormulaicAssemblicator extends TileEntityElectricBlock im
 
     private boolean tryMoveToOutput(ItemStack stack, boolean doMove) {
         stack = stack.copy();
-        for (int i = 21; i <= 26; i++) {
+        for (int i = SLOT_OUTPUT_FIRST; i <= SLOT_OUTPUT_LAST; i++) {
             ItemStack outputStack = inventory.get(i);
             if (outputStack.isEmpty()) {
                 if (doMove) {
@@ -416,11 +425,11 @@ public class TileEntityFormulaicAssemblicator extends TileEntityElectricBlock im
     }
 
     private void encodeFormula() {
-        ItemStack formulaStack = inventory.get(2);
+        ItemStack formulaStack = inventory.get(SLOT_FORMULA);
         if (!formulaStack.isEmpty() && formulaStack.getItem() instanceof ItemCraftingFormula) {
             ItemCraftingFormula item = (ItemCraftingFormula) formulaStack.getItem();
             if (item.getInventory(formulaStack) == null) {
-                RecipeFormula formula = new RecipeFormula(world, inventory, 27);
+                RecipeFormula formula = new RecipeFormula(world, inventory, SLOT_CRAFT_MATRIX_FIRST);
                 if (formula.isValidFormula(world)) {
                     item.setInventory(formulaStack, formula.input);
                     markDirty();
@@ -442,16 +451,16 @@ public class TileEntityFormulaicAssemblicator extends TileEntityElectricBlock im
 
     @Override
     public boolean canExtractItem(int slotID, @Nonnull ItemStack itemstack, @Nonnull EnumFacing side) {
-        if (slotID == 1) {
+        if (slotID == SLOT_ENERGY) {
             return ChargeUtils.canBeOutputted(itemstack, false);
         }
-        return slotID >= 21 && slotID <= 26;
+        return slotID >= SLOT_OUTPUT_FIRST && slotID <= SLOT_OUTPUT_LAST;
 
     }
 
     @Override
     public boolean isItemValidForSlot(int slotID, @Nonnull ItemStack itemstack) {
-        if (slotID >= 3 && slotID <= 20) {
+        if (slotID >= SLOT_INPUT_FIRST && slotID <= SLOT_INPUT_LAST) {
             if (formula == null) {
                 return true;
             }
@@ -459,7 +468,7 @@ public class TileEntityFormulaicAssemblicator extends TileEntityElectricBlock im
             if (indices.size() > 0) {
                 if (stockControl) {
                     int filled = 0;
-                    for (int i = 3; i < 20; i++) {
+                    for (int i = SLOT_INPUT_FIRST; i < SLOT_INPUT_LAST; i++) {
                         ItemStack slotStack = inventory.get(i);
                         if (!slotStack.isEmpty()) {
                             if (formula.isIngredientInPos(world, slotStack, indices.get(0))) {
@@ -471,7 +480,7 @@ public class TileEntityFormulaicAssemblicator extends TileEntityElectricBlock im
                 }
                 return true;
             }
-        } else if (slotID == 1) {
+        } else if (slotID == SLOT_ENERGY) {
             return ChargeUtils.canBeDischarged(itemstack);
         }
         return false;

--- a/src/main/java/mekanism/common/tile/TileEntityFormulaicAssemblicator.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFormulaicAssemblicator.java
@@ -110,6 +110,15 @@ public class TileEntityFormulaicAssemblicator extends TileEntityElectricBlock im
     }
 
     @Override
+    public void onLoad() {
+        super.onLoad();
+        if (!world.isRemote) {
+            checkFormula();
+            recalculateRecipe();
+        }
+    }
+
+    @Override
     public void onUpdate() {
         super.onUpdate();
         if (!world.isRemote) {
@@ -123,20 +132,7 @@ public class TileEntityFormulaicAssemblicator extends TileEntityElectricBlock im
             } else if (MekanismUtils.canFunction(this)) {
                 pulseOperations++;
             }
-            RecipeFormula prev = formula;
-            ItemStack formulaStack = inventory.get(SLOT_FORMULA);
-            if (!formulaStack.isEmpty() && formulaStack.getItem() instanceof ItemCraftingFormula) {
-                if (formula == null || lastFormulaStack != formulaStack) {
-                    loadFormula();
-                }
-            } else {
-                formula = null;
-            }
-            if (prev != formula) {
-                needsFormulaUpdate = true;
-            }
-
-            lastFormulaStack = formulaStack;
+            checkFormula();
             if (autoMode && formula == null) {
                 toggleAutoMode();
             }
@@ -167,6 +163,23 @@ public class TileEntityFormulaicAssemblicator extends TileEntityElectricBlock im
                 operatingTicks = 0;
             }
         }
+    }
+
+    private void checkFormula() {
+        RecipeFormula prev = formula;
+        ItemStack formulaStack = inventory.get(SLOT_FORMULA);
+        if (!formulaStack.isEmpty() && formulaStack.getItem() instanceof ItemCraftingFormula) {
+            if (formula == null || lastFormulaStack != formulaStack) {
+                loadFormula();
+            }
+        } else {
+            formula = null;
+        }
+        if (prev != formula) {
+            needsFormulaUpdate = true;
+        }
+
+        lastFormulaStack = formulaStack;
     }
 
     public void loadFormula() {

--- a/src/main/java/mekanism/common/util/MekanismUtils.java
+++ b/src/main/java/mekanism/common/util/MekanismUtils.java
@@ -899,14 +899,14 @@ public final class MekanismUtils {
     }
 
     /**
-     * Finds the output of a defined InventoryCrafting grid.
+     * Finds the output of a brute forced repairing action
      *
      * @param inv   - InventoryCrafting to check
      * @param world - world reference
      *
      * @return output ItemStack
      */
-    public static ItemStack findMatchingRecipe(InventoryCrafting inv, World world) {
+    public static ItemStack findRepairRecipe(InventoryCrafting inv, World world) {
         NonNullList<ItemStack> dmgItems = NonNullList.withSize(2, ItemStack.EMPTY);
         for (int i = 0; i < inv.getSizeInventory(); i++) {
             if (!inv.getStackInSlot(i).isEmpty()) {
@@ -932,8 +932,7 @@ public final class MekanismUtils {
             int solve = Math.max(0, theItem.getMaxDamage() - value);
             return new ItemStack(dmgItems.get(0).getItem(), 1, solve);
         }
-        IRecipe potentialResult = CraftingManager.findMatchingRecipe(inv, world);
-        return potentialResult != null ? potentialResult.getRecipeOutput() : ItemStack.EMPTY;
+        return ItemStack.EMPTY;
     }
 
     /**


### PR DESCRIPTION
## Changes proposed in this pull request:
- Fixes the assemblicator to use `IRecpie.getRemainingItems` instead of only handling containers (see #5413)
- Changes the weird MekanismUtils method to just be used in the assemblicator for repair recipes
- Caches the IRecipe used when not using a formula (yay performance)

## To-Do
- [x] Check formula's NBT sensitivity in the above situation - using the vanilla test script from #5413 it shows the sword as red once it's been damaged
- [x] bug: if you have say a stack of 2 in the recipe grid on loading the world and opening the gui until the gui is refreshed it will show an x and the craft buttons will be grayed out.
- [ ] decide what to do with remaining items - output or input slots? configurable?
- [ ] Test, test, test (on face value the issue is solved)