### PR TITLE
IFluidHandlerWrapper implementation cleanup

### DIFF
--- a/src/main/java/mekanism/common/base/FluidHandlerWrapper.java
+++ b/src/main/java/mekanism/common/base/FluidHandlerWrapper.java
@@ -33,7 +33,7 @@ public class FluidHandlerWrapper implements IFluidHandler {
 
     @Override
     public int fill(FluidStack resource, boolean doFill) {
-        if (side == null) {
+        if (side == null || resource == null) {
             return 0;
         }
         if (wrapper.canFill(side, resource)) {
@@ -44,7 +44,7 @@ public class FluidHandlerWrapper implements IFluidHandler {
 
     @Override
     public FluidStack drain(FluidStack resource, boolean doDrain) {
-        if (side == null) {
+        if (side == null || resource == null) {
             return null;
         }
         if (wrapper.canDrain(side, resource)) {

--- a/src/main/java/mekanism/common/base/IFluidHandlerWrapper.java
+++ b/src/main/java/mekanism/common/base/IFluidHandlerWrapper.java
@@ -1,5 +1,6 @@
 package mekanism.common.base;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import net.minecraft.util.EnumFacing;
 import net.minecraftforge.fluids.FluidStack;
@@ -7,14 +8,29 @@ import net.minecraftforge.fluids.FluidTankInfo;
 
 public interface IFluidHandlerWrapper {
 
-    int fill(EnumFacing from, @Nullable FluidStack resource, boolean doFill);
+    //TODO: Contracts and stuff
 
-    FluidStack drain(EnumFacing from, @Nullable FluidStack resource, boolean doDrain);
+    /**
+     * It is assumed that canFill is checked before calling this method
+     */
+    int fill(EnumFacing from, @Nonnull FluidStack resource, boolean doFill);
 
+    /**
+     * It is assumed that canDrain is checked before calling this method
+     */
+    FluidStack drain(EnumFacing from, @Nonnull FluidStack resource, boolean doDrain);
+
+    /**
+     * It is assumed that canDrain (with a null fluidstack) is checked before calling this method
+     */
     FluidStack drain(EnumFacing from, int maxDrain, boolean doDrain);
 
-    boolean canFill(EnumFacing from, @Nullable FluidStack fluid);
+    //TODO: Go through and ensure this is checked against being null before this gets called
+    boolean canFill(EnumFacing from, @Nonnull FluidStack fluid);
 
+    /**
+     * null fluid needs to have amounts end up getting specified for draining rather than using the drain with a null stack
+     */
     boolean canDrain(EnumFacing from, @Nullable FluidStack fluid);
 
     FluidTankInfo[] getTankInfo(EnumFacing from);

--- a/src/main/java/mekanism/common/base/IFluidHandlerWrapper.java
+++ b/src/main/java/mekanism/common/base/IFluidHandlerWrapper.java
@@ -8,8 +8,6 @@ import net.minecraftforge.fluids.FluidTankInfo;
 
 public interface IFluidHandlerWrapper {
 
-    //TODO: Contracts and stuff
-
     /**
      * It is assumed that canFill is checked before calling this method
      */
@@ -33,7 +31,6 @@ public interface IFluidHandlerWrapper {
         return null;
     }
 
-    //TODO: Go through and ensure this is checked against being null before this gets called
     default boolean canFill(EnumFacing from, @Nonnull FluidStack fluid) {
         return false;
     }

--- a/src/main/java/mekanism/common/base/IFluidHandlerWrapper.java
+++ b/src/main/java/mekanism/common/base/IFluidHandlerWrapper.java
@@ -13,25 +13,37 @@ public interface IFluidHandlerWrapper {
     /**
      * It is assumed that canFill is checked before calling this method
      */
-    int fill(EnumFacing from, @Nonnull FluidStack resource, boolean doFill);
+    default int fill(EnumFacing from, @Nonnull FluidStack resource, boolean doFill) {
+        return 0;
+    }
 
     /**
      * It is assumed that canDrain is checked before calling this method
      */
-    FluidStack drain(EnumFacing from, @Nonnull FluidStack resource, boolean doDrain);
+    @Nullable
+    default FluidStack drain(EnumFacing from, @Nonnull FluidStack resource, boolean doDrain) {
+        return drain(from, resource.amount, doDrain);
+    }
 
     /**
-     * It is assumed that canDrain (with a null fluidstack) is checked before calling this method
+     * It is assumed that canDrain is checked before calling this method
      */
-    FluidStack drain(EnumFacing from, int maxDrain, boolean doDrain);
+    @Nullable
+    default FluidStack drain(EnumFacing from, int maxDrain, boolean doDrain) {
+        return null;
+    }
 
     //TODO: Go through and ensure this is checked against being null before this gets called
-    boolean canFill(EnumFacing from, @Nonnull FluidStack fluid);
+    default boolean canFill(EnumFacing from, @Nonnull FluidStack fluid) {
+        return false;
+    }
 
     /**
      * null fluid needs to have amounts end up getting specified for draining rather than using the drain with a null stack
      */
-    boolean canDrain(EnumFacing from, @Nullable FluidStack fluid);
+    default boolean canDrain(EnumFacing from, @Nullable FluidStack fluid) {
+        return false;
+    }
 
     FluidTankInfo[] getTankInfo(EnumFacing from);
 

--- a/src/main/java/mekanism/common/content/entangloporter/InventoryFrequency.java
+++ b/src/main/java/mekanism/common/content/entangloporter/InventoryFrequency.java
@@ -3,19 +3,16 @@ package mekanism.common.content.entangloporter;
 import io.netty.buffer.ByteBuf;
 import java.util.UUID;
 import mekanism.api.TileNetworkList;
-import mekanism.api.gas.GasStack;
 import mekanism.api.gas.GasTank;
-import mekanism.common.PacketHandler;
 import mekanism.common.frequency.Frequency;
 import mekanism.common.tier.FluidTankTier;
 import mekanism.common.tier.GasTankTier;
+import mekanism.common.util.TileUtils;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.util.NonNullList;
 import net.minecraftforge.common.util.Constants.NBT;
-import net.minecraftforge.fluids.FluidRegistry;
-import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTank;
 
 public class InventoryFrequency extends Frequency {
@@ -95,20 +92,8 @@ public class InventoryFrequency extends Frequency {
     public void write(TileNetworkList data) {
         super.write(data);
         data.add(storedEnergy);
-        if (storedFluid.getFluid() != null) {
-            data.add(true);
-            data.add(FluidRegistry.getFluidName(storedFluid.getFluid()));
-            data.add(storedFluid.getFluidAmount());
-        } else {
-            data.add(false);
-        }
-        if (storedGas.getGas() != null) {
-            data.add(true);
-            data.add(storedGas.getGasType().getID());
-            data.add(storedGas.getStored());
-        } else {
-            data.add(false);
-        }
+        TileUtils.addTankData(data, storedFluid);
+        TileUtils.addTankData(data, storedGas);
         data.add(temperature);
     }
 
@@ -118,16 +103,8 @@ public class InventoryFrequency extends Frequency {
         storedFluid = new FluidTank(FluidTankTier.ULTIMATE.getOutput());
         storedGas = new GasTank(GasTankTier.ULTIMATE.getOutput());
         storedEnergy = dataStream.readDouble();
-        if (dataStream.readBoolean()) {
-            storedFluid.setFluid(new FluidStack(FluidRegistry.getFluid(PacketHandler.readString(dataStream)), dataStream.readInt()));
-        } else {
-            storedFluid.setFluid(null);
-        }
-        if (dataStream.readBoolean()) {
-            storedGas.setGas(new GasStack(dataStream.readInt(), dataStream.readInt()));
-        } else {
-            storedGas.setGas(null);
-        }
+        TileUtils.readTankData(dataStream, storedFluid);
+        TileUtils.readTankData(dataStream, storedGas);
         temperature = dataStream.readDouble();
     }
 }

--- a/src/main/java/mekanism/common/tile/TileEntityBoilerValve.java
+++ b/src/main/java/mekanism/common/tile/TileEntityBoilerValve.java
@@ -11,6 +11,7 @@ import mekanism.common.content.boiler.BoilerTank;
 import mekanism.common.content.boiler.BoilerWaterTank;
 import mekanism.common.integration.computer.IComputerIntegration;
 import mekanism.common.util.CapabilityUtils;
+import mekanism.common.util.FluidContainerUtils;
 import mekanism.common.util.MekanismUtils;
 import mekanism.common.util.PipeUtils;
 import net.minecraft.tileentity.TileEntity;
@@ -80,35 +81,22 @@ public class TileEntityBoilerValve extends TileEntityBoilerCasing implements IFl
     }
 
     @Override
-    public int fill(EnumFacing from, @Nullable FluidStack resource, boolean doFill) {
-        if (structure != null && structure.upperRenderLocation != null && getPos().getY() < structure.upperRenderLocation.y - 1) {
-            return waterTank.fill(resource, doFill);
-        }
-        return 0;
+    public int fill(EnumFacing from, @Nonnull FluidStack resource, boolean doFill) {
+        return waterTank.fill(resource, doFill);
     }
 
     @Override
-    public FluidStack drain(EnumFacing from, @Nullable FluidStack resource, boolean doDrain) {
-        if (structure != null && structure.upperRenderLocation != null && getPos().getY() >= structure.upperRenderLocation.y - 1) {
-            if (structure.steamStored != null) {
-                if (resource != null && resource.getFluid() == structure.steamStored.getFluid()) {
-                    return steamTank.drain(resource.amount, doDrain);
-                }
-            }
-        }
-        return null;
+    public FluidStack drain(EnumFacing from, @Nonnull FluidStack resource, boolean doDrain) {
+        return drain(from, resource.amount, doDrain);
     }
 
     @Override
     public FluidStack drain(EnumFacing from, int maxDrain, boolean doDrain) {
-        if (structure != null && structure.upperRenderLocation != null && getPos().getY() >= structure.upperRenderLocation.y - 1) {
-            return steamTank.drain(maxDrain, doDrain);
-        }
-        return null;
+        return steamTank.drain(maxDrain, doDrain);
     }
 
     @Override
-    public boolean canFill(EnumFacing from, @Nullable FluidStack fluid) {
+    public boolean canFill(EnumFacing from, @Nonnull FluidStack fluid) {
         if ((!world.isRemote && structure != null) || (world.isRemote && clientHasStructure)) {
             return structure.upperRenderLocation != null && getPos().getY() < structure.upperRenderLocation.y - 1;
         }
@@ -118,7 +106,7 @@ public class TileEntityBoilerValve extends TileEntityBoilerCasing implements IFl
     @Override
     public boolean canDrain(EnumFacing from, @Nullable FluidStack fluid) {
         if ((!world.isRemote && structure != null) || (world.isRemote && clientHasStructure)) {
-            return structure.upperRenderLocation != null && getPos().getY() >= structure.upperRenderLocation.y - 1;
+            return structure.upperRenderLocation != null && getPos().getY() >= structure.upperRenderLocation.y - 1 && FluidContainerUtils.canDrain(structure.steamStored, fluid);
         }
         return false;
     }

--- a/src/main/java/mekanism/common/tile/TileEntityBoilerValve.java
+++ b/src/main/java/mekanism/common/tile/TileEntityBoilerValve.java
@@ -17,6 +17,7 @@ import mekanism.common.util.MekanismUtils;
 import mekanism.common.util.PipeUtils;
 import net.minecraft.util.EnumFacing;
 import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTankInfo;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
@@ -92,7 +93,7 @@ public class TileEntityBoilerValve extends TileEntityBoilerCasing implements IFl
     @Override
     public boolean canFill(EnumFacing from, @Nonnull FluidStack fluid) {
         if ((!world.isRemote && structure != null) || (world.isRemote && clientHasStructure)) {
-            return structure.upperRenderLocation != null && getPos().getY() < structure.upperRenderLocation.y - 1;
+            return structure.upperRenderLocation != null && getPos().getY() < structure.upperRenderLocation.y - 1 && fluid.getFluid() == FluidRegistry.WATER;
         }
         return false;
     }

--- a/src/main/java/mekanism/common/tile/TileEntityBoilerValve.java
+++ b/src/main/java/mekanism/common/tile/TileEntityBoilerValve.java
@@ -86,11 +86,7 @@ public class TileEntityBoilerValve extends TileEntityBoilerCasing implements IFl
     }
 
     @Override
-    public FluidStack drain(EnumFacing from, @Nonnull FluidStack resource, boolean doDrain) {
-        return drain(from, resource.amount, doDrain);
-    }
-
-    @Override
+    @Nullable
     public FluidStack drain(EnumFacing from, int maxDrain, boolean doDrain) {
         return steamTank.drain(maxDrain, doDrain);
     }

--- a/src/main/java/mekanism/common/tile/TileEntityChemicalWasher.java
+++ b/src/main/java/mekanism/common/tile/TileEntityChemicalWasher.java
@@ -3,7 +3,6 @@ package mekanism.common.tile;
 import io.netty.buffer.ByteBuf;
 import java.util.List;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import mekanism.api.TileNetworkList;
 import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasStack;
@@ -289,23 +288,8 @@ public class TileEntityChemicalWasher extends TileEntityMachine implements IGasH
     }
 
     @Override
-    public FluidStack drain(EnumFacing from, @Nonnull FluidStack resource, boolean doDrain) {
-        return null;
-    }
-
-    @Override
-    public FluidStack drain(EnumFacing from, int maxDrain, boolean doDrain) {
-        return null;
-    }
-
-    @Override
     public boolean canFill(EnumFacing from, @Nonnull FluidStack fluid) {
         return from == EnumFacing.UP && fluid.getFluid().equals(FluidRegistry.WATER);
-    }
-
-    @Override
-    public boolean canDrain(EnumFacing from, @Nullable FluidStack fluid) {
-        return false;
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/TileEntityChemicalWasher.java
+++ b/src/main/java/mekanism/common/tile/TileEntityChemicalWasher.java
@@ -284,15 +284,12 @@ public class TileEntityChemicalWasher extends TileEntityMachine implements IGasH
     }
 
     @Override
-    public int fill(EnumFacing from, @Nullable FluidStack resource, boolean doFill) {
-        if (canFill(from, resource)) {
-            return fluidTank.fill(resource, doFill);
-        }
-        return 0;
+    public int fill(EnumFacing from, @Nonnull FluidStack resource, boolean doFill) {
+        return fluidTank.fill(resource, doFill);
     }
 
     @Override
-    public FluidStack drain(EnumFacing from, @Nullable FluidStack resource, boolean doDrain) {
+    public FluidStack drain(EnumFacing from, @Nonnull FluidStack resource, boolean doDrain) {
         return null;
     }
 
@@ -302,7 +299,7 @@ public class TileEntityChemicalWasher extends TileEntityMachine implements IGasH
     }
 
     @Override
-    public boolean canFill(EnumFacing from, @Nullable FluidStack fluid) {
+    public boolean canFill(EnumFacing from, @Nonnull FluidStack fluid) {
         return from == EnumFacing.UP && fluid.getFluid().equals(FluidRegistry.WATER);
     }
 

--- a/src/main/java/mekanism/common/tile/TileEntityDynamicValve.java
+++ b/src/main/java/mekanism/common/tile/TileEntityDynamicValve.java
@@ -52,36 +52,29 @@ public class TileEntityDynamicValve extends TileEntityDynamicTank implements IFl
     }
 
     @Override
-    public int fill(EnumFacing from, @Nullable FluidStack resource, boolean doFill) {
+    public int fill(EnumFacing from, @Nonnull FluidStack resource, boolean doFill) {
         return fluidTank.fill(resource, doFill);
     }
 
     @Override
-    public FluidStack drain(EnumFacing from, @Nullable FluidStack resource, boolean doDrain) {
-        if (structure != null && structure.fluidStored != null) {
-            if (resource != null && resource.getFluid() == structure.fluidStored.getFluid()) {
-                return fluidTank.drain(resource.amount, doDrain);
-            }
-        }
-        return null;
+    public FluidStack drain(EnumFacing from, @Nonnull FluidStack resource, boolean doDrain) {
+        return drain(from, resource.amount, doDrain);
     }
 
     @Override
     public FluidStack drain(EnumFacing from, int maxDrain, boolean doDrain) {
-        if (structure != null) {
-            return fluidTank.drain(maxDrain, doDrain);
-        }
-        return null;
+        return fluidTank.drain(maxDrain, doDrain);
     }
 
     @Override
-    public boolean canFill(EnumFacing from, @Nullable FluidStack fluid) {
+    public boolean canFill(EnumFacing from, @Nonnull FluidStack fluid) {
         return (!world.isRemote && structure != null) || (world.isRemote && clientHasStructure);
     }
 
     @Override
     public boolean canDrain(EnumFacing from, @Nullable FluidStack fluid) {
-        return (!world.isRemote && structure != null) || (world.isRemote && clientHasStructure);
+        return ((!world.isRemote && structure != null) || (world.isRemote && clientHasStructure)) &&
+               FluidContainerUtils.canDrain(structure.fluidStored, fluid);
     }
 
     @Nonnull

--- a/src/main/java/mekanism/common/tile/TileEntityDynamicValve.java
+++ b/src/main/java/mekanism/common/tile/TileEntityDynamicValve.java
@@ -57,11 +57,7 @@ public class TileEntityDynamicValve extends TileEntityDynamicTank implements IFl
     }
 
     @Override
-    public FluidStack drain(EnumFacing from, @Nonnull FluidStack resource, boolean doDrain) {
-        return drain(from, resource.amount, doDrain);
-    }
-
-    @Override
+    @Nullable
     public FluidStack drain(EnumFacing from, int maxDrain, boolean doDrain) {
         return fluidTank.drain(maxDrain, doDrain);
     }
@@ -73,8 +69,7 @@ public class TileEntityDynamicValve extends TileEntityDynamicTank implements IFl
 
     @Override
     public boolean canDrain(EnumFacing from, @Nullable FluidStack fluid) {
-        return ((!world.isRemote && structure != null) || (world.isRemote && clientHasStructure)) &&
-               FluidContainerUtils.canDrain(structure.fluidStored, fluid);
+        return ((!world.isRemote && structure != null) || (world.isRemote && clientHasStructure)) && FluidContainerUtils.canDrain(structure.fluidStored, fluid);
     }
 
     @Nonnull

--- a/src/main/java/mekanism/common/tile/TileEntityElectricPump.java
+++ b/src/main/java/mekanism/common/tile/TileEntityElectricPump.java
@@ -372,34 +372,28 @@ public class TileEntityElectricPump extends TileEntityElectricBlock implements I
     }
 
     @Override
-    public FluidStack drain(EnumFacing from, @Nullable FluidStack resource, boolean doDrain) {
-        if (resource != null && fluidTank.getFluid() != null && fluidTank.getFluid().getFluid() == resource.getFluid() && from == EnumFacing.byIndex(1)) {
-            return drain(from, resource.amount, doDrain);
-        }
-        return null;
+    public FluidStack drain(EnumFacing from, @Nonnull FluidStack resource, boolean doDrain) {
+        return drain(from, resource.amount, doDrain);
     }
 
     @Override
-    public int fill(EnumFacing from, @Nullable FluidStack resource, boolean doFill) {
+    public int fill(EnumFacing from, @Nonnull FluidStack resource, boolean doFill) {
         return 0;
     }
 
     @Override
     public FluidStack drain(EnumFacing from, int maxDrain, boolean doDrain) {
-        if (from == EnumFacing.byIndex(1)) {
-            return fluidTank.drain(maxDrain, doDrain);
-        }
-        return null;
+        return fluidTank.drain(maxDrain, doDrain);
     }
 
     @Override
-    public boolean canFill(EnumFacing from, @Nullable FluidStack fluid) {
+    public boolean canFill(EnumFacing from, @Nonnull FluidStack fluid) {
         return false;
     }
 
     @Override
     public boolean canDrain(EnumFacing from, @Nullable FluidStack fluid) {
-        return from == EnumFacing.byIndex(1);
+        return from == EnumFacing.byIndex(1) && FluidContainerUtils.canDrain(fluidTank.getFluid(), fluid);
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/TileEntityElectricPump.java
+++ b/src/main/java/mekanism/common/tile/TileEntityElectricPump.java
@@ -372,23 +372,9 @@ public class TileEntityElectricPump extends TileEntityElectricBlock implements I
     }
 
     @Override
-    public FluidStack drain(EnumFacing from, @Nonnull FluidStack resource, boolean doDrain) {
-        return drain(from, resource.amount, doDrain);
-    }
-
-    @Override
-    public int fill(EnumFacing from, @Nonnull FluidStack resource, boolean doFill) {
-        return 0;
-    }
-
-    @Override
+    @Nullable
     public FluidStack drain(EnumFacing from, int maxDrain, boolean doDrain) {
         return fluidTank.drain(maxDrain, doDrain);
-    }
-
-    @Override
-    public boolean canFill(EnumFacing from, @Nonnull FluidStack fluid) {
-        return false;
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/TileEntityElectrolyticSeparator.java
+++ b/src/main/java/mekanism/common/tile/TileEntityElectrolyticSeparator.java
@@ -365,13 +365,13 @@ public class TileEntityElectrolyticSeparator extends TileEntityMachine implement
     }
 
     @Override
-    public FluidStack drain(EnumFacing from, @Nullable FluidStack resource, boolean doDrain) {
+    public FluidStack drain(EnumFacing from, @Nonnull FluidStack resource, boolean doDrain) {
         return null;
     }
 
     @Override
-    public boolean canFill(EnumFacing from, @Nullable FluidStack fluid) {
-        return fluid != null && Recipe.ELECTROLYTIC_SEPARATOR.containsRecipe(fluid.getFluid());
+    public boolean canFill(EnumFacing from, @Nonnull FluidStack fluid) {
+        return Recipe.ELECTROLYTIC_SEPARATOR.containsRecipe(fluid.getFluid());
     }
 
     @Override
@@ -380,11 +380,8 @@ public class TileEntityElectrolyticSeparator extends TileEntityMachine implement
     }
 
     @Override
-    public int fill(EnumFacing from, @Nullable FluidStack resource, boolean doFill) {
-        if (resource != null && Recipe.ELECTROLYTIC_SEPARATOR.containsRecipe(resource.getFluid())) {
-            return fluidTank.fill(resource, doFill);
-        }
-        return 0;
+    public int fill(EnumFacing from, @Nonnull FluidStack resource, boolean doFill) {
+        return fluidTank.fill(resource, doFill);
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/TileEntityElectrolyticSeparator.java
+++ b/src/main/java/mekanism/common/tile/TileEntityElectrolyticSeparator.java
@@ -4,7 +4,6 @@ import io.netty.buffer.ByteBuf;
 import java.util.EnumSet;
 import java.util.List;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import mekanism.api.TileNetworkList;
 import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasStack;
@@ -365,28 +364,13 @@ public class TileEntityElectrolyticSeparator extends TileEntityMachine implement
     }
 
     @Override
-    public FluidStack drain(EnumFacing from, @Nonnull FluidStack resource, boolean doDrain) {
-        return null;
-    }
-
-    @Override
     public boolean canFill(EnumFacing from, @Nonnull FluidStack fluid) {
         return Recipe.ELECTROLYTIC_SEPARATOR.containsRecipe(fluid.getFluid());
     }
 
     @Override
-    public boolean canDrain(EnumFacing from, @Nullable FluidStack fluid) {
-        return false;
-    }
-
-    @Override
     public int fill(EnumFacing from, @Nonnull FluidStack resource, boolean doFill) {
         return fluidTank.fill(resource, doFill);
-    }
-
-    @Override
-    public FluidStack drain(EnumFacing from, int maxDrain, boolean doDrain) {
-        return null;
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/TileEntityFluidTank.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFluidTank.java
@@ -395,22 +395,18 @@ public class TileEntityFluidTank extends TileEntityContainerBlock implements IAc
         if (tier == FluidTankTier.CREATIVE) {
             return resource.amount;
         }
-        if (canFill(from, resource)) {
-            int filled = fluidTank.fill(resource, doFill);
-            if (filled < resource.amount && !isActive) {
-                filled += pushUp(PipeUtils.copy(resource, resource.amount - filled), doFill);
-            }
-            if (filled > 0 && from == EnumFacing.UP) {
-                if (valve == 0) {
-                    needsPacket = true;
-                }
-                valve = 20;
-                valveFluid = new FluidStack(resource, 1);
-            }
-            return filled;
+        int filled = fluidTank.fill(resource, doFill);
+        if (filled < resource.amount && !isActive) {
+            filled += pushUp(PipeUtils.copy(resource, resource.amount - filled), doFill);
         }
-
-        return 0;
+        if (filled > 0 && from == EnumFacing.UP) {
+            if (valve == 0) {
+                needsPacket = true;
+            }
+            valve = 20;
+            valveFluid = new FluidStack(resource, 1);
+        }
+        return filled;
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/TileEntityFluidTank.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFluidTank.java
@@ -414,11 +414,7 @@ public class TileEntityFluidTank extends TileEntityContainerBlock implements IAc
     }
 
     @Override
-    public FluidStack drain(EnumFacing from, @Nonnull FluidStack resource, boolean doDrain) {
-        return drain(from, resource.amount, doDrain);
-    }
-
-    @Override
+    @Nullable
     public FluidStack drain(EnumFacing from, int maxDrain, boolean doDrain) {
         return fluidTank.drain(maxDrain, tier != FluidTankTier.CREATIVE && doDrain);
     }

--- a/src/main/java/mekanism/common/tile/TileEntityFluidTank.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFluidTank.java
@@ -418,28 +418,21 @@ public class TileEntityFluidTank extends TileEntityContainerBlock implements IAc
     @Override
     public boolean canFill(EnumFacing from, @Nonnull FluidStack fluid) {
         TileEntity tile = MekanismUtils.getTileEntity(world, getPos().offset(EnumFacing.DOWN));
-        if (from == EnumFacing.DOWN) {
-            if (isActive && !(tile instanceof TileEntityFluidTank)) {
-                return false;
-            }
+        if (from == EnumFacing.DOWN && isActive && !(tile instanceof TileEntityFluidTank)) {
+            return false;
         }
         if (tier == FluidTankTier.CREATIVE) {
             return true;
         }
-
         if (isActive && tile instanceof TileEntityFluidTank) { // Only fill if tanks underneath have same fluid.
-            return (fluidTank.getFluid() == null && ((TileEntityFluidTank) tile).canFill(EnumFacing.UP, fluid)) ||
-                   (fluidTank.getFluid() != null && fluidTank.getFluid().isFluidEqual(fluid));
+            return fluidTank.getFluid() == null ? ((TileEntityFluidTank) tile).canFill(EnumFacing.UP, fluid) : fluidTank.getFluid().isFluidEqual(fluid);
         }
         return FluidContainerUtils.canFill(fluidTank.getFluid(), fluid);
     }
 
     @Override
     public boolean canDrain(EnumFacing from, @Nullable FluidStack fluid) {
-        if (fluidTank != null && FluidContainerUtils.canDrain(fluidTank.getFluid(), fluid)) {
-            return !(isActive && from == EnumFacing.DOWN);
-        }
-        return false;
+        return fluidTank != null && FluidContainerUtils.canDrain(fluidTank.getFluid(), fluid) && !isActive || from != EnumFacing.DOWN;
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/TileEntityFluidTank.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFluidTank.java
@@ -391,11 +391,11 @@ public class TileEntityFluidTank extends TileEntityContainerBlock implements IAc
     }
 
     @Override
-    public int fill(EnumFacing from, @Nullable FluidStack resource, boolean doFill) {
+    public int fill(EnumFacing from, @Nonnull FluidStack resource, boolean doFill) {
         if (tier == FluidTankTier.CREATIVE) {
-            return resource != null ? resource.amount : 0;
+            return resource.amount;
         }
-        if (resource != null && canFill(from, resource)) {
+        if (canFill(from, resource)) {
             int filled = fluidTank.fill(resource, doFill);
             if (filled < resource.amount && !isActive) {
                 filled += pushUp(PipeUtils.copy(resource, resource.amount - filled), doFill);
@@ -414,23 +414,17 @@ public class TileEntityFluidTank extends TileEntityContainerBlock implements IAc
     }
 
     @Override
-    public FluidStack drain(EnumFacing from, @Nullable FluidStack resource, boolean doDrain) {
-        if (resource != null && canDrain(from, resource)) {
-            return fluidTank.drain(resource.amount, tier != FluidTankTier.CREATIVE && doDrain);
-        }
-        return null;
+    public FluidStack drain(EnumFacing from, @Nonnull FluidStack resource, boolean doDrain) {
+        return drain(from, resource.amount, doDrain);
     }
 
     @Override
     public FluidStack drain(EnumFacing from, int maxDrain, boolean doDrain) {
-        if (canDrain(from, null)) {
-            return fluidTank.drain(maxDrain, tier != FluidTankTier.CREATIVE && doDrain);
-        }
-        return null;
+        return fluidTank.drain(maxDrain, tier != FluidTankTier.CREATIVE && doDrain);
     }
 
     @Override
-    public boolean canFill(EnumFacing from, @Nullable FluidStack fluid) {
+    public boolean canFill(EnumFacing from, @Nonnull FluidStack fluid) {
         TileEntity tile = MekanismUtils.getTileEntity(world, getPos().offset(EnumFacing.DOWN));
         if (from == EnumFacing.DOWN) {
             if (isActive && !(tile instanceof TileEntityFluidTank)) {
@@ -445,15 +439,13 @@ public class TileEntityFluidTank extends TileEntityContainerBlock implements IAc
             return (fluidTank.getFluid() == null && ((TileEntityFluidTank) tile).canFill(EnumFacing.UP, fluid)) ||
                    (fluidTank.getFluid() != null && fluidTank.getFluid().isFluidEqual(fluid));
         }
-        return fluidTank.getFluid() == null || fluidTank.getFluid().isFluidEqual(fluid);
+        return FluidContainerUtils.canFill(fluidTank.getFluid(), fluid);
     }
 
     @Override
     public boolean canDrain(EnumFacing from, @Nullable FluidStack fluid) {
-        if (fluidTank != null) {
-            if (fluid == null || fluidTank.getFluid() != null && fluidTank.getFluid().isFluidEqual(fluid)) {
-                return !(isActive && from == EnumFacing.DOWN);
-            }
+        if (fluidTank != null && FluidContainerUtils.canDrain(fluidTank.getFluid(), fluid)) {
+            return !(isActive && from == EnumFacing.DOWN);
         }
         return false;
     }

--- a/src/main/java/mekanism/common/tile/TileEntityFluidicPlenisher.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFluidicPlenisher.java
@@ -337,19 +337,13 @@ public class TileEntityFluidicPlenisher extends TileEntityElectricBlock implemen
     }
 
     @Override
-    public FluidStack drain(EnumFacing from, @Nullable FluidStack resource, boolean doDrain) {
-        if (resource != null && fluidTank.getFluid() != null && fluidTank.getFluid().getFluid() == resource.getFluid() && from == EnumFacing.UP) {
-            return drain(from, resource.amount, doDrain);
-        }
+    public FluidStack drain(EnumFacing from, @Nonnull FluidStack resource, boolean doDrain) {
         return null;
     }
 
     @Override
-    public int fill(EnumFacing from, @Nullable FluidStack resource, boolean doFill) {
-        if (from == EnumFacing.UP && resource != null && resource.getFluid().canBePlacedInWorld()) {
-            return fluidTank.fill(resource, true);
-        }
-        return 0;
+    public int fill(EnumFacing from, @Nonnull FluidStack resource, boolean doFill) {
+        return fluidTank.fill(resource, true);
     }
 
     @Override
@@ -358,8 +352,8 @@ public class TileEntityFluidicPlenisher extends TileEntityElectricBlock implemen
     }
 
     @Override
-    public boolean canFill(EnumFacing from, @Nullable FluidStack fluid) {
-        return from == EnumFacing.UP && fluid != null && fluid.getFluid().canBePlacedInWorld();
+    public boolean canFill(EnumFacing from, @Nonnull FluidStack fluid) {
+        return from == EnumFacing.UP && fluid.getFluid().canBePlacedInWorld();
     }
 
     @Override
@@ -372,9 +366,7 @@ public class TileEntityFluidicPlenisher extends TileEntityElectricBlock implemen
         activeNodes.clear();
         usedNodes.clear();
         finishedCalc = false;
-        player.sendMessage(new TextComponentString(EnumColor.DARK_BLUE + Mekanism.LOG_TAG + " " + EnumColor.GREY +
-                                                   LangUtils.localize("tooltip.configurator.plenisherReset")));
-
+        player.sendMessage(new TextComponentString(EnumColor.DARK_BLUE + Mekanism.LOG_TAG + " " + EnumColor.GREY + LangUtils.localize("tooltip.configurator.plenisherReset")));
         return EnumActionResult.SUCCESS;
     }
 

--- a/src/main/java/mekanism/common/tile/TileEntityFluidicPlenisher.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFluidicPlenisher.java
@@ -6,7 +6,6 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
 import mekanism.api.IConfigurable;
@@ -337,28 +336,13 @@ public class TileEntityFluidicPlenisher extends TileEntityElectricBlock implemen
     }
 
     @Override
-    public FluidStack drain(EnumFacing from, @Nonnull FluidStack resource, boolean doDrain) {
-        return null;
-    }
-
-    @Override
     public int fill(EnumFacing from, @Nonnull FluidStack resource, boolean doFill) {
         return fluidTank.fill(resource, true);
     }
 
     @Override
-    public FluidStack drain(EnumFacing from, int maxDrain, boolean doDrain) {
-        return null;
-    }
-
-    @Override
     public boolean canFill(EnumFacing from, @Nonnull FluidStack fluid) {
         return from == EnumFacing.UP && fluid.getFluid().canBePlacedInWorld();
-    }
-
-    @Override
-    public boolean canDrain(EnumFacing from, @Nullable FluidStack fluid) {
-        return false;
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/TileEntityPRC.java
+++ b/src/main/java/mekanism/common/tile/TileEntityPRC.java
@@ -3,7 +3,6 @@ package mekanism.common.tile;
 import io.netty.buffer.ByteBuf;
 import java.util.Map;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import mekanism.api.EnumColor;
 import mekanism.api.TileNetworkList;
 import mekanism.api.gas.Gas;
@@ -254,26 +253,11 @@ public class TileEntityPRC extends TileEntityBasicMachine<PressurizedInput, Pres
     }
 
     @Override
-    public FluidStack drain(EnumFacing from, @Nonnull FluidStack resource, boolean doDrain) {
-        return null;
-    }
-
-    @Override
-    public FluidStack drain(EnumFacing from, int maxDrain, boolean doDrain) {
-        return null;
-    }
-
-    @Override
     public boolean canFill(EnumFacing from, @Nonnull FluidStack fluid) {
         SideData data = configComponent.getOutput(TransmissionType.FLUID, from, facing);
         if (data.hasSlot(0)) {
             return FluidContainerUtils.canFill(inputFluidTank.getFluid(), fluid);
         }
-        return false;
-    }
-
-    @Override
-    public boolean canDrain(EnumFacing from, @Nullable FluidStack fluid) {
         return false;
     }
 

--- a/src/main/java/mekanism/common/tile/TileEntityPRC.java
+++ b/src/main/java/mekanism/common/tile/TileEntityPRC.java
@@ -30,6 +30,7 @@ import mekanism.common.tile.component.TileComponentConfig;
 import mekanism.common.tile.component.TileComponentEjector;
 import mekanism.common.tile.prefab.TileEntityBasicMachine;
 import mekanism.common.util.ChargeUtils;
+import mekanism.common.util.FluidContainerUtils;
 import mekanism.common.util.InventoryUtils;
 import mekanism.common.util.ItemDataUtils;
 import mekanism.common.util.LangUtils;
@@ -248,15 +249,12 @@ public class TileEntityPRC extends TileEntityBasicMachine<PressurizedInput, Pres
     }
 
     @Override
-    public int fill(EnumFacing from, @Nullable FluidStack resource, boolean doFill) {
-        if (canFill(from, resource)) {
-            return inputFluidTank.fill(resource, doFill);
-        }
-        return 0;
+    public int fill(EnumFacing from, @Nonnull FluidStack resource, boolean doFill) {
+        return inputFluidTank.fill(resource, doFill);
     }
 
     @Override
-    public FluidStack drain(EnumFacing from, @Nullable FluidStack resource, boolean doDrain) {
+    public FluidStack drain(EnumFacing from, @Nonnull FluidStack resource, boolean doDrain) {
         return null;
     }
 
@@ -266,10 +264,10 @@ public class TileEntityPRC extends TileEntityBasicMachine<PressurizedInput, Pres
     }
 
     @Override
-    public boolean canFill(EnumFacing from, @Nullable FluidStack fluid) {
+    public boolean canFill(EnumFacing from, @Nonnull FluidStack fluid) {
         SideData data = configComponent.getOutput(TransmissionType.FLUID, from, facing);
         if (data.hasSlot(0)) {
-            return inputFluidTank.getFluid() == null || inputFluidTank.getFluid().isFluidEqual(fluid);
+            return FluidContainerUtils.canFill(inputFluidTank.getFluid(), fluid);
         }
         return false;
     }

--- a/src/main/java/mekanism/common/tile/TileEntityQuantumEntangloporter.java
+++ b/src/main/java/mekanism/common/tile/TileEntityQuantumEntangloporter.java
@@ -369,11 +369,7 @@ public class TileEntityQuantumEntangloporter extends TileEntityElectricBlock imp
     }
 
     @Override
-    public FluidStack drain(EnumFacing from, @Nonnull FluidStack resource, boolean doDrain) {
-        return drain(from, resource.amount, doDrain);
-    }
-
-    @Override
+    @Nullable
     public FluidStack drain(EnumFacing from, int maxDrain, boolean doDrain) {
         return frequency.storedFluid.drain(maxDrain, doDrain);
     }

--- a/src/main/java/mekanism/common/tile/TileEntityRotaryCondensentrator.java
+++ b/src/main/java/mekanism/common/tile/TileEntityRotaryCondensentrator.java
@@ -37,6 +37,7 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.NonNullList;
 import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTank;
 import net.minecraftforge.fluids.FluidTankInfo;
@@ -146,9 +147,12 @@ public class TileEntityRotaryCondensentrator extends TileEntityMachine implement
 
     }
 
-    public boolean isValidFluid(FluidStack f) {
-        return f != null && GasRegistry.getGas(f.getFluid()) != null;
+    public boolean isValidFluid(@Nonnull Fluid f) {
+        return GasRegistry.getGas(f) != null;
+    }
 
+    public boolean isValidFluid(FluidStack f) {
+        return f != null && isValidFluid(f.getFluid());
     }
 
     @Override
@@ -289,7 +293,7 @@ public class TileEntityRotaryCondensentrator extends TileEntityMachine implement
 
     @Override
     public boolean canFill(EnumFacing from, @Nonnull FluidStack fluid) {
-        return mode == 1 && from == MekanismUtils.getRight(facing) && (fluidTank.getFluid() == null ? isValidFluid(new FluidStack(fluid, 1)) : fluidTank.getFluid().isFluidEqual(fluid));
+        return mode == 1 && from == MekanismUtils.getRight(facing) && (fluidTank.getFluid() == null ? isValidFluid(fluid) : fluidTank.getFluid().isFluidEqual(fluid));
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/TileEntityRotaryCondensentrator.java
+++ b/src/main/java/mekanism/common/tile/TileEntityRotaryCondensentrator.java
@@ -278,18 +278,11 @@ public class TileEntityRotaryCondensentrator extends TileEntityMachine implement
 
     @Override
     public int fill(EnumFacing from, @Nonnull FluidStack resource, boolean doFill) {
-        if (canFill(from, resource)) {
-            return fluidTank.fill(resource, doFill);
-        }
-        return 0;
+        return fluidTank.fill(resource, doFill);
     }
 
     @Override
-    public FluidStack drain(EnumFacing from, @Nonnull FluidStack resource, boolean doDrain) {
-        return drain(from, resource.amount, doDrain);
-    }
-
-    @Override
+    @Nullable
     public FluidStack drain(EnumFacing from, int maxDrain, boolean doDrain) {
         return fluidTank.drain(maxDrain, doDrain);
     }

--- a/src/main/java/mekanism/common/tile/TileEntityRotaryCondensentrator.java
+++ b/src/main/java/mekanism/common/tile/TileEntityRotaryCondensentrator.java
@@ -277,7 +277,7 @@ public class TileEntityRotaryCondensentrator extends TileEntityMachine implement
     }
 
     @Override
-    public int fill(EnumFacing from, @Nullable FluidStack resource, boolean doFill) {
+    public int fill(EnumFacing from, @Nonnull FluidStack resource, boolean doFill) {
         if (canFill(from, resource)) {
             return fluidTank.fill(resource, doFill);
         }
@@ -285,22 +285,23 @@ public class TileEntityRotaryCondensentrator extends TileEntityMachine implement
     }
 
     @Override
-    public FluidStack drain(EnumFacing from, @Nullable FluidStack resource, boolean doDrain) {
-        if (resource != null && fluidTank.getFluid() != null && fluidTank.getFluid().getFluid() == resource.getFluid()) {
-            return drain(from, resource.amount, doDrain);
-        }
-        return null;
+    public FluidStack drain(EnumFacing from, @Nonnull FluidStack resource, boolean doDrain) {
+        return drain(from, resource.amount, doDrain);
     }
 
     @Override
-    public boolean canFill(EnumFacing from, @Nullable FluidStack fluid) {
-        return fluid != null && mode == 1 && from == MekanismUtils.getRight(facing) &&
-               (fluidTank.getFluid() == null ? isValidFluid(new FluidStack(fluid, 1)) : fluidTank.getFluid().isFluidEqual(fluid));
+    public FluidStack drain(EnumFacing from, int maxDrain, boolean doDrain) {
+        return fluidTank.drain(maxDrain, doDrain);
+    }
+
+    @Override
+    public boolean canFill(EnumFacing from, @Nonnull FluidStack fluid) {
+        return mode == 1 && from == MekanismUtils.getRight(facing) && (fluidTank.getFluid() == null ? isValidFluid(new FluidStack(fluid, 1)) : fluidTank.getFluid().isFluidEqual(fluid));
     }
 
     @Override
     public boolean canDrain(EnumFacing from, @Nullable FluidStack fluid) {
-        return mode == 0 && from == MekanismUtils.getRight(facing);
+        return mode == 0 && from == MekanismUtils.getRight(facing) && FluidContainerUtils.canDrain(fluidTank.getFluid(), fluid);
     }
 
     @Override
@@ -314,14 +315,6 @@ public class TileEntityRotaryCondensentrator extends TileEntityMachine implement
     @Override
     public FluidTankInfo[] getAllTanks() {
         return new FluidTankInfo[]{fluidTank.getInfo()};
-    }
-
-    @Override
-    public FluidStack drain(EnumFacing from, int maxDrain, boolean doDrain) {
-        if (canDrain(from, null)) {
-            return fluidTank.drain(maxDrain, doDrain);
-        }
-        return null;
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/TileEntityThermalEvaporationValve.java
+++ b/src/main/java/mekanism/common/tile/TileEntityThermalEvaporationValve.java
@@ -50,11 +50,7 @@ public class TileEntityThermalEvaporationValve extends TileEntityThermalEvaporat
     }
 
     @Override
-    public FluidStack drain(EnumFacing from, @Nonnull FluidStack resource, boolean doDrain) {
-        return drain(from, resource.amount, doDrain);
-    }
-
-    @Override
+    @Nullable
     public FluidStack drain(EnumFacing from, int maxDrain, boolean doDrain) {
         TileEntityThermalEvaporationController controller = getController();
         return controller == null ? null : controller.outputTank.drain(maxDrain, doDrain);

--- a/src/main/java/mekanism/common/tile/TileEntityThermalEvaporationValve.java
+++ b/src/main/java/mekanism/common/tile/TileEntityThermalEvaporationValve.java
@@ -8,6 +8,7 @@ import mekanism.common.base.FluidHandlerWrapper;
 import mekanism.common.base.IComparatorSupport;
 import mekanism.common.base.IFluidHandlerWrapper;
 import mekanism.common.capabilities.Capabilities;
+import mekanism.common.util.FluidContainerUtils;
 import mekanism.common.util.MekanismUtils;
 import mekanism.common.util.PipeUtils;
 import net.minecraft.util.EnumFacing;
@@ -43,39 +44,32 @@ public class TileEntityThermalEvaporationValve extends TileEntityThermalEvaporat
     }
 
     @Override
-    public int fill(EnumFacing from, @Nullable FluidStack resource, boolean doFill) {
+    public int fill(EnumFacing from, @Nonnull FluidStack resource, boolean doFill) {
         TileEntityThermalEvaporationController controller = getController();
         return controller == null ? 0 : controller.inputTank.fill(resource, doFill);
     }
 
     @Override
-    public FluidStack drain(EnumFacing from, @Nullable FluidStack resource, boolean doDrain) {
-        TileEntityThermalEvaporationController controller = getController();
-        if (controller != null && resource != null && resource.isFluidEqual(controller.outputTank.getFluid())) {
-            return controller.outputTank.drain(resource.amount, doDrain);
-        }
-        return null;
+    public FluidStack drain(EnumFacing from, @Nonnull FluidStack resource, boolean doDrain) {
+        return drain(from, resource.amount, doDrain);
     }
 
     @Override
     public FluidStack drain(EnumFacing from, int maxDrain, boolean doDrain) {
         TileEntityThermalEvaporationController controller = getController();
-        if (controller != null) {
-            return controller.outputTank.drain(maxDrain, doDrain);
-        }
-        return null;
+        return controller == null ? null : controller.outputTank.drain(maxDrain, doDrain);
     }
 
     @Override
-    public boolean canFill(EnumFacing from, @Nullable FluidStack fluid) {
+    public boolean canFill(EnumFacing from, @Nonnull FluidStack fluid) {
         TileEntityThermalEvaporationController controller = getController();
-        return controller != null && fluid != null && controller.hasRecipe(fluid.getFluid());
+        return controller != null && controller.hasRecipe(fluid.getFluid());
     }
 
     @Override
     public boolean canDrain(EnumFacing from, @Nullable FluidStack fluid) {
         TileEntityThermalEvaporationController controller = getController();
-        return controller != null && controller.outputTank.getFluidAmount() > 0;
+        return controller != null && controller.outputTank.getFluidAmount() > 0 && FluidContainerUtils.canDrain(controller.outputTank.getFluid(), fluid);
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityMechanicalPipe.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityMechanicalPipe.java
@@ -198,23 +198,8 @@ public class TileEntityMechanicalPipe extends TileEntityTransmitter<IFluidHandle
     }
 
     @Override
-    public FluidStack drain(EnumFacing from, int maxDrain, boolean doDrain) {
-        return null;
-    }
-
-    @Override
-    public FluidStack drain(EnumFacing from, @Nonnull FluidStack resource, boolean doDrain) {
-        return null;
-    }
-
-    @Override
     public boolean canFill(EnumFacing from, @Nonnull FluidStack fluid) {
         return getConnectionType(from) == ConnectionType.NORMAL;
-    }
-
-    @Override
-    public boolean canDrain(EnumFacing from, @Nullable FluidStack fluid) {
-        return false;
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityMechanicalPipe.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityMechanicalPipe.java
@@ -54,13 +54,11 @@ public class TileEntityMechanicalPipe extends TileEntityTransmitter<IFluidHandle
             updateShare();
             IFluidHandler[] connectedAcceptors = PipeUtils.getConnectedAcceptors(getPos(), getWorld());
             for (EnumFacing side : getConnections(ConnectionType.PULL)) {
-                if (connectedAcceptors[side.ordinal()] != null) {
-                    IFluidHandler container = connectedAcceptors[side.ordinal()];
-                    if (container != null) {
-                        FluidStack received = container.drain(getAvailablePull(), false);
-                        if (received != null && received.amount != 0 && takeFluid(received, false) == received.amount) {
-                            container.drain(takeFluid(received, true), true);
-                        }
+                IFluidHandler container = connectedAcceptors[side.ordinal()];
+                if (container != null) {
+                    FluidStack received = container.drain(getAvailablePull(), false);
+                    if (received != null && received.amount != 0 && takeFluid(received, false) == received.amount) {
+                        container.drain(takeFluid(received, true), true);
                     }
                 }
             }
@@ -195,11 +193,8 @@ public class TileEntityMechanicalPipe extends TileEntityTransmitter<IFluidHandle
     }
 
     @Override
-    public int fill(EnumFacing from, @Nullable FluidStack resource, boolean doFill) {
-        if (getConnectionType(from) == ConnectionType.NORMAL) {
-            return takeFluid(resource, doFill);
-        }
-        return 0;
+    public int fill(EnumFacing from, @Nonnull FluidStack resource, boolean doFill) {
+        return takeFluid(resource, doFill);
     }
 
     @Override
@@ -208,12 +203,12 @@ public class TileEntityMechanicalPipe extends TileEntityTransmitter<IFluidHandle
     }
 
     @Override
-    public FluidStack drain(EnumFacing from, @Nullable FluidStack resource, boolean doDrain) {
+    public FluidStack drain(EnumFacing from, @Nonnull FluidStack resource, boolean doDrain) {
         return null;
     }
 
     @Override
-    public boolean canFill(EnumFacing from, @Nullable FluidStack fluid) {
+    public boolean canFill(EnumFacing from, @Nonnull FluidStack fluid) {
         return getConnectionType(from) == ConnectionType.NORMAL;
     }
 

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityPressurizedTube.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityPressurizedTube.java
@@ -79,13 +79,11 @@ public class TileEntityPressurizedTube extends TileEntityTransmitter<IGasHandler
             updateShare();
             IGasHandler[] connectedAcceptors = GasUtils.getConnectedAcceptors(getPos(), getWorld());
             for (EnumFacing side : getConnections(ConnectionType.PULL)) {
-                if (connectedAcceptors[side.ordinal()] != null) {
-                    IGasHandler container = connectedAcceptors[side.ordinal()];
-                    if (container != null) {
-                        GasStack received = container.drawGas(side.getOpposite(), getAvailablePull(), false);
-                        if (received != null && received.amount != 0 && takeGas(received, false) == received.amount) {
-                            container.drawGas(side.getOpposite(), takeGas(received, true), true);
-                        }
+                IGasHandler container = connectedAcceptors[side.ordinal()];
+                if (container != null) {
+                    GasStack received = container.drawGas(side.getOpposite(), getAvailablePull(), false);
+                    if (received != null && received.amount != 0 && takeGas(received, false) == received.amount) {
+                        container.drawGas(side.getOpposite(), takeGas(received, true), true);
                     }
                 }
             }

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityThermodynamicConductor.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityThermodynamicConductor.java
@@ -181,9 +181,7 @@ public class TileEntityThermodynamicConductor extends TileEntityTransmitter<IHea
     public IHeatTransfer getAdjacent(EnumFacing side) {
         if (connectionMapContainsSide(getAllCurrentConnections(), side)) {
             TileEntity adj = MekanismUtils.getTileEntity(world, getPos().offset(side));
-            if (CapabilityUtils.hasCapability(adj, Capabilities.HEAT_TRANSFER_CAPABILITY, side.getOpposite())) {
-                return CapabilityUtils.getCapability(adj, Capabilities.HEAT_TRANSFER_CAPABILITY, side.getOpposite());
-            }
+            return CapabilityUtils.getCapability(adj, Capabilities.HEAT_TRANSFER_CAPABILITY, side.getOpposite());
         }
         return null;
     }

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityUniversalCable.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityUniversalCable.java
@@ -76,8 +76,8 @@ public class TileEntityUniversalCable extends TileEntityTransmitter<EnergyAccept
                 TileEntity[] connectedOutputters = CableUtils.getConnectedOutputters(getPos(), getWorld());
                 double canDraw = tier.getCableCapacity();
                 for (EnumFacing side : sides) {
-                    if (connectedOutputters[side.ordinal()] != null) {
-                        TileEntity outputter = connectedOutputters[side.ordinal()];
+                    TileEntity outputter = connectedOutputters[side.ordinal()];
+                    if (outputter != null) {
                         //pre declare some variables for inline assignment & checks
                         IStrictEnergyStorage strictStorage;
                         ITeslaProducer teslaProducer;//do not assign anything to this here, or classloader issues may happen

--- a/src/main/java/mekanism/common/util/FluidContainerUtils.java
+++ b/src/main/java/mekanism/common/util/FluidContainerUtils.java
@@ -1,5 +1,7 @@
 package mekanism.common.util;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import mekanism.common.tile.prefab.TileEntityContainerBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
@@ -17,6 +19,14 @@ public final class FluidContainerUtils {
 
     public static boolean isFluidContainer(ItemStack stack) {
         return !stack.isEmpty() && stack.hasCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY, null);
+    }
+
+    public static boolean canDrain(@Nullable FluidStack tankFluid, @Nullable FluidStack drainFluid) {
+        return tankFluid != null && (drainFluid == null || tankFluid.isFluidEqual(drainFluid));
+    }
+
+    public static boolean canFill(@Nullable FluidStack tankFluid, @Nonnull FluidStack fillFluid) {
+        return tankFluid == null || tankFluid.isFluidEqual(fillFluid);
     }
 
     public static FluidStack extractFluid(FluidTank tileTank, TileEntityContainerBlock tile, int slotID) {

--- a/src/main/java/mekanism/generators/common/tile/TileEntityBioGenerator.java
+++ b/src/main/java/mekanism/generators/common/tile/TileEntityBioGenerator.java
@@ -2,7 +2,6 @@ package mekanism.generators.common.tile;
 
 import io.netty.buffer.ByteBuf;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import mekanism.api.TileNetworkList;
 import mekanism.common.FluidSlot;
 import mekanism.common.MekanismItems;
@@ -218,24 +217,9 @@ public class TileEntityBioGenerator extends TileEntityGenerator implements IFlui
     }
 
     @Override
-    public FluidStack drain(EnumFacing from, int maxDrain, boolean doDrain) {
-        return null;
-    }
-
-    @Override
-    public FluidStack drain(EnumFacing from, @Nonnull FluidStack resource, boolean doDrain) {
-        return null;
-    }
-
-    @Override
     public boolean canFill(EnumFacing from, @Nonnull FluidStack fluid) {
         //TODO
         return fluid.getFluid().equals(FluidRegistry.getFluid("bioethanol"));
-    }
-
-    @Override
-    public boolean canDrain(EnumFacing from, @Nullable FluidStack fluid) {
-        return false;
     }
 
     @Override

--- a/src/main/java/mekanism/generators/common/tile/TileEntityBioGenerator.java
+++ b/src/main/java/mekanism/generators/common/tile/TileEntityBioGenerator.java
@@ -197,29 +197,23 @@ public class TileEntityBioGenerator extends TileEntityGenerator implements IFlui
 
     @Override
     public int fill(EnumFacing from, @Nonnull FluidStack resource, boolean doFill) {
-        if (FluidRegistry.isFluidRegistered("bioethanol") && from != facing) {
-            if (resource.getFluid() == FluidRegistry.getFluid("bioethanol")) {
-                int fuelTransfer;
-                int fuelNeeded = bioFuelSlot.MAX_FLUID - bioFuelSlot.fluidStored;
-                int attemptTransfer = resource.amount;
-                if (attemptTransfer <= fuelNeeded) {
-                    fuelTransfer = attemptTransfer;
-                } else {
-                    fuelTransfer = fuelNeeded;
-                }
-                if (doFill) {
-                    bioFuelSlot.setFluid(bioFuelSlot.fluidStored + fuelTransfer);
-                }
-                return fuelTransfer;
-            }
+        int fuelTransfer;
+        int fuelNeeded = bioFuelSlot.MAX_FLUID - bioFuelSlot.fluidStored;
+        int attemptTransfer = resource.amount;
+        if (attemptTransfer <= fuelNeeded) {
+            fuelTransfer = attemptTransfer;
+        } else {
+            fuelTransfer = fuelNeeded;
         }
-        return 0;
+        if (doFill) {
+            bioFuelSlot.setFluid(bioFuelSlot.fluidStored + fuelTransfer);
+        }
+        return fuelTransfer;
     }
 
     @Override
     public boolean canFill(EnumFacing from, @Nonnull FluidStack fluid) {
-        //TODO
-        return fluid.getFluid().equals(FluidRegistry.getFluid("bioethanol"));
+        return from != facing && fluid.getFluid() == FluidRegistry.getFluid("bioethanol");
     }
 
     @Override

--- a/src/main/java/mekanism/generators/common/tile/TileEntityBioGenerator.java
+++ b/src/main/java/mekanism/generators/common/tile/TileEntityBioGenerator.java
@@ -197,8 +197,8 @@ public class TileEntityBioGenerator extends TileEntityGenerator implements IFlui
     }
 
     @Override
-    public int fill(EnumFacing from, @Nullable FluidStack resource, boolean doFill) {
-        if (resource != null && FluidRegistry.isFluidRegistered("bioethanol") && from != facing) {
+    public int fill(EnumFacing from, @Nonnull FluidStack resource, boolean doFill) {
+        if (FluidRegistry.isFluidRegistered("bioethanol") && from != facing) {
             if (resource.getFluid() == FluidRegistry.getFluid("bioethanol")) {
                 int fuelTransfer;
                 int fuelNeeded = bioFuelSlot.MAX_FLUID - bioFuelSlot.fluidStored;
@@ -223,13 +223,14 @@ public class TileEntityBioGenerator extends TileEntityGenerator implements IFlui
     }
 
     @Override
-    public FluidStack drain(EnumFacing from, @Nullable FluidStack resource, boolean doDrain) {
+    public FluidStack drain(EnumFacing from, @Nonnull FluidStack resource, boolean doDrain) {
         return null;
     }
 
     @Override
-    public boolean canFill(EnumFacing from, @Nullable FluidStack fluid) {
-        return fluid != null && fluid.getFluid().equals(FluidRegistry.getFluid("bioethanol"));
+    public boolean canFill(EnumFacing from, @Nonnull FluidStack fluid) {
+        //TODO
+        return fluid.getFluid().equals(FluidRegistry.getFluid("bioethanol"));
     }
 
     @Override

--- a/src/main/java/mekanism/generators/common/tile/TileEntityHeatGenerator.java
+++ b/src/main/java/mekanism/generators/common/tile/TileEntityHeatGenerator.java
@@ -245,11 +245,8 @@ public class TileEntityHeatGenerator extends TileEntityGenerator implements IFlu
     }
 
     @Override
-    public int fill(EnumFacing from, @Nullable FluidStack resource, boolean doFill) {
-        if (resource != null && resource.getFluid() == FluidRegistry.LAVA && from != facing) {
-            return lavaTank.fill(resource, doFill);
-        }
-        return 0;
+    public int fill(EnumFacing from, @Nonnull FluidStack resource, boolean doFill) {
+        return lavaTank.fill(resource, doFill);
     }
 
     @Override
@@ -258,13 +255,13 @@ public class TileEntityHeatGenerator extends TileEntityGenerator implements IFlu
     }
 
     @Override
-    public FluidStack drain(EnumFacing from, @Nullable FluidStack resource, boolean doDrain) {
+    public FluidStack drain(EnumFacing from, @Nonnull FluidStack resource, boolean doDrain) {
         return null;
     }
 
     @Override
-    public boolean canFill(EnumFacing from, @Nullable FluidStack fluid) {
-        return fluid != null && fluid.getFluid().equals(FluidRegistry.LAVA) && from != facing;
+    public boolean canFill(EnumFacing from, @Nonnull FluidStack fluid) {
+        return fluid.getFluid().equals(FluidRegistry.LAVA) && from != facing;
     }
 
     @Override

--- a/src/main/java/mekanism/generators/common/tile/TileEntityHeatGenerator.java
+++ b/src/main/java/mekanism/generators/common/tile/TileEntityHeatGenerator.java
@@ -2,7 +2,6 @@ package mekanism.generators.common.tile;
 
 import io.netty.buffer.ByteBuf;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import mekanism.api.Coord4D;
 import mekanism.api.IHeatTransfer;
 import mekanism.api.TileNetworkList;
@@ -250,23 +249,8 @@ public class TileEntityHeatGenerator extends TileEntityGenerator implements IFlu
     }
 
     @Override
-    public FluidStack drain(EnumFacing from, int maxDrain, boolean doDrain) {
-        return null;
-    }
-
-    @Override
-    public FluidStack drain(EnumFacing from, @Nonnull FluidStack resource, boolean doDrain) {
-        return null;
-    }
-
-    @Override
     public boolean canFill(EnumFacing from, @Nonnull FluidStack fluid) {
         return fluid.getFluid().equals(FluidRegistry.LAVA) && from != facing;
-    }
-
-    @Override
-    public boolean canDrain(EnumFacing from, @Nullable FluidStack fluid) {
-        return false;
     }
 
     @Override

--- a/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorPort.java
+++ b/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorPort.java
@@ -109,12 +109,12 @@ public class TileEntityReactorPort extends TileEntityReactorBlock implements IFl
 
     @Override
     public boolean canFill(EnumFacing from, @Nonnull FluidStack fluid) {
-        return getReactor() != null && fluid.getFluid().equals(FluidRegistry.WATER) && !fluidEject;
+        return getReactor() != null && !fluidEject && fluid.getFluid() == FluidRegistry.WATER;
     }
 
     @Override
     public boolean canDrain(EnumFacing from, @Nullable FluidStack fluid) {
-        return getReactor() != null && fluid != null && fluid.getFluid() == FluidRegistry.getFluid("steam");
+        return getReactor() != null && (fluid == null || fluid.getFluid() == FluidRegistry.getFluid("steam"));
     }
 
     @Override

--- a/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorPort.java
+++ b/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorPort.java
@@ -1,6 +1,7 @@
 package mekanism.generators.common.tile.reactor;
 
 import io.netty.buffer.ByteBuf;
+import java.util.EnumSet;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import mekanism.api.Coord4D;
@@ -19,6 +20,7 @@ import mekanism.common.base.IFluidHandlerWrapper;
 import mekanism.common.capabilities.Capabilities;
 import mekanism.common.util.CableUtils;
 import mekanism.common.util.CapabilityUtils;
+import mekanism.common.util.EmitUtils;
 import mekanism.common.util.HeatUtils;
 import mekanism.common.util.InventoryUtils;
 import mekanism.common.util.LangUtils;
@@ -82,15 +84,14 @@ public class TileEntityReactorPort extends TileEntityReactorBlock implements IFl
             CableUtils.emit(this);
             if (fluidEject && getReactor() != null && getReactor().getSteamTank().getFluid() != null) {
                 IFluidTank tank = getReactor().getSteamTank();
-                for (EnumFacing side : EnumFacing.values()) {
-                    TileEntity tile = Coord4D.get(this).offset(side).getTileEntity(world);
-                    if (tile != null && !(tile instanceof TileEntityReactorPort) && CapabilityUtils.hasCapability(tile, CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, side.getOpposite())) {
+                EmitUtils.forEachSide(getWorld(), getPos(), EnumSet.allOf(EnumFacing.class), (tile, side) -> {
+                    if (!(tile instanceof TileEntityReactorPort)) {
                         IFluidHandler handler = CapabilityUtils.getCapability(tile, CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, side.getOpposite());
-                        if (PipeUtils.canFill(handler, tank.getFluid())) {
+                        if (handler != null && PipeUtils.canFill(handler, tank.getFluid())) {
                             tank.drain(handler.fill(tank.getFluid(), true), true);
                         }
                     }
-                }
+                });
             }
         }
     }

--- a/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorPort.java
+++ b/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorPort.java
@@ -101,11 +101,7 @@ public class TileEntityReactorPort extends TileEntityReactorBlock implements IFl
     }
 
     @Override
-    public FluidStack drain(EnumFacing from, @Nonnull FluidStack resource, boolean doDrain) {
-        return drain(from, resource.amount, doDrain);
-    }
-
-    @Override
+    @Nullable
     public FluidStack drain(EnumFacing from, int maxDrain, boolean doDrain) {
         return getReactor().getSteamTank().drain(maxDrain, doDrain);
     }

--- a/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorPort.java
+++ b/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorPort.java
@@ -96,32 +96,23 @@ public class TileEntityReactorPort extends TileEntityReactorBlock implements IFl
     }
 
     @Override
-    public int fill(EnumFacing from, @Nullable FluidStack resource, boolean doFill) {
-        if (resource != null && resource.getFluid() == FluidRegistry.WATER && getReactor() != null && !fluidEject) {
-            return getReactor().getWaterTank().fill(resource, doFill);
-        }
-        return 0;
+    public int fill(EnumFacing from, @Nonnull FluidStack resource, boolean doFill) {
+        return getReactor().getWaterTank().fill(resource, doFill);
     }
 
     @Override
-    public FluidStack drain(EnumFacing from, @Nullable FluidStack resource, boolean doDrain) {
-        if (resource != null && resource.getFluid() == FluidRegistry.getFluid("steam") && getReactor() != null) {
-            getReactor().getSteamTank().drain(resource.amount, doDrain);
-        }
-        return null;
+    public FluidStack drain(EnumFacing from, @Nonnull FluidStack resource, boolean doDrain) {
+        return drain(from, resource.amount, doDrain);
     }
 
     @Override
     public FluidStack drain(EnumFacing from, int maxDrain, boolean doDrain) {
-        if (getReactor() != null) {
-            return getReactor().getSteamTank().drain(maxDrain, doDrain);
-        }
-        return null;
+        return getReactor().getSteamTank().drain(maxDrain, doDrain);
     }
 
     @Override
-    public boolean canFill(EnumFacing from, @Nullable FluidStack fluid) {
-        return getReactor() != null && fluid != null && fluid.getFluid().equals(FluidRegistry.WATER) && !fluidEject;
+    public boolean canFill(EnumFacing from, @Nonnull FluidStack fluid) {
+        return getReactor() != null && fluid.getFluid().equals(FluidRegistry.WATER) && !fluidEject;
     }
 
     @Override

--- a/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineValve.java
+++ b/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineValve.java
@@ -309,10 +309,7 @@ public class TileEntityTurbineValve extends TileEntityTurbineCasing implements I
     }
 
     @Override
-    public int fill(EnumFacing from, @Nullable FluidStack resource, boolean doFill) {
-        if (resource == null || !canFill(from, resource)) {
-            return 0;
-        }
+    public int fill(EnumFacing from, @Nonnull FluidStack resource, boolean doFill) {
         int filled = fluidTank.fill(resource, doFill);
         if (doFill) {
             structure.newSteamInput += filled;
@@ -324,7 +321,7 @@ public class TileEntityTurbineValve extends TileEntityTurbineCasing implements I
     }
 
     @Override
-    public FluidStack drain(EnumFacing from, @Nullable FluidStack resource, boolean doDrain) {
+    public FluidStack drain(EnumFacing from, @Nonnull FluidStack resource, boolean doDrain) {
         return null;
     }
 
@@ -334,8 +331,8 @@ public class TileEntityTurbineValve extends TileEntityTurbineCasing implements I
     }
 
     @Override
-    public boolean canFill(EnumFacing from, @Nullable FluidStack fluid) {
-        if (fluid != null && fluid.getFluid().equals(FluidRegistry.getFluid("steam"))) {
+    public boolean canFill(EnumFacing from, @Nonnull FluidStack fluid) {
+        if (fluid.getFluid().equals(FluidRegistry.getFluid("steam"))) {
             return (!world.isRemote && structure != null) || (world.isRemote && clientHasStructure);
         }
         return false;

--- a/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineValve.java
+++ b/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineValve.java
@@ -321,7 +321,7 @@ public class TileEntityTurbineValve extends TileEntityTurbineCasing implements I
 
     @Override
     public boolean canFill(EnumFacing from, @Nonnull FluidStack fluid) {
-        if (fluid.getFluid().equals(FluidRegistry.getFluid("steam"))) {
+        if (fluid.getFluid() == FluidRegistry.getFluid("steam")) {
             return (!world.isRemote && structure != null) || (world.isRemote && clientHasStructure);
         }
         return false;

--- a/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineValve.java
+++ b/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineValve.java
@@ -8,7 +8,6 @@ import ic2.api.energy.tile.IEnergyConductor;
 import ic2.api.energy.tile.IEnergyEmitter;
 import ic2.api.energy.tile.IEnergyTile;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import mekanism.api.Coord4D;
 import mekanism.common.base.FluidHandlerWrapper;
 import mekanism.common.base.IComparatorSupport;
@@ -321,25 +320,10 @@ public class TileEntityTurbineValve extends TileEntityTurbineCasing implements I
     }
 
     @Override
-    public FluidStack drain(EnumFacing from, @Nonnull FluidStack resource, boolean doDrain) {
-        return null;
-    }
-
-    @Override
-    public FluidStack drain(EnumFacing from, int maxDrain, boolean doDrain) {
-        return null;
-    }
-
-    @Override
     public boolean canFill(EnumFacing from, @Nonnull FluidStack fluid) {
         if (fluid.getFluid().equals(FluidRegistry.getFluid("steam"))) {
             return (!world.isRemote && structure != null) || (world.isRemote && clientHasStructure);
         }
-        return false;
-    }
-
-    @Override
-    public boolean canDrain(EnumFacing from, @Nullable FluidStack fluid) {
         return false;
     }
 

--- a/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineVent.java
+++ b/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineVent.java
@@ -1,13 +1,13 @@
 package mekanism.generators.common.tile.turbine;
 
+import java.util.EnumSet;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import mekanism.api.Coord4D;
 import mekanism.common.base.FluidHandlerWrapper;
 import mekanism.common.base.IFluidHandlerWrapper;
 import mekanism.common.util.CapabilityUtils;
+import mekanism.common.util.EmitUtils;
 import mekanism.common.util.PipeUtils;
-import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fluids.FluidRegistry;
@@ -29,13 +29,12 @@ public class TileEntityTurbineVent extends TileEntityTurbineCasing implements IF
         super.onUpdate();
         if (structure != null && structure.flowRemaining > 0) {
             FluidStack fluidStack = new FluidStack(FluidRegistry.WATER, structure.flowRemaining);
-            for (EnumFacing side : EnumFacing.VALUES) {
-                TileEntity tile = Coord4D.get(this).offset(side).getTileEntity(world);
+            EmitUtils.forEachSide(getWorld(), getPos(), EnumSet.allOf(EnumFacing.class), (tile, side) -> {
                 IFluidHandler handler = CapabilityUtils.getCapability(tile, CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, side.getOpposite());
                 if (handler != null && PipeUtils.canFill(handler, fluidStack)) {
                     structure.flowRemaining -= handler.fill(fluidStack, true);
                 }
-            }
+            });
         }
     }
 
@@ -59,7 +58,7 @@ public class TileEntityTurbineVent extends TileEntityTurbineCasing implements IF
     @Override
     public boolean canDrain(EnumFacing from, @Nullable FluidStack fluid) {
         //TODO: Why is this sometimes not true if it can never actually drain
-        return fluid != null && fluid.getFluid().equals(FluidRegistry.WATER);
+        return fluid == null || fluid.getFluid().equals(FluidRegistry.WATER);
     }
 
     @Override

--- a/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineVent.java
+++ b/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineVent.java
@@ -52,12 +52,12 @@ public class TileEntityTurbineVent extends TileEntityTurbineCasing implements IF
     }
 
     @Override
-    public int fill(EnumFacing from, @Nullable FluidStack resource, boolean doFill) {
+    public int fill(EnumFacing from, @Nonnull FluidStack resource, boolean doFill) {
         return 0;
     }
 
     @Override
-    public FluidStack drain(EnumFacing from, @Nullable FluidStack resource, boolean doDrain) {
+    public FluidStack drain(EnumFacing from, @Nonnull FluidStack resource, boolean doDrain) {
         return null;
     }
 
@@ -67,12 +67,13 @@ public class TileEntityTurbineVent extends TileEntityTurbineCasing implements IF
     }
 
     @Override
-    public boolean canFill(EnumFacing from, @Nullable FluidStack fluid) {
+    public boolean canFill(EnumFacing from, @Nonnull FluidStack fluid) {
         return false;
     }
 
     @Override
     public boolean canDrain(EnumFacing from, @Nullable FluidStack fluid) {
+        //TODO: Why is this sometimes not true if it can never actually drain
         return fluid != null && fluid.getFluid().equals(FluidRegistry.WATER);
     }
 

--- a/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineVent.java
+++ b/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineVent.java
@@ -31,11 +31,9 @@ public class TileEntityTurbineVent extends TileEntityTurbineCasing implements IF
             FluidStack fluidStack = new FluidStack(FluidRegistry.WATER, structure.flowRemaining);
             for (EnumFacing side : EnumFacing.VALUES) {
                 TileEntity tile = Coord4D.get(this).offset(side).getTileEntity(world);
-                if (CapabilityUtils.hasCapability(tile, CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, side.getOpposite())) {
-                    IFluidHandler handler = CapabilityUtils.getCapability(tile, CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, side.getOpposite());
-                    if (PipeUtils.canFill(handler, fluidStack)) {
-                        structure.flowRemaining -= handler.fill(fluidStack, true);
-                    }
+                IFluidHandler handler = CapabilityUtils.getCapability(tile, CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, side.getOpposite());
+                if (handler != null && PipeUtils.canFill(handler, fluidStack)) {
+                    structure.flowRemaining -= handler.fill(fluidStack, true);
                 }
             }
         }
@@ -52,23 +50,10 @@ public class TileEntityTurbineVent extends TileEntityTurbineCasing implements IF
     }
 
     @Override
-    public int fill(EnumFacing from, @Nonnull FluidStack resource, boolean doFill) {
-        return 0;
-    }
-
-    @Override
-    public FluidStack drain(EnumFacing from, @Nonnull FluidStack resource, boolean doDrain) {
-        return null;
-    }
-
-    @Override
+    @Nullable
     public FluidStack drain(EnumFacing from, int maxDrain, boolean doDrain) {
+        //TODO: Is this supposed to be implemented
         return null;
-    }
-
-    @Override
-    public boolean canFill(EnumFacing from, @Nonnull FluidStack fluid) {
-        return false;
     }
 
     @Override

--- a/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineVent.java
+++ b/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineVent.java
@@ -51,14 +51,13 @@ public class TileEntityTurbineVent extends TileEntityTurbineCasing implements IF
     @Override
     @Nullable
     public FluidStack drain(EnumFacing from, int maxDrain, boolean doDrain) {
-        //TODO: Is this supposed to be implemented
+        //TODO: Implement this as it appears to be missing
         return null;
     }
 
     @Override
     public boolean canDrain(EnumFacing from, @Nullable FluidStack fluid) {
-        //TODO: Why is this sometimes not true if it can never actually drain
-        return fluid == null || fluid.getFluid().equals(FluidRegistry.WATER);
+        return fluid == null || fluid.getFluid() == FluidRegistry.WATER;
     }
 
     @Override

--- a/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineVent.java
+++ b/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineVent.java
@@ -27,7 +27,7 @@ public class TileEntityTurbineVent extends TileEntityTurbineCasing implements IF
     @Override
     public void onUpdate() {
         super.onUpdate();
-        if (structure != null && structure.flowRemaining > 0) {
+        if (!world.isRemote && structure != null && structure.flowRemaining > 0) {
             FluidStack fluidStack = new FluidStack(FluidRegistry.WATER, structure.flowRemaining);
             EmitUtils.forEachSide(getWorld(), getPos(), EnumSet.allOf(EnumFacing.class), (tile, side) -> {
                 IFluidHandler handler = CapabilityUtils.getCapability(tile, CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, side.getOpposite());
@@ -51,13 +51,20 @@ public class TileEntityTurbineVent extends TileEntityTurbineCasing implements IF
     @Override
     @Nullable
     public FluidStack drain(EnumFacing from, int maxDrain, boolean doDrain) {
-        //TODO: Implement this as it appears to be missing
-        return null;
+        int amount = Math.min(maxDrain, structure.flowRemaining);
+        if (amount <= 0) {
+            return null;
+        }
+        FluidStack fluidStack = new FluidStack(FluidRegistry.WATER, amount);
+        if (doDrain) {
+            structure.flowRemaining -= amount;
+        }
+        return fluidStack;
     }
 
     @Override
     public boolean canDrain(EnumFacing from, @Nullable FluidStack fluid) {
-        return fluid == null || fluid.getFluid() == FluidRegistry.WATER;
+        return structure != null && (fluid == null || fluid.getFluid() == FluidRegistry.WATER);
     }
 
     @Override


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add some default implementations into IFluidHandlerWrapper so less code is needed when only implementing one of fill and drain support. (Both default to being unsupported).
- Change where null fluid stacks get caught for IFluidHandlerWrapper to ensure the logic is simpler about what happens where. This includes changing some things from `@Nullable` to `@Nonnull`
- Add assumptions that `canDrain` and `canFill` get called before `drain` and `fill` respectively.
- Default drain by fluidstack type to drain by amount as `canDrain` already checked the type is correct
- Cleanup Entangloporter InventoryFrequency to use TileUtils for gas and fluid syncing
- Unify some of the fluid comparison code, checking NBT of fluidstacks in even more places for the fluid now.
- Implement `drain` method for `TileEntityTurbineVent` as previously only `canDrain` was implemented.
- Some ejecting from multiblocks now use the `EmitUtils#forEachSide` to ensure the tile it is trying to eject to is loaded.

This PR fixes #5550 and various other oddities with our fluid handlers by cleaning up the IFluidHandlerWrapper code a good bit making it easier to read/manage.