### PR TITLE
Fix a few issues with sound

### DIFF
--- a/src/main/java/mekanism/client/ClientPlayerTracker.java
+++ b/src/main/java/mekanism/client/ClientPlayerTracker.java
@@ -11,7 +11,7 @@ public class ClientPlayerTracker {
 
     @SubscribeEvent
     public void onPlayerChangedDimension(PlayerChangedDimensionEvent event) {
-        Mekanism.playerState.clearPlayer(event.player);
+        Mekanism.playerState.clearPlayer(event.player.getUniqueID());
         Mekanism.freeRunnerOn.remove(event.player.getUniqueID());
     }
 }

--- a/src/main/java/mekanism/client/ClientTickHandler.java
+++ b/src/main/java/mekanism/client/ClientTickHandler.java
@@ -193,7 +193,7 @@ public class ClientTickHandler {
             // kicks off sounds as necessary
             Mekanism.playerState.setJetpackState(playerUUID, isJetpackActive(mc.player), true);
             Mekanism.playerState.setGasmaskState(playerUUID, isGasMaskOn(mc.player), true);
-            Mekanism.playerState.setFlamethrowerState(playerUUID, isFlamethrowerOn(mc.player), true);
+            Mekanism.playerState.setFlamethrowerState(playerUUID, hasFlamethrower(mc.player), isFlamethrowerOn(mc.player), true);
 
             for (Iterator<Entry<EntityPlayer, TeleportData>> iter = portableTeleports.entrySet().iterator(); iter.hasNext(); ) {
                 Entry<EntityPlayer, TeleportData> entry = iter.next();

--- a/src/main/java/mekanism/client/ClientTickHandler.java
+++ b/src/main/java/mekanism/client/ClientTickHandler.java
@@ -179,7 +179,7 @@ public class ClientTickHandler {
         }
 
         if (mc.world != null && mc.player != null && !Mekanism.proxy.isPaused()) {
-            if ((!initHoliday || MekanismClient.ticksPassed % 1200 == 0) && mc.player != null) {
+            if (!initHoliday || MekanismClient.ticksPassed % 1200 == 0) {
                 HolidayManager.check();
                 initHoliday = true;
             }

--- a/src/main/java/mekanism/client/ClientTickHandler.java
+++ b/src/main/java/mekanism/client/ClientTickHandler.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Random;
 import java.util.Set;
+import java.util.UUID;
 import mekanism.api.IClientTicker;
 import mekanism.api.gas.GasStack;
 import mekanism.client.render.RenderTickHandler;
@@ -115,10 +116,7 @@ public class ClientTickHandler {
         if (player != mc.player) {
             return Mekanism.playerState.isFlamethrowerOn(player);
         }
-        if (hasFlamethrower(player)) {
-            return mc.gameSettings.keyBindUseItem.isKeyDown();
-        }
-        return false;
+        return hasFlamethrower(player) && mc.gameSettings.keyBindUseItem.isKeyDown();
     }
 
     public static boolean hasFlamethrower(EntityPlayer player) {
@@ -130,10 +128,11 @@ public class ClientTickHandler {
     }
 
     public static void portableTeleport(EntityPlayer player, EnumHand hand, Frequency freq) {
-        if (MekanismConfig.current().general.portableTeleporterDelay.val() == 0) {
+        int delay = MekanismConfig.current().general.portableTeleporterDelay.val();
+        if (delay == 0) {
             Mekanism.packetHandler.sendToServer(new PortableTeleporterMessage(PortableTeleporterPacketType.TELEPORT, hand, freq));
         } else {
-            portableTeleports.put(player, new TeleportData(hand, freq, mc.world.getWorldTime() + MekanismConfig.current().general.portableTeleporterDelay.val()));
+            portableTeleports.put(player, new TeleportData(hand, freq, mc.world.getWorldTime() + delay));
         }
     }
 
@@ -172,20 +171,19 @@ public class ClientTickHandler {
                 initHoliday = true;
             }
 
-            if (Mekanism.freeRunnerOn.contains(mc.player.getUniqueID()) != isFreeRunnerOn(mc.player)) {
-                if (isFreeRunnerOn(mc.player) && mc.currentScreen == null) {
-                    Mekanism.freeRunnerOn.add(mc.player.getUniqueID());
+            UUID playerUUID = mc.player.getUniqueID();
+            boolean freeRunnerOn = isFreeRunnerOn(mc.player);
+            if (Mekanism.freeRunnerOn.contains(playerUUID) != freeRunnerOn) {
+                if (freeRunnerOn && mc.currentScreen == null) {
+                    Mekanism.freeRunnerOn.add(playerUUID);
                 } else {
-                    Mekanism.freeRunnerOn.remove(mc.player.getUniqueID());
+                    Mekanism.freeRunnerOn.remove(playerUUID);
                 }
-
-                Mekanism.packetHandler.sendToServer(new PacketFreeRunnerData.FreeRunnerDataMessage(PacketFreeRunnerData.FreeRunnerPacket.UPDATE,
-                      mc.player.getUniqueID(), isFreeRunnerOn(mc.player)));
+                Mekanism.packetHandler.sendToServer(new PacketFreeRunnerData.FreeRunnerDataMessage(PacketFreeRunnerData.FreeRunnerPacket.UPDATE, playerUUID, freeRunnerOn));
             }
 
             ItemStack bootStack = mc.player.getItemStackFromSlot(EntityEquipmentSlot.FEET);
-
-            if (!bootStack.isEmpty() && bootStack.getItem() instanceof ItemFreeRunners && isFreeRunnerOn(mc.player) && !mc.player.isSneaking()) {
+            if (!bootStack.isEmpty() && bootStack.getItem() instanceof ItemFreeRunners && freeRunnerOn && !mc.player.isSneaking()) {
                 mc.player.stepHeight = 1.002F;
             } else if (mc.player.stepHeight == 1.002F) {
                 mc.player.stepHeight = 0.6F;
@@ -193,18 +191,17 @@ public class ClientTickHandler {
 
             // Update player's state for various items; this also automatically notifies server if something changed and
             // kicks off sounds as necessary
-            Mekanism.playerState.setJetpackState(mc.player.getUniqueID(), isJetpackActive(mc.player), true);
-            Mekanism.playerState.setGasmaskState(mc.player.getUniqueID(), isGasMaskOn(mc.player), true);
-            Mekanism.playerState.setFlamethrowerState(mc.player.getUniqueID(), isFlamethrowerOn(mc.player), true);
+            Mekanism.playerState.setJetpackState(playerUUID, isJetpackActive(mc.player), true);
+            Mekanism.playerState.setGasmaskState(playerUUID, isGasMaskOn(mc.player), true);
+            Mekanism.playerState.setFlamethrowerState(playerUUID, isFlamethrowerOn(mc.player), true);
 
             for (Iterator<Entry<EntityPlayer, TeleportData>> iter = portableTeleports.entrySet().iterator(); iter.hasNext(); ) {
                 Entry<EntityPlayer, TeleportData> entry = iter.next();
-
+                EntityPlayer player = entry.getKey();
                 for (int i = 0; i < 100; i++) {
-                    double x = entry.getKey().posX + rand.nextDouble() - 0.5D;
-                    double y = entry.getKey().posY + rand.nextDouble() * 2 - 2D;
-                    double z = entry.getKey().posZ + rand.nextDouble() - 0.5D;
-
+                    double x = player.posX + rand.nextDouble() - 0.5D;
+                    double y = player.posY + rand.nextDouble() * 2 - 2D;
+                    double z = player.posZ + rand.nextDouble() - 0.5D;
                     mc.world.spawnParticle(EnumParticleTypes.PORTAL, x, y, z, 0, 1, 0);
                 }
 
@@ -221,22 +218,23 @@ public class ClientTickHandler {
                 MekanismClient.updateKey(mc.gameSettings.keyBindSneak, KeySync.DESCEND);
             }
 
-            if (isFlamethrowerOn(mc.player)) {
-                ItemFlamethrower flamethrower = (ItemFlamethrower) mc.player.inventory.getCurrentItem().getItem();
-                if (!(mc.player.isCreative() || mc.player.isSpectator())) {
+            if (!mc.player.isCreative() && !mc.player.isSpectator()) {
+                if (isFlamethrowerOn(mc.player)) {
+                    ItemFlamethrower flamethrower = (ItemFlamethrower) mc.player.inventory.getCurrentItem().getItem();
                     flamethrower.useGas(mc.player.inventory.getCurrentItem());
                 }
             }
 
             if (isJetpackActive(mc.player)) {
                 ItemJetpack jetpack = (ItemJetpack) chestStack.getItem();
-
-                if (jetpack.getMode(chestStack) == JetpackMode.NORMAL) {
+                JetpackMode mode = jetpack.getMode(chestStack);
+                if (mode == JetpackMode.NORMAL) {
                     mc.player.motionY = Math.min(mc.player.motionY + 0.15D, 0.5D);
                     mc.player.fallDistance = 0.0F;
-                } else if (jetpack.getMode(chestStack) == JetpackMode.HOVER) {
-                    if ((!mc.gameSettings.keyBindJump.isKeyDown() && !mc.gameSettings.keyBindSneak.isKeyDown()) ||
-                        (mc.gameSettings.keyBindJump.isKeyDown() && mc.gameSettings.keyBindSneak.isKeyDown()) || mc.currentScreen != null) {
+                } else if (mode == JetpackMode.HOVER) {
+                    boolean ascending = mc.gameSettings.keyBindJump.isKeyDown();
+                    boolean descending = mc.gameSettings.keyBindSneak.isKeyDown();
+                    if ((!ascending && !descending) || (ascending && descending) || mc.currentScreen != null) {
                         if (mc.player.motionY > 0) {
                             mc.player.motionY = Math.max(mc.player.motionY - 0.15D, 0);
                         } else if (mc.player.motionY < 0) {
@@ -244,14 +242,10 @@ public class ClientTickHandler {
                                 mc.player.motionY = Math.min(mc.player.motionY + 0.15D, 0);
                             }
                         }
-                    } else {
-                        if (mc.gameSettings.keyBindJump.isKeyDown() && mc.currentScreen == null) {
-                            mc.player.motionY = Math.min(mc.player.motionY + 0.15D, 0.2D);
-                        } else if (mc.gameSettings.keyBindSneak.isKeyDown() && mc.currentScreen == null) {
-                            if (!CommonPlayerTickHandler.isOnGround(mc.player)) {
-                                mc.player.motionY = Math.max(mc.player.motionY - 0.15D, -0.2D);
-                            }
-                        }
+                    } else if (ascending) {
+                        mc.player.motionY = Math.min(mc.player.motionY + 0.15D, 0.2D);
+                    } else if (!CommonPlayerTickHandler.isOnGround(mc.player)) {
+                        mc.player.motionY = Math.max(mc.player.motionY - 0.15D, -0.2D);
                     }
                     mc.player.fallDistance = 0.0F;
                 }
@@ -268,11 +262,9 @@ public class ClientTickHandler {
                     mc.player.setAir(mc.player.getAir() + received.amount);
                 }
                 if (mc.player.getAir() == max) {
-                    for (Object obj : mc.player.getActivePotionEffects()) {
-                        if (obj instanceof PotionEffect) {
-                            for (int i = 0; i < 9; i++) {
-                                ((PotionEffect) obj).onUpdate(mc.player);
-                            }
+                    for (PotionEffect effect : mc.player.getActivePotionEffects()) {
+                        for (int i = 0; i < 9; i++) {
+                            effect.onUpdate(mc.player);
                         }
                     }
                 }

--- a/src/main/java/mekanism/client/MekanismKeyHandler.java
+++ b/src/main/java/mekanism/client/MekanismKeyHandler.java
@@ -16,7 +16,6 @@ import mekanism.common.item.ItemJetpack.JetpackMode;
 import mekanism.common.item.ItemScubaTank;
 import mekanism.common.item.ItemWalkieTalkie;
 import mekanism.common.network.PacketFlamethrowerData.FlamethrowerDataMessage;
-import mekanism.common.network.PacketFlamethrowerData.FlamethrowerPacket;
 import mekanism.common.network.PacketFreeRunnerData;
 import mekanism.common.network.PacketFreeRunnerData.FreeRunnerDataMessage;
 import mekanism.common.network.PacketItemStack.ItemStackMessage;
@@ -120,7 +119,7 @@ public class MekanismKeyHandler extends MekKeyHandler {
             } else if (player.isSneaking() && item instanceof ItemFlamethrower) {
                 ItemFlamethrower flamethrower = (ItemFlamethrower) item;
                 flamethrower.incrementMode(toolStack);
-                Mekanism.packetHandler.sendToServer(new FlamethrowerDataMessage(FlamethrowerPacket.MODE, EnumHand.MAIN_HAND, null, false));
+                Mekanism.packetHandler.sendToServer(FlamethrowerDataMessage.MODE_CHANGE(EnumHand.MAIN_HAND));
                 player.sendMessage(new TextComponentGroup(TextFormatting.GRAY).string(Mekanism.LOG_TAG, TextFormatting.DARK_BLUE).string(" ")
                       .translation("mekanism.tooltip.flamethrower.modeBump", flamethrower.getMode(toolStack).getTextComponent()));
             }

--- a/src/main/java/mekanism/client/sound/FlamethrowerSound.java
+++ b/src/main/java/mekanism/client/sound/FlamethrowerSound.java
@@ -22,7 +22,7 @@ public class FlamethrowerSound extends PlayerSound {
     }
 
     @Override
-    public boolean shouldPlaySound() {
+    public boolean shouldPlaySound(@Nonnull EntityPlayer player) {
         if (!ClientTickHandler.hasFlamethrower(player)) {
             return false;
         }

--- a/src/main/java/mekanism/client/sound/FlamethrowerSound.java
+++ b/src/main/java/mekanism/client/sound/FlamethrowerSound.java
@@ -1,5 +1,6 @@
 package mekanism.client.sound;
 
+import javax.annotation.Nonnull;
 import mekanism.client.ClientTickHandler;
 import mekanism.common.Mekanism;
 import net.minecraft.entity.player.EntityPlayer;
@@ -10,31 +11,35 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 @SideOnly(Side.CLIENT)
 public class FlamethrowerSound extends PlayerSound {
 
-    private static ResourceLocation IDLE_SOUND = new ResourceLocation(Mekanism.MODID, "item.flamethrower.idle");
-    private static ResourceLocation ON_SOUND = new ResourceLocation(Mekanism.MODID, "item.flamethrower.active");
-    private static ResourceLocation OFF_SOUND = new ResourceLocation(Mekanism.MODID, "item.flamethrower.active");
+    private static final ResourceLocation IDLE_SOUND = new ResourceLocation(Mekanism.MODID, "item.flamethrower.idle");
+    private static final ResourceLocation ON_SOUND = new ResourceLocation(Mekanism.MODID, "item.flamethrower.active");
 
-    private boolean inUse;
+    private boolean active;
 
-    public FlamethrowerSound(EntityPlayer player) {
-        super(player, IDLE_SOUND);
-        inUse = ClientTickHandler.isFlamethrowerOn(player);
-        this.positionedSoundLocation = inUse ? ON_SOUND : OFF_SOUND;
+    private FlamethrowerSound(@Nonnull EntityPlayer player, boolean active) {
+        super(player, active ? ON_SOUND : IDLE_SOUND);
+        this.active = active;
     }
 
     @Override
     public boolean shouldPlaySound() {
-        boolean hasFlamethrower = ClientTickHandler.hasFlamethrower(player);
-        boolean isFlamethrowerOn = ClientTickHandler.isFlamethrowerOn(player);
-
-        if (!hasFlamethrower) {
+        if (!ClientTickHandler.hasFlamethrower(player)) {
             return false;
         }
+        return ClientTickHandler.isFlamethrowerOn(player) == active;
+    }
 
-        if (inUse != isFlamethrowerOn) {
-            inUse = isFlamethrowerOn;
-            this.positionedSoundLocation = inUse ? ON_SOUND : OFF_SOUND;
+    public static class Active extends FlamethrowerSound {
+
+        public Active(@Nonnull EntityPlayer player) {
+            super(player, true);
         }
-        return true;
+    }
+
+    public static class Idle extends FlamethrowerSound {
+
+        public Idle(@Nonnull EntityPlayer player) {
+            super(player, false);
+        }
     }
 }

--- a/src/main/java/mekanism/client/sound/GasMaskSound.java
+++ b/src/main/java/mekanism/client/sound/GasMaskSound.java
@@ -1,5 +1,6 @@
 package mekanism.client.sound;
 
+import javax.annotation.Nonnull;
 import mekanism.client.ClientTickHandler;
 import mekanism.common.Mekanism;
 import mekanism.common.item.ItemGasMask;
@@ -13,7 +14,7 @@ public class GasMaskSound extends PlayerSound {
 
     private static final ResourceLocation SOUND = new ResourceLocation(Mekanism.MODID, "item.gasMask");
 
-    public GasMaskSound(EntityPlayer player) {
+    public GasMaskSound(@Nonnull EntityPlayer player) {
         super(player, SOUND);
     }
 

--- a/src/main/java/mekanism/client/sound/GasMaskSound.java
+++ b/src/main/java/mekanism/client/sound/GasMaskSound.java
@@ -3,7 +3,6 @@ package mekanism.client.sound;
 import javax.annotation.Nonnull;
 import mekanism.client.ClientTickHandler;
 import mekanism.common.Mekanism;
-import mekanism.common.item.ItemGasMask;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.relauncher.Side;
@@ -19,8 +18,7 @@ public class GasMaskSound extends PlayerSound {
     }
 
     @Override
-    public boolean shouldPlaySound() {
-        boolean hasGasMask = !player.inventory.armorInventory.get(3).isEmpty() && player.inventory.armorInventory.get(3).getItem() instanceof ItemGasMask;
-        return hasGasMask && ClientTickHandler.isGasMaskOn(player);
+    public boolean shouldPlaySound(@Nonnull EntityPlayer player) {
+        return ClientTickHandler.isGasMaskOn(player);
     }
 }

--- a/src/main/java/mekanism/client/sound/JetpackSound.java
+++ b/src/main/java/mekanism/client/sound/JetpackSound.java
@@ -1,5 +1,6 @@
 package mekanism.client.sound;
 
+import javax.annotation.Nonnull;
 import mekanism.client.ClientTickHandler;
 import mekanism.common.Mekanism;
 import net.minecraft.entity.player.EntityPlayer;
@@ -12,7 +13,7 @@ public class JetpackSound extends PlayerSound {
 
     private static final ResourceLocation SOUND = new ResourceLocation(Mekanism.MODID, "item.jetpack");
 
-    public JetpackSound(EntityPlayer player) {
+    public JetpackSound(@Nonnull EntityPlayer player) {
         super(player, SOUND);
     }
 

--- a/src/main/java/mekanism/client/sound/JetpackSound.java
+++ b/src/main/java/mekanism/client/sound/JetpackSound.java
@@ -18,7 +18,7 @@ public class JetpackSound extends PlayerSound {
     }
 
     @Override
-    public boolean shouldPlaySound() {
+    public boolean shouldPlaySound(@Nonnull EntityPlayer player) {
         return ClientTickHandler.isJetpackActive(player);
     }
 }

--- a/src/main/java/mekanism/client/sound/PlayerSound.java
+++ b/src/main/java/mekanism/client/sound/PlayerSound.java
@@ -1,5 +1,6 @@
 package mekanism.client.sound;
 
+import javax.annotation.Nonnull;
 import mekanism.common.config.MekanismConfig;
 import net.minecraft.client.audio.ITickableSound;
 import net.minecraft.client.audio.PositionedSound;
@@ -12,6 +13,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 @SideOnly(Side.CLIENT)
 public abstract class PlayerSound extends PositionedSound implements ITickableSound {
 
+    @Nonnull
     protected EntityPlayer player;
 
     private float fadeUpStep = 0.1f;
@@ -19,7 +21,7 @@ public abstract class PlayerSound extends PositionedSound implements ITickableSo
 
     private boolean donePlaying = false;
 
-    public PlayerSound(EntityPlayer player, ResourceLocation sound) {
+    public PlayerSound(@Nonnull EntityPlayer player, ResourceLocation sound) {
         super(sound, SoundCategory.PLAYERS);
         this.player = player;
         this.repeat = true;

--- a/src/main/java/mekanism/client/sound/PlayerSound.java
+++ b/src/main/java/mekanism/client/sound/PlayerSound.java
@@ -1,6 +1,8 @@
 package mekanism.client.sound;
 
+import java.lang.ref.WeakReference;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import mekanism.common.config.MekanismConfig;
 import net.minecraft.client.audio.ITickableSound;
 import net.minecraft.client.audio.PositionedSound;
@@ -14,55 +16,82 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 public abstract class PlayerSound extends PositionedSound implements ITickableSound {
 
     @Nonnull
-    protected EntityPlayer player;
+    private WeakReference<EntityPlayer> playerReference;
+    private float lastX;
+    private float lastY;
+    private float lastZ;
 
     private float fadeUpStep = 0.1f;
     private float fadeDownStep = 0.1f;
 
     private boolean donePlaying = false;
 
-    public PlayerSound(@Nonnull EntityPlayer player, ResourceLocation sound) {
+    public PlayerSound(@Nonnull EntityPlayer player, @Nonnull ResourceLocation sound) {
         super(sound, SoundCategory.PLAYERS);
-        this.player = player;
+        this.playerReference = new WeakReference<>(player);
+        this.lastX = (float) player.posX;
+        this.lastY = (float) player.posY;
+        this.lastZ = (float) player.posZ;
         this.repeat = true;
         this.repeatDelay = 0;
 
         // N.B. the volume must be > 0 on first time it's processed by sound system or else it will not
         // get registered for tick events.
-        this.volume = 0.1f;
+        this.volume = 0.1F;
+    }
+
+    @Nullable
+    private EntityPlayer getPlayer() {
+        return playerReference.get();
     }
 
     @Override
     public float getXPosF() {
-        return (float) player.posX;
+        //Gracefully handle the player becoming null if this object is kept around after update marks us as donePlaying
+        EntityPlayer player = getPlayer();
+        if (player != null) {
+            this.lastX = (float) player.posX;
+        }
+        return this.lastX;
     }
 
     @Override
     public float getYPosF() {
-        return (float) player.posY;
+        //Gracefully handle the player becoming null if this object is kept around after update marks us as donePlaying
+        EntityPlayer player = getPlayer();
+        if (player != null) {
+            this.lastY = (float) player.posY;
+        }
+        return this.lastY;
     }
 
     @Override
     public float getZPosF() {
-        return (float) player.posZ;
+        //Gracefully handle the player becoming null if this object is kept around after update marks us as donePlaying
+        EntityPlayer player = getPlayer();
+        if (player != null) {
+            this.lastZ = (float) player.posZ;
+        }
+        return this.lastZ;
     }
 
     @Override
     public void update() {
-        if (player.isDead) {
+        EntityPlayer player = getPlayer();
+        if (player == null || player.isDead) {
             this.donePlaying = true;
-            this.volume = 0.0f;
+            this.volume = 0.0F;
             return;
         }
 
-        if (shouldPlaySound()) {
-            if (volume < 1.0f) {
+        if (shouldPlaySound(player)) {
+            if (volume < 1.0F) {
                 // If we weren't max volume, start fading up
-                volume = Math.max(1.0f, volume + fadeUpStep);
+                volume = Math.max(1.0F, volume + fadeUpStep);
             }
-        } else if (volume > 0.0f) {
+        } else if (volume > 0.0F) {
             // Not yet fully muted, fade down
-            volume = Math.max(0.0f, volume - fadeDownStep);
+            volume = Math.max(0.0F, volume - fadeDownStep);
         }
     }
 
@@ -71,10 +100,16 @@ public abstract class PlayerSound extends PositionedSound implements ITickableSo
         return donePlaying;
     }
 
-    public abstract boolean shouldPlaySound();
+    public abstract boolean shouldPlaySound(@Nonnull EntityPlayer player);
 
     @Override
     public float getVolume() {
         return (float) (super.getVolume() * MekanismConfig.current().client.baseSoundVolume.val());
+    }
+
+    public enum SoundType {
+        FLAMETHROWER,
+        JETPACK,
+        GAS_MASK
     }
 }

--- a/src/main/java/mekanism/client/sound/PlayerSound.java
+++ b/src/main/java/mekanism/client/sound/PlayerSound.java
@@ -87,7 +87,7 @@ public abstract class PlayerSound extends PositionedSound implements ITickableSo
         if (shouldPlaySound(player)) {
             if (volume < 1.0F) {
                 // If we weren't max volume, start fading up
-                volume = Math.max(1.0F, volume + fadeUpStep);
+                volume = Math.min(1.0F, volume + fadeUpStep);
             }
         } else if (volume > 0.0F) {
             // Not yet fully muted, fade down

--- a/src/main/java/mekanism/client/sound/SoundHandler.java
+++ b/src/main/java/mekanism/client/sound/SoundHandler.java
@@ -49,26 +49,30 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 @SideOnly(Side.CLIENT)
 public class SoundHandler {
 
+    //TODO: Figure out if this should keep track of UUID instead
     private static IdentityHashMap<EntityPlayer, Boolean> jetpackSounds = new IdentityHashMap<>();
     private static IdentityHashMap<EntityPlayer, Boolean> gasmaskSounds = new IdentityHashMap<>();
+    private static IdentityHashMap<EntityPlayer, Boolean> flamethrowerSounds = new IdentityHashMap<>();
 
     private static Map<Long, ISound> soundMap = new HashMap<>();
     private static boolean IN_MUFFLED_CHECK = false;
 
-    public static void startSound(EntityPlayer player, String soundName) {
-        ISound soundToPlay = null;
-
+    public static void startSound(@Nullable EntityPlayer player, String soundName) {
+        if (player == null) {
+            return;
+        }
         if (soundName.equals("jetpack") && !jetpackSounds.containsKey(player)) {
             jetpackSounds.put(player, true);
-            soundToPlay = new JetpackSound(player);
-        }
-        if (soundName.equals("gasmask") && !gasmaskSounds.containsKey(player)) {
+            playSound(new JetpackSound(player));
+        } else if (soundName.equals("gasmask") && !gasmaskSounds.containsKey(player)) {
             gasmaskSounds.put(player, true);
-            soundToPlay = new GasMaskSound(player);
-        }
-
-        if (soundToPlay != null) {
-            Minecraft.getMinecraft().getSoundHandler().playSound(soundToPlay);
+            playSound(new GasMaskSound(player));
+        } else if (soundName.equals("flamethrower") && !flamethrowerSounds.containsKey(player)) {
+            flamethrowerSounds.put(player, true);
+            //TODO: Evaluate at some point if there is a better way to do this
+            // Currently it requests both play, except only one can ever play at once due to the shouldPlaySound method
+            playSound(new FlamethrowerSound.Active(player));
+            playSound(new FlamethrowerSound.Idle(player));
         }
     }
 

--- a/src/main/java/mekanism/client/sound/SoundHandler.java
+++ b/src/main/java/mekanism/client/sound/SoundHandler.java
@@ -25,6 +25,7 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundCategory;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
 import net.minecraftforge.client.ForgeHooksClient;
 import net.minecraftforge.client.event.sound.PlaySoundEvent;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
@@ -71,31 +72,36 @@ public class SoundHandler {
         flamethrowerSounds.remove(uuid);
     }
 
-    public static void startSound(@Nullable EntityPlayer player, SoundType soundType) {
-        if (player == null) {
-            return;
-        }
-        UUID uuid = player.getUniqueID();
+    public static void startSound(@Nonnull World world, @Nonnull UUID uuid, @Nonnull SoundType soundType) {
         switch (soundType) {
             case JETPACK:
                 if (!jetpackSounds.contains(uuid)) {
-                    jetpackSounds.add(uuid);
-                    playSound(new JetpackSound(player));
+                    EntityPlayer player = world.getPlayerEntityByUUID(uuid);
+                    if (player != null) {
+                        jetpackSounds.add(uuid);
+                        playSound(new JetpackSound(player));
+                    }
                 }
                 break;
             case GAS_MASK:
                 if (!gasmaskSounds.contains(uuid)) {
-                    gasmaskSounds.add(uuid);
-                    playSound(new GasMaskSound(player));
+                    EntityPlayer player = world.getPlayerEntityByUUID(uuid);
+                    if (player != null) {
+                        gasmaskSounds.add(uuid);
+                        playSound(new GasMaskSound(player));
+                    }
                 }
                 break;
             case FLAMETHROWER:
                 if (!flamethrowerSounds.contains(uuid)) {
-                    flamethrowerSounds.add(uuid);
-                    //TODO: Evaluate at some point if there is a better way to do this
-                    // Currently it requests both play, except only one can ever play at once due to the shouldPlaySound method
-                    playSound(new FlamethrowerSound.Active(player));
-                    playSound(new FlamethrowerSound.Idle(player));
+                    EntityPlayer player = world.getPlayerEntityByUUID(uuid);
+                    if (player != null) {
+                        flamethrowerSounds.add(uuid);
+                        //TODO: Evaluate at some point if there is a better way to do this
+                        // Currently it requests both play, except only one can ever play at once due to the shouldPlaySound method
+                        playSound(new FlamethrowerSound.Active(player));
+                        playSound(new FlamethrowerSound.Idle(player));
+                    }
                 }
                 break;
         }

--- a/src/main/java/mekanism/common/CommonPlayerTickHandler.java
+++ b/src/main/java/mekanism/common/CommonPlayerTickHandler.java
@@ -37,8 +37,8 @@ public class CommonPlayerTickHandler {
     }
 
     public static boolean isGasMaskOn(EntityPlayer player) {
-        ItemStack tank = player.inventory.armorInventory.get(2);
-        ItemStack mask = player.inventory.armorInventory.get(3);
+        ItemStack tank = player.getItemStackFromSlot(EntityEquipmentSlot.CHEST);
+        ItemStack mask = player.getItemStackFromSlot(EntityEquipmentSlot.HEAD);
         if (!tank.isEmpty() && !mask.isEmpty()) {
             if (tank.getItem() instanceof ItemScubaTank && mask.getItem() instanceof ItemGasMask) {
                 ItemScubaTank scubaTank = (ItemScubaTank) tank.getItem();
@@ -131,18 +131,20 @@ public class CommonPlayerTickHandler {
     }
 
     public boolean isJetpackOn(EntityPlayer player) {
-        ItemStack stack = player.inventory.armorInventory.get(2);
-        if (!stack.isEmpty() && !(player.isCreative() || player.isSpectator())) {
-            if (stack.getItem() instanceof ItemJetpack) {
-                ItemJetpack jetpack = (ItemJetpack) stack.getItem();
-                if (jetpack.getGas(stack) != null) {
-                    if (Mekanism.keyMap.has(player, KeySync.ASCEND) && jetpack.getMode(stack) == JetpackMode.NORMAL) {
-                        return true;
-                    } else if (jetpack.getMode(stack) == JetpackMode.HOVER) {
-                        if ((!Mekanism.keyMap.has(player, KeySync.ASCEND) && !Mekanism.keyMap.has(player, KeySync.DESCEND)) ||
-                            (Mekanism.keyMap.has(player, KeySync.ASCEND) && Mekanism.keyMap.has(player, KeySync.DESCEND))) {
-                            return !isOnGround(player);
-                        } else if (Mekanism.keyMap.has(player, KeySync.DESCEND)) {
+        if (!player.isCreative() && !player.isSpectator()) {
+            ItemStack chest = player.getItemStackFromSlot(EntityEquipmentSlot.CHEST);
+            if (!chest.isEmpty() && chest.getItem() instanceof ItemJetpack) {
+                ItemJetpack jetpack = (ItemJetpack) chest.getItem();
+                if (jetpack.getGas(chest) != null) {
+                    JetpackMode mode = jetpack.getMode(chest);
+                    if (mode == JetpackMode.NORMAL) {
+                        return Mekanism.keyMap.has(player, KeySync.ASCEND);
+                    } else if (mode == JetpackMode.HOVER) {
+                        boolean ascending = Mekanism.keyMap.has(player, KeySync.ASCEND);
+                        boolean descending = Mekanism.keyMap.has(player, KeySync.DESCEND);
+                        //if ((!ascending && !descending) || (ascending && descending) || descending)
+                        //Simplifies to
+                        if (!ascending || descending) {
                             return !isOnGround(player);
                         }
                         return true;

--- a/src/main/java/mekanism/common/PlayerState.java
+++ b/src/main/java/mekanism/common/PlayerState.java
@@ -139,6 +139,13 @@ public class PlayerState {
             activeFlamethrowers.add(uuid); // Off -> on
         }
 
+        //TODO: Fix it not enabling the idle sound when changing to a flame thrower for the first time
+        // The reason this happens is because alreadyActive is false, and isActive is false as well.
+        // Realistically, we want to remove the isActive check below as a sound plays for idle as well,
+        // and instead have this stuff run when a player is HOLDING a flame thrower. We do however, want
+        // the activeFlamethrowers set to continue working as it does so this would require a bit larger
+        // of a change and I am leaving it be for now as it is not a major bug.
+
         // If something changed and we're in a remote world, take appropriate action
         if (changed && world.isRemote) {
             // If the player is the "local" player, we need to tell the server the state has changed

--- a/src/main/java/mekanism/common/PlayerState.java
+++ b/src/main/java/mekanism/common/PlayerState.java
@@ -64,7 +64,7 @@ public class PlayerState {
 
             // Start a sound playing if the person is now flying
             if (isActive && MekanismConfig.current().client.enablePlayerSounds.val()) {
-                SoundHandler.startSound(world.getPlayerEntityByUUID(uuid), SoundType.JETPACK);
+                SoundHandler.startSound(world, uuid, SoundType.JETPACK);
             }
         }
     }
@@ -107,7 +107,7 @@ public class PlayerState {
 
             // Start a sound playing if the person is now using a gasmask
             if (isActive && MekanismConfig.current().client.enablePlayerSounds.val()) {
-                SoundHandler.startSound(world.getPlayerEntityByUUID(uuid), SoundType.GAS_MASK);
+                SoundHandler.startSound(world, uuid, SoundType.GAS_MASK);
             }
         }
     }
@@ -159,16 +159,16 @@ public class PlayerState {
             } else {
                 //Start the sound if it isn't already active, and still isn't, but has a flame thrower
                 // This allows us to catch and start playing the idle sound
-                startSound = !isActive && hasFlameThrower;
                 //TODO: Currently this only happens for the local player as "having" a flame thrower is not
-                // synced from server to client. This is not that big a deal.
+                // synced from server to client. This is not that big a deal, though may be something we want
+                // to look into eventually
+                startSound = !isActive && hasFlameThrower;
                 //Note: If they just continue to hold (but not use) a flame thrower it "will" continue having this
-                // attempt to start the sound. The uuid is checked before a sound is actually queued, however
-                // we may want to make it so that the world.getPlayerEntityByUUID is not used until we know that
-                // a player object is not needed.
+                // attempt to start the sound. This is not a major deal as the uuid gets checked before attempting
+                // to retrieve the player or actually creating a new sound object.
             }
             if (startSound && MekanismConfig.current().client.enablePlayerSounds.val()) {
-                SoundHandler.startSound(world.getPlayerEntityByUUID(uuid), SoundType.FLAMETHROWER);
+                SoundHandler.startSound(world, uuid, SoundType.FLAMETHROWER);
             }
         }
     }

--- a/src/main/java/mekanism/common/PlayerState.java
+++ b/src/main/java/mekanism/common/PlayerState.java
@@ -7,8 +7,8 @@ import mekanism.client.sound.SoundHandler;
 import mekanism.common.config.MekanismConfig;
 import mekanism.common.network.PacketFlamethrowerData.FlamethrowerDataMessage;
 import mekanism.common.network.PacketFlamethrowerData.FlamethrowerPacket;
-import mekanism.common.network.PacketJetpackData;
-import mekanism.common.network.PacketScubaTankData;
+import mekanism.common.network.PacketJetpackData.JetpackDataMessage;
+import mekanism.common.network.PacketScubaTankData.ScubaTankDataMessage;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.world.World;
 
@@ -57,7 +57,7 @@ public class PlayerState {
         if (changed && world.isRemote) {
             // If the player is the "local" player, we need to tell the server the state has changed
             if (isLocal) {
-                Mekanism.packetHandler.sendToServer(PacketJetpackData.JetpackDataMessage.UPDATE(uuid, isActive));
+                Mekanism.packetHandler.sendToServer(JetpackDataMessage.UPDATE(uuid, isActive));
             }
 
             // Start a sound playing if the person is now flying
@@ -100,7 +100,7 @@ public class PlayerState {
         if (changed && world.isRemote) {
             // If the player is the "local" player, we need to tell the server the state has changed
             if (isLocal) {
-                Mekanism.packetHandler.sendToServer(PacketScubaTankData.ScubaTankDataMessage.UPDATE(uuid, isActive));
+                Mekanism.packetHandler.sendToServer(ScubaTankDataMessage.UPDATE(uuid, isActive));
             }
 
             // Start a sound playing if the person is now using a gasmask

--- a/src/main/java/mekanism/common/item/ItemFlamethrower.java
+++ b/src/main/java/mekanism/common/item/ItemFlamethrower.java
@@ -43,8 +43,9 @@ public class ItemFlamethrower extends ItemMekanism implements IGasItem {
     }
 
     public void useGas(ItemStack stack) {
-        if (getGas(stack) != null) {
-            setGas(stack, new GasStack(getGas(stack).getGas(), getGas(stack).amount - 1));
+        GasStack gas = getGas(stack);
+        if (gas != null) {
+            setGas(stack, new GasStack(gas.getGas(), gas.amount - 1));
         }
     }
 

--- a/src/main/java/mekanism/common/item/ItemJetpack.java
+++ b/src/main/java/mekanism/common/item/ItemJetpack.java
@@ -99,7 +99,10 @@ public class ItemJetpack extends ItemArmor implements IGasItem, ISpecialArmor {
     }
 
     public void useGas(ItemStack stack) {
-        setGas(stack, new GasStack(getGas(stack).getGas(), getGas(stack).amount - 1));
+        GasStack gas = getGas(stack);
+        if (gas != null) {
+            setGas(stack, new GasStack(gas.getGas(), gas.amount - 1));
+        }
     }
 
     @Override

--- a/src/main/java/mekanism/common/item/ItemScubaTank.java
+++ b/src/main/java/mekanism/common/item/ItemScubaTank.java
@@ -86,16 +86,20 @@ public class ItemScubaTank extends ItemArmor implements IGasItem {
     }
 
     public void useGas(ItemStack itemstack) {
-        setGas(itemstack, new GasStack(getGas(itemstack).getGas(), getGas(itemstack).amount - 1));
+        GasStack gas = getGas(itemstack);
+        if (gas != null) {
+            setGas(itemstack, new GasStack(gas.getGas(), gas.amount - 1));
+        }
     }
 
     public GasStack useGas(ItemStack itemstack, int amount) {
-        if (getGas(itemstack) == null) {
+        GasStack gas = getGas(itemstack);
+        if (gas == null) {
             return null;
         }
-        Gas type = getGas(itemstack).getGas();
-        int gasToUse = Math.min(getStored(itemstack), Math.min(getRate(itemstack), amount));
-        setGas(itemstack, new GasStack(type, getStored(itemstack) - gasToUse));
+        Gas type = gas.getGas();
+        int gasToUse = Math.min(gas.amount, Math.min(getRate(itemstack), amount));
+        setGas(itemstack, new GasStack(type, gas.amount - gasToUse));
         return new GasStack(type, gasToUse);
     }
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adds some null safety to PlayerSounds and only get the player object when needed
- Fix flame thrower not playing sounds (it still doesn't play a sound when first equipped but unused for other players)
- Cleaned up various logic and method readability in ClientTickHandler and CommonPlayerTickHandler
- Keep track of which sounds we have for a player by UUID instead of EntityPlayer reference. Also use a WeakReference in PlayerSound instead of directly saving the EntityPlayer object (gracefully falls back to last known x, y, z position if the reference gets cleaned up while a reference to PlayerSound is still stored). This should allow the GC to do its job a lot better.
- Updated PacketFlamethrowerData to be like the Jetpack and GasMask ones in terms of MODE_CHANGE, UPDATE, and FULL options

I did do some testing, though it would probably not hurt to double check some of the logic/test more thoroughly on multiplayer.

One other thing to note I believe that at least one case where the player looked up is null may have to do with the fact I believe it syncs data for clients in all dimensions not just the one that is the same as our player. Not sure if/where we should catch that if we decide to but for the most part I believe these changes improve the handling of the various player sounds.