### PR TITLE
Atomic Disassembler config

### DIFF
--- a/src/main/java/mekanism/common/config/GeneralConfig.java
+++ b/src/main/java/mekanism/common/config/GeneralConfig.java
@@ -106,19 +106,19 @@ public class GeneralConfig extends BaseConfig {
     public final DoubleOption ENERGY_PER_REDSTONE = new DoubleOption(this, "general", "EnergyPerRedstone", 10000D,
           "How much energy (Joules) a piece of redstone gives in machines.");
 
-    public final IntOption DISASSEMBLER_USAGE = new IntOption(this, "general", "DisassemblerEnergyUsage", 10,
+    public final IntOption disassemblerEnergyUsage = new IntOption(this, "general", "DisassemblerEnergyUsage", 10,
           "Base Energy (Joules) usage of the Atomic Disassembler. (Gets multiplied by speed factor)", 0, 1000000);
 
-    public final IntOption DISASSEMBLER_HOE_USAGE = new IntOption(this, "general", "DisassemblerEnergyUsageHoe", 10,
+    public final IntOption disassemblerEnergyUsageHoe = new IntOption(this, "general", "DisassemblerEnergyUsageHoe", 10,
           "Cost in Joules of using the Atomic Disassembler as a hoe.", 0, 1000000);
 
-    public final IntOption DISASSEMBLER_WEAPON_USAGE = new IntOption(this, "general", "DisassemblerEnergyUsageWeapon", 2000,
+    public final IntOption disassemblerEnergyUsageWeapon = new IntOption(this, "general", "DisassemblerEnergyUsageWeapon", 2000,
           "Cost in Joules of using the Atomic Disassembler as a weapon.", 0, 1000000);
 
-    public final IntOption DISASSEMBLER_DAMAGE_MIN = new IntOption(this, "general", "DisassemblerDamageMin", 4,
+    public final IntOption disassemblerDamageMin = new IntOption(this, "general", "DisassemblerDamageMin", 4,
           "The amount of damage the Atomic Disassembler does when it is out of power. (Value is in number of half hearts)");
 
-    public final IntOption DISASSEMBLER_DAMAGE_MAX = new IntOption(this, "general", "DisassemblerDamageMax", 20,
+    public final IntOption disassemblerDamageMax = new IntOption(this, "general", "DisassemblerDamageMax", 20,
           "The amount of damage the Atomic Disassembler does when it has at least DisassemblerEnergyUsageWeapon power stored. (Value is in number of half hearts)");
 
     public final IntOption VOICE_PORT = new IntOption(this, "general", "VoicePort", 36123,

--- a/src/main/java/mekanism/common/config/GeneralConfig.java
+++ b/src/main/java/mekanism/common/config/GeneralConfig.java
@@ -107,13 +107,13 @@ public class GeneralConfig extends BaseConfig {
           "How much energy (Joules) a piece of redstone gives in machines.");
 
     public final IntOption disassemblerEnergyUsage = new IntOption(this, "general", "DisassemblerEnergyUsage", 10,
-          "Base Energy (Joules) usage of the Atomic Disassembler. (Gets multiplied by speed factor)", 0, 1000000);
+          "Base Energy (Joules) usage of the Atomic Disassembler. (Gets multiplied by speed factor)");
 
     public final IntOption disassemblerEnergyUsageHoe = new IntOption(this, "general", "DisassemblerEnergyUsageHoe", 10,
-          "Cost in Joules of using the Atomic Disassembler as a hoe.", 0, 1000000);
+          "Cost in Joules of using the Atomic Disassembler as a hoe.");
 
     public final IntOption disassemblerEnergyUsageWeapon = new IntOption(this, "general", "DisassemblerEnergyUsageWeapon", 2000,
-          "Cost in Joules of using the Atomic Disassembler as a weapon.", 0, 1000000);
+          "Cost in Joules of using the Atomic Disassembler as a weapon.");
 
     public final IntOption disassemblerDamageMin = new IntOption(this, "general", "DisassemblerDamageMin", 4,
           "The amount of damage the Atomic Disassembler does when it is out of power. (Value is in number of half hearts)");

--- a/src/main/java/mekanism/common/config/GeneralConfig.java
+++ b/src/main/java/mekanism/common/config/GeneralConfig.java
@@ -121,6 +121,8 @@ public class GeneralConfig extends BaseConfig {
     public final IntOption disassemblerDamageMax = new IntOption(this, "general", "DisassemblerDamageMax", 20,
           "The amount of damage the Atomic Disassembler does when it has at least DisassemblerEnergyUsageWeapon power stored. (Value is in number of half hearts)");
 
+    public final DoubleOption disassemblerBatteryCapacity = new DoubleOption(this, "general", "DisassemblerBatteryCapacity", 1000000, "Maximum amount (joules) of energy the Atomic Disassembler can contain", 0, Double.MAX_VALUE).setRequiresGameRestart(true);
+
     public final IntOption VOICE_PORT = new IntOption(this, "general", "VoicePort", 36123,
           "TCP port for the Voice server to listen on.", 1, 65535);
 

--- a/src/main/java/mekanism/common/config/GeneralConfig.java
+++ b/src/main/java/mekanism/common/config/GeneralConfig.java
@@ -107,7 +107,19 @@ public class GeneralConfig extends BaseConfig {
           "How much energy (Joules) a piece of redstone gives in machines.");
 
     public final IntOption DISASSEMBLER_USAGE = new IntOption(this, "general", "DisassemblerEnergyUsage", 10,
-          "Base Energy (Joules) usage of the Atomic Disassembler. (Gets multiplied by speed factor)");
+          "Base Energy (Joules) usage of the Atomic Disassembler. (Gets multiplied by speed factor)", 0, 1000000);
+
+    public final IntOption DISASSEMBLER_HOE_USAGE = new IntOption(this, "general", "DisassemblerEnergyUsageHoe", 10,
+          "Cost in Joules of using the Atomic Disassembler as a hoe.", 0, 1000000);
+
+    public final IntOption DISASSEMBLER_WEAPON_USAGE = new IntOption(this, "general", "DisassemblerEnergyUsageWeapon", 2000,
+          "Cost in Joules of using the Atomic Disassembler as a weapon.", 0, 1000000);
+
+    public final IntOption DISASSEMBLER_DAMAGE_MIN = new IntOption(this, "general", "DisassemblerDamageMin", 4,
+          "The amount of damage the Atomic Disassembler does when it is out of power. (Value is in number of half hearts)");
+
+    public final IntOption DISASSEMBLER_DAMAGE_MAX = new IntOption(this, "general", "DisassemblerDamageMax", 20,
+          "The amount of damage the Atomic Disassembler does when it has at least DisassemblerEnergyUsageWeapon power stored. (Value is in number of half hearts)");
 
     public final IntOption VOICE_PORT = new IntOption(this, "general", "VoicePort", 36123,
           "TCP port for the Voice server to listen on.", 1, 65535);

--- a/src/main/java/mekanism/common/item/ItemAtomicDisassembler.java
+++ b/src/main/java/mekanism/common/item/ItemAtomicDisassembler.java
@@ -68,9 +68,9 @@ public class ItemAtomicDisassembler extends ItemEnergized {
     @Override
     public boolean hitEntity(ItemStack itemstack, EntityLivingBase target, EntityLivingBase attacker) {
         double energy = getEnergy(itemstack);
-        int energyCost = MekanismConfig.current().general.DISASSEMBLER_WEAPON_USAGE.val();
-        int minDamage = MekanismConfig.current().general.DISASSEMBLER_DAMAGE_MIN.val();
-        int damageDifference = MekanismConfig.current().general.DISASSEMBLER_DAMAGE_MAX.val() - minDamage;
+        int energyCost = MekanismConfig.current().general.disassemblerEnergyUsageWeapon.val();
+        int minDamage = MekanismConfig.current().general.disassemblerDamageMin.val();
+        int damageDifference = MekanismConfig.current().general.disassemblerDamageMax.val() - minDamage;
         //If we don't have enough power use it at a reduced power level
         double percent = energyCost == 0 ? 1 : energy / energyCost;
         float damage = (float) (minDamage + damageDifference * percent);
@@ -190,7 +190,7 @@ public class ItemAtomicDisassembler extends ItemEnergized {
 
     private EnumActionResult useItemAs(EntityPlayer player, World world, BlockPos pos, EnumFacing side, ItemStack stack, int diameter, ItemUseConsumer consumer) {
         double energy = getEnergy(stack);
-        int hoeUsage = MekanismConfig.current().general.DISASSEMBLER_HOE_USAGE.val();
+        int hoeUsage = MekanismConfig.current().general.disassemblerEnergyUsageHoe.val();
         if (energy < hoeUsage || consumer.use(stack, player, world, pos, side) == EnumActionResult.FAIL) {
             //Fail if we don't have enough energy or using the item failed
             return EnumActionResult.FAIL;
@@ -264,7 +264,7 @@ public class ItemAtomicDisassembler extends ItemEnergized {
     }
 
     private int getDestroyEnergy(ItemStack itemStack, float hardness) {
-        int destroyEnergy = MekanismConfig.current().general.DISASSEMBLER_USAGE.val() * getMode(itemStack).getEfficiency();
+        int destroyEnergy = MekanismConfig.current().general.disassemblerEnergyUsage.val() * getMode(itemStack).getEfficiency();
         return hardness == 0 ? destroyEnergy / 2 : destroyEnergy;
     }
 

--- a/src/main/java/mekanism/common/item/ItemAtomicDisassembler.java
+++ b/src/main/java/mekanism/common/item/ItemAtomicDisassembler.java
@@ -72,7 +72,10 @@ public class ItemAtomicDisassembler extends ItemEnergized {
         int minDamage = MekanismConfig.current().general.disassemblerDamageMin.val();
         int damageDifference = MekanismConfig.current().general.disassemblerDamageMax.val() - minDamage;
         //If we don't have enough power use it at a reduced power level
-        double percent = energyCost == 0 ? 1 : energy / energyCost;
+        double percent = 1;
+        if (energy < energyCost && energyCost != 0) {
+            percent = energy / energyCost;
+        }
         float damage = (float) (minDamage + damageDifference * percent);
         if (attacker instanceof EntityPlayer) {
             target.attackEntityFrom(DamageSource.causePlayerDamage((EntityPlayer) attacker), damage);

--- a/src/main/java/mekanism/common/item/ItemAtomicDisassembler.java
+++ b/src/main/java/mekanism/common/item/ItemAtomicDisassembler.java
@@ -48,7 +48,7 @@ import net.minecraftforge.items.ItemHandlerHelper;
 public class ItemAtomicDisassembler extends ItemEnergized {
 
     public ItemAtomicDisassembler() {
-        super(1000000);
+        super(MekanismConfig.current().general.disassemblerBatteryCapacity.val());
     }
 
     @Override

--- a/src/main/java/mekanism/common/item/ItemAtomicDisassembler.java
+++ b/src/main/java/mekanism/common/item/ItemAtomicDisassembler.java
@@ -264,12 +264,8 @@ public class ItemAtomicDisassembler extends ItemEnergized {
     }
 
     private int getDestroyEnergy(ItemStack itemStack, float hardness) {
-        int destroyEnergy = getDestroyEnergy(itemStack);
+        int destroyEnergy = MekanismConfig.current().general.DISASSEMBLER_USAGE.val() * getMode(itemStack).getEfficiency();
         return hardness == 0 ? destroyEnergy / 2 : destroyEnergy;
-    }
-
-    private int getDestroyEnergy(ItemStack itemStack) {
-        return MekanismConfig.current().general.DISASSEMBLER_USAGE.val() * getMode(itemStack).getEfficiency();
     }
 
     public Mode getMode(ItemStack itemStack) {

--- a/src/main/java/mekanism/common/item/ItemAtomicDisassembler.java
+++ b/src/main/java/mekanism/common/item/ItemAtomicDisassembler.java
@@ -277,7 +277,7 @@ public class ItemAtomicDisassembler extends ItemEnergized {
 
     public void toggleMode(ItemStack itemStack) {
         Mode mode = getMode(itemStack);
-        ItemDataUtils.setInt(itemStack, "mode", mode.ordinal() + 1 < Mode.values().length ? mode.ordinal() + 1 : 0);
+        ItemDataUtils.setInt(itemStack, "mode", (mode.ordinal() + 1) % Mode.values().length);
     }
 
     @Override


### PR DESCRIPTION
## Changes proposed in this pull request:
- Cleaned up the code for `ItemAtomicDisassembler`
- Added config options (#5571, #5481) for min, max damage and energy cost for attacking and using the Disassembler as a hoe (or shovel for grass to grass path).
  - Previously it seemed that there was a value stored for how much power using the disassembler as a hoe should cost, but it did not seem to be used anywhere, so now there is, and it stops early in AOE hoeing if it stops having enough power to continue.
  - Changed how damage works at power levels < 2000 for the atomic disassembler. Previously if the disassembler had 1000 energy remaining it would do full damage (10 hearts) and then drain the disassembler. Now it will do 6 hearts before draining the disassembler.
- Extracted information pertaining to the `Mode` of the disassembler to an enum so that it is easier to add new values/change them. I currently do not have any config options setup to change the efficiencies/range of various modes but that is potentially something we can do in the future.