### PR TITLE
Minor cleanup

### DIFF
--- a/src/main/java/mekanism/api/gas/GasTank.java
+++ b/src/main/java/mekanism/api/gas/GasTank.java
@@ -141,6 +141,7 @@ public class GasTank implements GasTankInfo {
      *
      * @return - max gas
      */
+    @Override
     public int getMaxGas() {
         return maxGas;
     }
@@ -157,6 +158,7 @@ public class GasTank implements GasTankInfo {
      *
      * @return - GasStakc held by this tank
      */
+    @Override
     public GasStack getGas() {
         return stored;
     }
@@ -190,6 +192,7 @@ public class GasTank implements GasTankInfo {
      *
      * @return amount of gas stored
      */
+    @Override
     public int getStored() {
         return stored != null ? stored.amount : 0;
     }

--- a/src/main/java/mekanism/client/ClientProxy.java
+++ b/src/main/java/mekanism/client/ClientProxy.java
@@ -702,7 +702,7 @@ public class ClientProxy extends CommonProxy {
                 if (stack.getItem() instanceof ItemSeismicReader) {
                     return new GuiSeismicReader(player.world, new Coord4D(player), stack.copy());
                 }
-            break;
+                break;
         }
         return null;
     }

--- a/src/main/java/mekanism/client/ClientProxy.java
+++ b/src/main/java/mekanism/client/ClientProxy.java
@@ -895,7 +895,7 @@ public class ClientProxy extends CommonProxy {
         doSparkle(tileEntity, new SparkleAnimation(tileEntity, renderLoc, length, width, height, checker));
     }
 
-
+    @Override
     public void doMultiblockSparkle(TileEntity tileEntity, BlockPos corner1, BlockPos corner2, INodeChecker checker) {
         doSparkle(tileEntity, new SparkleAnimation(tileEntity, corner1, corner2, checker));
     }

--- a/src/main/java/mekanism/client/gui/GuiAdvancedElectricMachine.java
+++ b/src/main/java/mekanism/client/gui/GuiAdvancedElectricMachine.java
@@ -68,7 +68,7 @@ public class GuiAdvancedElectricMachine<RECIPE extends AdvancedMachineRecipe<REC
         int yAxis = mouseY - guiTop;
         if (xAxis >= 61 && xAxis <= 67 && yAxis >= 37 && yAxis <= 49) {
             displayTooltip(tileEntity.gasTank.getGas() != null ? tileEntity.gasTank.getGas().getGas().getLocalizedName() + ": " + tileEntity.gasTank.getStored()
-                                                                 : LangUtils.localize("gui.none"), xAxis, yAxis);
+                                                               : LangUtils.localize("gui.none"), xAxis, yAxis);
         }
         super.drawGuiContainerForegroundLayer(mouseX, mouseY);
     }

--- a/src/main/java/mekanism/client/gui/GuiMetallurgicInfuser.java
+++ b/src/main/java/mekanism/client/gui/GuiMetallurgicInfuser.java
@@ -68,7 +68,7 @@ public class GuiMetallurgicInfuser extends GuiMekanismTile<TileEntityMetallurgic
         int yAxis = mouseY - guiTop;
         if (xAxis >= 7 && xAxis <= 11 && yAxis >= 17 && yAxis <= 69) {
             displayTooltip(tileEntity.infuseStored.getType() != null ? tileEntity.infuseStored.getType().getLocalizedName() + ": " + tileEntity.infuseStored.getAmount()
-                                                                       : LangUtils.localize("gui.empty"), xAxis, yAxis);
+                                                                     : LangUtils.localize("gui.empty"), xAxis, yAxis);
         }
         super.drawGuiContainerForegroundLayer(mouseX, mouseY);
     }

--- a/src/main/java/mekanism/common/block/BlockBasic.java
+++ b/src/main/java/mekanism/common/block/BlockBasic.java
@@ -760,6 +760,7 @@ public abstract class BlockBasic extends BlockTileDrops {
             return block == Blocks.OBSIDIAN || type == BasicBlockType.REFINED_OBSIDIAN;
         }
 
+        @Override
         protected int getDistanceUntilEdge(BlockPos pos, @Nonnull EnumFacing facing) {
             int i;
             for (i = 0; i < 22; ++i) {
@@ -771,6 +772,7 @@ public abstract class BlockBasic extends BlockTileDrops {
             return isFrame(this.world.getBlockState(pos.offset(facing, i))) ? i : 0;
         }
 
+        @Override
         protected int calculatePortalHeight() {
             label56:
             for (this.height = 0; this.height < 21; ++this.height) {

--- a/src/main/java/mekanism/common/config/GeneralConfig.java
+++ b/src/main/java/mekanism/common/config/GeneralConfig.java
@@ -114,12 +114,12 @@ public class GeneralConfig extends BaseConfig {
 
     public final IntOption disassemblerEnergyUsageWeapon = new IntOption(this, "general", "DisassemblerEnergyUsageWeapon", 2000,
           "Cost in Joules of using the Atomic Disassembler as a weapon.");
-  
+
     public final IntOption disassemblerMiningRange = new IntOption(this, "general", "DisassemblerMiningRange", 10,
-            "The Range of the Atomic Disassembler Extended Vein Mining.");
+          "The Range of the Atomic Disassembler Extended Vein Mining.");
 
     public final IntOption disassemblerMiningCount = new IntOption(this, "general", "DisassemblerMiningCount", 128,
-            "The max Atomic Disassembler Vein Mining Block Count.");
+          "The max Atomic Disassembler Vein Mining Block Count.");
 
     public final BooleanOption disassemblerSlowMode = new BooleanOption(this, "general", "DisassemblerSlowMode", true,
           "Enable the 'Slow' mode for the Atomic Disassembler.");
@@ -131,7 +131,7 @@ public class GeneralConfig extends BaseConfig {
           "Enable the 'Vein Mining' mode for the Atomic Disassembler.");
 
     public final BooleanOption disassemblerExtendedMining = new BooleanOption(this, "general", "DisassemblerExtendedMiningMode", true,
-            "Enable the 'Extended Vein Mining' mode for the Atomic Disassembler. (Allows vein mining everything not just ores/logs)");
+          "Enable the 'Extended Vein Mining' mode for the Atomic Disassembler. (Allows vein mining everything not just ores/logs)");
 
     public final IntOption disassemblerDamageMin = new IntOption(this, "general", "DisassemblerDamageMin", 4,
           "The amount of damage the Atomic Disassembler does when it is out of power. (Value is in number of half hearts)");

--- a/src/main/java/mekanism/common/content/transporter/TItemStackFilter.java
+++ b/src/main/java/mekanism/common/content/transporter/TItemStackFilter.java
@@ -35,6 +35,7 @@ public class TItemStackFilter extends TransporterFilter implements IItemStackFil
         return super.getStackFromInventory(searcher, singleItem);
     }
 
+    @Override
     public Finder getFinder() {
         return new ItemStackFinder(itemType);
     }

--- a/src/main/java/mekanism/common/entity/EntityBabySkeleton.java
+++ b/src/main/java/mekanism/common/entity/EntityBabySkeleton.java
@@ -58,6 +58,7 @@ public class EntityBabySkeleton extends EntitySkeleton {
     }
 
     //copied from base entity, as abstractskeleton overrides it
+    @Override
     public float getEyeHeight() {
         return this.height * 0.85F;
     }

--- a/src/main/java/mekanism/common/integration/crafttweaker/gas/IGasStack.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/gas/IGasStack.java
@@ -21,14 +21,7 @@ public interface IGasStack extends IIngredient {
     @ZenGetter("displayName")
     String getDisplayName();
 
-    @Override
-    @ZenGetter("amount")
-    int getAmount();
-
     @ZenOperator(OperatorType.MUL)
     @ZenMethod
     IGasStack withAmount(int amount);
-
-    @Override
-    Object getInternal();
 }

--- a/src/main/java/mekanism/common/integration/crafttweaker/gas/IGasStack.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/gas/IGasStack.java
@@ -21,6 +21,7 @@ public interface IGasStack extends IIngredient {
     @ZenGetter("displayName")
     String getDisplayName();
 
+    @Override
     @ZenGetter("amount")
     int getAmount();
 
@@ -28,5 +29,6 @@ public interface IGasStack extends IIngredient {
     @ZenMethod
     IGasStack withAmount(int amount);
 
+    @Override
     Object getInternal();
 }

--- a/src/main/java/mekanism/common/integration/forgeenergy/ForgeEnergyCableIntegration.java
+++ b/src/main/java/mekanism/common/integration/forgeenergy/ForgeEnergyCableIntegration.java
@@ -1,8 +1,6 @@
 package mekanism.common.integration.forgeenergy;
 
-import mekanism.common.config.MekanismConfig;
 import mekanism.common.tile.transmitter.TileEntityUniversalCable;
-import mekanism.common.util.MekanismUtils;
 import net.minecraft.util.EnumFacing;
 import net.minecraftforge.energy.IEnergyStorage;
 

--- a/src/main/java/mekanism/common/integration/tesla/TeslaCableIntegration.java
+++ b/src/main/java/mekanism/common/integration/tesla/TeslaCableIntegration.java
@@ -1,6 +1,5 @@
 package mekanism.common.integration.tesla;
 
-import mekanism.common.config.MekanismConfig;
 import mekanism.common.integration.MekanismHooks;
 import mekanism.common.tile.transmitter.TileEntityUniversalCable;
 import net.darkhax.tesla.api.ITeslaConsumer;

--- a/src/main/java/mekanism/common/inventory/InventoryList.java
+++ b/src/main/java/mekanism/common/inventory/InventoryList.java
@@ -65,6 +65,7 @@ public class InventoryList implements IInventory {
     /**
      * Sets the given item stack to the specified slot in the inventory (can be crafting or armor sections).
      */
+    @Override
     public void setInventorySlotContents(int index, @Nonnull ItemStack stack) {
         this.inventoryContents.set(index, stack);
         if (!stack.isEmpty() && stack.getCount() > this.getInventoryStackLimit()) {
@@ -76,10 +77,12 @@ public class InventoryList implements IInventory {
     /**
      * Returns the number of slots in the inventory.
      */
+    @Override
     public int getSizeInventory() {
         return this.slotsCount;
     }
 
+    @Override
     public boolean isEmpty() {
         for (ItemStack itemstack : this.inventoryContents) {
             if (!itemstack.isEmpty()) {
@@ -101,6 +104,7 @@ public class InventoryList implements IInventory {
     /**
      * Returns true if this thing is named
      */
+    @Override
     public boolean hasCustomName() {
         return false;
     }
@@ -123,6 +127,7 @@ public class InventoryList implements IInventory {
     /**
      * Returns the maximum stack size for a inventory slot. Seems to always be 64, possibly will be extended.
      */
+    @Override
     public int getInventoryStackLimit() {
         return 64;
     }
@@ -130,6 +135,7 @@ public class InventoryList implements IInventory {
     /**
      * For tile entities, ensures the chunk containing the tile entity is saved to disk later - the game won't think it hasn't changed and skip it.
      */
+    @Override
     public void markDirty() {
         this.te.markDirty();
     }
@@ -137,34 +143,42 @@ public class InventoryList implements IInventory {
     /**
      * Don't rename this method to canInteractWith due to conflicts with Container
      */
+    @Override
     public boolean isUsableByPlayer(@Nonnull EntityPlayer player) {
         return true;
     }
 
+    @Override
     public void openInventory(@Nonnull EntityPlayer player) {
     }
 
+    @Override
     public void closeInventory(@Nonnull EntityPlayer player) {
     }
 
     /**
      * Returns true if automation is allowed to insert the given stack (ignoring stack size) into the given slot. For guis use Slot.isItemValid
      */
+    @Override
     public boolean isItemValidForSlot(int index, @Nonnull ItemStack stack) {
         return true;
     }
 
+    @Override
     public int getField(int id) {
         return 0;
     }
 
+    @Override
     public void setField(int id, int value) {
     }
 
+    @Override
     public int getFieldCount() {
         return 0;
     }
 
+    @Override
     public void clear() {
         this.inventoryContents.clear();
     }

--- a/src/main/java/mekanism/common/item/ItemAtomicDisassembler.java
+++ b/src/main/java/mekanism/common/item/ItemAtomicDisassembler.java
@@ -325,7 +325,7 @@ public class ItemAtomicDisassembler extends ItemEnergized {
          * Gets a Mode from its ordinal. NOTE: if this mode is not enabled then it will reset to NORMAL
          */
         public static Mode getFromInt(int ordinal) {
-            Mode[] values = Mode.values();
+            Mode[] values = values();
             //If it is out of bounds just shift it as if it had gone around that many times
             Mode mode = values[ordinal % values.length];
             return mode.isEnabled() ? mode : NORMAL;

--- a/src/main/java/mekanism/common/recipe/machines/AmbientGasRecipe.java
+++ b/src/main/java/mekanism/common/recipe/machines/AmbientGasRecipe.java
@@ -15,6 +15,7 @@ public class AmbientGasRecipe extends MachineRecipe<IntegerInput, GasOutput, Amb
         this(new IntegerInput(input), new GasOutput(new GasStack(GasRegistry.getGas(output), 1)));
     }
 
+    @Override
     public AmbientGasRecipe copy() {
         return new AmbientGasRecipe(getInput().copy(), getOutput().copy());
     }

--- a/src/main/java/mekanism/common/tile/TileEntityBin.java
+++ b/src/main/java/mekanism/common/tile/TileEntityBin.java
@@ -561,6 +561,7 @@ public class TileEntityBin extends TileEntityBasicBlock implements ISidedInvento
         }
 
         @Nonnull
+        @Override
         public ItemStack extractItem(int slot, int amount, boolean simulate) {
             return slot != 0 ? ItemStack.EMPTY : tileEntityBin.remove(amount, simulate);
         }

--- a/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
+++ b/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
@@ -1051,6 +1051,7 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
         return getBlockType().getTranslationKey() + "." + fullName + ".name";
     }
 
+    @Override
     public void writeSustainedData(ItemStack itemStack) {
         ItemDataUtils.setBoolean(itemStack, "hasMinerConfig", true);
 

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityEffectsBlock.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityEffectsBlock.java
@@ -146,6 +146,7 @@ public abstract class TileEntityEffectsBlock extends TileEntityElectricBlock imp
         }
     }
 
+    @Override
     public boolean wasActiveRecently() {
         // If the machine is currently active or it flipped off within our threshold,
         // we'll consider it recently active.

--- a/src/main/java/mekanism/common/transmitters/grid/EnergyNetwork.java
+++ b/src/main/java/mekanism/common/transmitters/grid/EnergyNetwork.java
@@ -57,6 +57,7 @@ public class EnergyNetwork extends DynamicNetwork<EnergyAcceptorWrapper, EnergyN
     }
 
     @Nullable
+    @Override
     public EnergyStack getBuffer() {
         return buffer;
     }

--- a/src/main/java/mekanism/common/transmitters/grid/FluidNetwork.java
+++ b/src/main/java/mekanism/common/transmitters/grid/FluidNetwork.java
@@ -69,6 +69,7 @@ public class FluidNetwork extends DynamicNetwork<IFluidHandler, FluidNetwork, Fl
     }
 
     @Nullable
+    @Override
     public FluidStack getBuffer() {
         return buffer;
     }

--- a/src/main/java/mekanism/common/transmitters/grid/GasNetwork.java
+++ b/src/main/java/mekanism/common/transmitters/grid/GasNetwork.java
@@ -85,6 +85,7 @@ public class GasNetwork extends DynamicNetwork<IGasHandler, GasNetwork, GasStack
     }
 
     @Nullable
+    @Override
     public GasStack getBuffer() {
         return buffer;
     }

--- a/src/main/java/mekanism/common/util/GasUtils.java
+++ b/src/main/java/mekanism/common/util/GasUtils.java
@@ -28,9 +28,8 @@ public final class GasUtils {
 
     public static IGasHandler[] getConnectedAcceptors(BlockPos pos, World world, Set<EnumFacing> sides) {
         final IGasHandler[] acceptors = new IGasHandler[]{null, null, null, null, null, null};
-        EmitUtils.forEachSide(world, pos, sides, (tile, side) -> {
-            acceptors[side.ordinal()] = CapabilityUtils.getCapability(tile, Capabilities.GAS_HANDLER_CAPABILITY, side.getOpposite());
-        });
+        EmitUtils.forEachSide(world, pos, sides, (tile, side) ->
+              acceptors[side.ordinal()] = CapabilityUtils.getCapability(tile, Capabilities.GAS_HANDLER_CAPABILITY, side.getOpposite()));
         return acceptors;
     }
 

--- a/src/main/java/mekanism/common/util/PipeUtils.java
+++ b/src/main/java/mekanism/common/util/PipeUtils.java
@@ -48,9 +48,8 @@ public final class PipeUtils {
      */
     public static IFluidHandler[] getConnectedAcceptors(BlockPos pos, World world) {
         final IFluidHandler[] acceptors = new IFluidHandler[]{null, null, null, null, null, null};
-        EmitUtils.forEachSide(world, pos, EnumSet.allOf(EnumFacing.class), (tile, side) -> {
-            acceptors[side.ordinal()] = CapabilityUtils.getCapability(tile, CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, side.getOpposite());
-        });
+        EmitUtils.forEachSide(world, pos, EnumSet.allOf(EnumFacing.class), (tile, side) ->
+              acceptors[side.ordinal()] = CapabilityUtils.getCapability(tile, CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, side.getOpposite()));
         return acceptors;
     }
 

--- a/src/main/java/mekanism/generators/client/gui/GuiIndustrialTurbine.java
+++ b/src/main/java/mekanism/generators/client/gui/GuiIndustrialTurbine.java
@@ -82,8 +82,8 @@ public class GuiIndustrialTurbine extends GuiEmbeddedGaugeTile<TileEntityTurbine
             int yAxis = mouseY - guiTop;
             if (xAxis >= 7 && xAxis <= 39 && yAxis >= 14 && yAxis <= 72) {
                 displayTooltip(tileEntity.structure.fluidStored != null
-                                 ? LangUtils.localizeFluidStack(tileEntity.structure.fluidStored) + ": " + tileEntity.structure.fluidStored.amount + "mB"
-                                 : LangUtils.localize("gui.empty"), xAxis, yAxis);
+                               ? LangUtils.localizeFluidStack(tileEntity.structure.fluidStored) + ": " + tileEntity.structure.fluidStored.amount + "mB"
+                               : LangUtils.localize("gui.empty"), xAxis, yAxis);
             }
         }
         super.drawGuiContainerForegroundLayer(mouseX, mouseY);

--- a/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorController.java
+++ b/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorController.java
@@ -61,6 +61,7 @@ public class TileEntityReactorController extends TileEntityReactorBlock implemen
         inventory = NonNullList.withSize(1, ItemStack.EMPTY);
     }
 
+    @Override
     public boolean isFrame() {
         return false;
     }

--- a/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorLogicAdapter.java
+++ b/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorLogicAdapter.java
@@ -36,6 +36,7 @@ public class TileEntityReactorLogicAdapter extends TileEntityReactorBlock implem
         }
     }
 
+    @Override
     public boolean isFrame() {
         return false;
     }

--- a/src/main/resources/mekanism_at.cfg
+++ b/src/main/resources/mekanism_at.cfg
@@ -1,7 +1,3 @@
-
-#net.minecraft.client.Minecraft
-public net.minecraft.client.Minecraft field_71428_T #timer
-
 #net.minecraft.client.gui.inventory.GuiContainer
 public net.minecraft.client.gui.inventory.GuiContainer field_146999_f #xSize
 public net.minecraft.client.gui.inventory.GuiContainer field_147000_g #ySize
@@ -13,19 +9,6 @@ public net.minecraft.network.NetHandlerPlayServer field_147365_f #floatingTickCo
 
 #net.minecraft.client.audio.SoundHandler
 public net.minecraft.client.audio.SoundHandler field_147694_f #sndManager
-
-#net.minecraft.client.audio.SoundManager
-public net.minecraft.client.audio.SoundManager field_148630_i #invPlayingSounds
-#unused: public net.minecraft.client.audio.SoundManager field_148620_e #sndSystem
-
-#net.minecraft.client.entity.AbstractClientPlayer
-public net.minecraft.client.entity.AbstractClientPlayer func_175155_b()Lnet/minecraft/client/network/NetworkPlayerInfo; #getPlayerInfo
-
-#net.minecraft.client.network.NetworkPlayerInfo
-public net.minecraft.client.network.NetworkPlayerInfo field_187107_a #playerTextures
-
-#net.minecraft.entity.Entity
-public net.minecraft.entity.Entity func_180432_n(Lnet/minecraft/entity/Entity;)V #copyDataFromOld
 
 #net.minecraft.client.renderer.BufferBuilder
 public net.minecraft.client.renderer.BufferBuilder field_179010_r #isDrawing


### PR DESCRIPTION
## Changes proposed in this pull request:
Minor cleanup to code, removing unused access transformers and ensuring that all methods that override another have the `@Override` annotation. Should make it easier to not lose track of things when porting to 1.14 if the mappings change.