### PR TITLE
Fix network connections across chunk loading

### DIFF
--- a/src/main/java/mekanism/common/tile/transmitter/TileEntitySidedPipe.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntitySidedPipe.java
@@ -419,6 +419,16 @@ public abstract class TileEntitySidedPipe extends TileEntity implements ITileNet
      * @param newlyEnabledTransmitters The transmitters that are now enabled and were not before.
      */
     protected void recheckConnections(byte newlyEnabledTransmitters) {
+        //If our connectivity changed on a side and it is also a sided pipe, inform it to recheck its connections
+        //This fixes pipes not reconnecting cross chunk
+        for (EnumFacing side : EnumFacing.VALUES) {
+            if (connectionMapContainsSide(newlyEnabledTransmitters, side)) {
+                TileEntity tileEntity = MekanismUtils.getTileEntity(world, getPos().offset(side));
+                if (tileEntity instanceof TileEntitySidedPipe) {
+                    ((TileEntitySidedPipe) tileEntity).refreshConnections();
+                }
+            }
+        }
     }
 
     /**

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityTransmitter.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityTransmitter.java
@@ -113,19 +113,24 @@ public abstract class TileEntityTransmitter<A, N extends DynamicNetwork<A, N, BU
 
     @Override
     protected void recheckConnections(byte newlyEnabledTransmitters) {
-        if (canHaveIncompatibleNetworks() && getTransmitter().hasTransmitterNetwork()) {
-            //We only need to check if we can have incompatible networks and if we actually have a network
-            boolean networkUpdated = false;
-            for (EnumFacing side : EnumFacing.VALUES) {
-                if (connectionMapContainsSide(newlyEnabledTransmitters, side)) {
-                    //Recheck the side that is now enabled, as we manually merge this
-                    // cannot be simplified to a first match is good enough
-                    networkUpdated |= recheckConnectionPrechecked(side);
+        if (getTransmitter().hasTransmitterNetwork()) {
+            if (canHaveIncompatibleNetworks()) {
+                //We only need to check if we can have incompatible networks and if we actually have a network
+                boolean networkUpdated = false;
+                for (EnumFacing side : EnumFacing.VALUES) {
+                    if (connectionMapContainsSide(newlyEnabledTransmitters, side)) {
+                        //Recheck the side that is now enabled, as we manually merge this
+                        // cannot be simplified to a first match is good enough
+                        networkUpdated |= recheckConnectionPrechecked(side);
+                    }
+                }
+                if (networkUpdated) {
+                    refreshNetwork();
                 }
             }
-            if (networkUpdated) {
-                refreshNetwork();
-            }
+        } else {
+            //If we don't have a transmitter network then recheck connection status both ways
+            super.recheckConnections(newlyEnabledTransmitters);
         }
     }
 


### PR DESCRIPTION
## Changes proposed in this pull request:
Reconnect pipes across chunks when the chunk loads. This is the more proper fix to #4676 that I had thought was fixed, but once the network ghost chunk loading got fixed resurfaced. It was very easy to reproduce now that there is no ghost chunk loading so writing a fix was simple. The networks already were fixing themselves; however, the pipes across chunks were not getting properly informed to update their "connections" as well.