### PR TITLE
Energy conversion code deduplication

### DIFF
--- a/src/main/java/mekanism/common/FuelHandler.java
+++ b/src/main/java/mekanism/common/FuelHandler.java
@@ -6,7 +6,7 @@ import buildcraft.api.mj.MjAPI;
 import java.util.HashMap;
 import java.util.Map;
 import mekanism.api.gas.Gas;
-import mekanism.common.config.MekanismConfig;
+import mekanism.common.integration.redstoneflux.RFIntegration;
 import mekanism.common.util.MekanismUtils;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
@@ -55,7 +55,7 @@ public class FuelHandler {
 
             // getPowerPerCycle returns value in 1 BuildCraft micro MJ
             // 1 BuildCraft MJ equals 20 RF
-            energyPerTick = bcFuel.getPowerPerCycle() / (double) MjAPI.MJ * 20 * MekanismConfig.current().general.FROM_RF.val();
+            energyPerTick = RFIntegration.fromRF(bcFuel.getPowerPerCycle() / (double) MjAPI.MJ * 20);
         }
     }
 }

--- a/src/main/java/mekanism/common/entity/EntityRobit.java
+++ b/src/main/java/mekanism/common/entity/EntityRobit.java
@@ -19,6 +19,8 @@ import mekanism.common.entity.ai.RobitAIFollow;
 import mekanism.common.entity.ai.RobitAIPickup;
 import mekanism.common.integration.MekanismHooks;
 import mekanism.common.integration.forgeenergy.ForgeEnergyIntegration;
+import mekanism.common.integration.ic2.IC2Integration;
+import mekanism.common.integration.redstoneflux.RFIntegration;
 import mekanism.common.integration.tesla.TeslaIntegration;
 import mekanism.common.item.ItemConfigurator;
 import mekanism.common.item.ItemRobit;
@@ -179,13 +181,12 @@ public class EntityRobit extends EntityCreature implements IInventory, ISustaine
                     }
                 } else if (MekanismUtils.useRF() && stack.getItem() instanceof IEnergyContainerItem) {
                     IEnergyContainerItem item = (IEnergyContainerItem) stack.getItem();
-                    int needed = MekanismUtils.clampToInt((MAX_ELECTRICITY - getEnergy()) * MekanismConfig.current().general.TO_RF.val());
-                    setEnergy(getEnergy() + (item.extractEnergy(stack, needed, false) * MekanismConfig.current().general.FROM_RF.val()));
+                    int needed = RFIntegration.toRF(MAX_ELECTRICITY - getEnergy());
+                    setEnergy(getEnergy() + RFIntegration.fromRF(item.extractEnergy(stack, needed, false)));
                 } else if (MekanismUtils.useIC2() && stack.getItem() instanceof IElectricItem) {
                     IElectricItem item = (IElectricItem) stack.getItem();
                     if (item.canProvideEnergy(stack)) {
-                        double gain = ElectricItem.manager.discharge(stack, (MAX_ELECTRICITY - getEnergy()) * MekanismConfig.current().general.TO_IC2.val(), 4, true, true, false)
-                                      * MekanismConfig.current().general.FROM_IC2.val();
+                        double gain = IC2Integration.fromEU(ElectricItem.manager.discharge(stack, IC2Integration.toEU(MAX_ELECTRICITY - getEnergy()), 4, true, true, false));
                         setEnergy(getEnergy() + gain);
                     }
                 } else if (stack.getItem() == Items.REDSTONE && getEnergy() + MekanismConfig.current().general.ENERGY_PER_REDSTONE.val() <= MAX_ELECTRICITY) {

--- a/src/main/java/mekanism/common/integration/ic2/IC2Integration.java
+++ b/src/main/java/mekanism/common/integration/ic2/IC2Integration.java
@@ -4,12 +4,26 @@ import ic2.api.energy.EnergyNet;
 import ic2.api.energy.tile.IEnergySink;
 import ic2.api.energy.tile.IEnergySource;
 import ic2.api.energy.tile.IEnergyTile;
+import mekanism.common.config.MekanismConfig;
 import mekanism.common.integration.MekanismHooks;
+import mekanism.common.util.MekanismUtils;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraftforge.fml.common.Optional.Method;
 
 public class IC2Integration {
+
+    public static double toEU(double joules) {
+        return joules * MekanismConfig.current().general.TO_IC2.val();
+    }
+
+    public static int toEUAsInt(double joules) {
+        return MekanismUtils.clampToInt(toEU(joules));
+    }
+
+    public static double fromEU(double eu) {
+        return eu * MekanismConfig.current().general.FROM_IC2.val();
+    }
 
     @Method(modid = MekanismHooks.IC2_MOD_ID)
     public static boolean isOutputter(TileEntity tileEntity, EnumFacing side) {

--- a/src/main/java/mekanism/common/integration/ic2/IC2ItemManager.java
+++ b/src/main/java/mekanism/common/integration/ic2/IC2ItemManager.java
@@ -2,8 +2,6 @@ package mekanism.common.integration.ic2;
 
 import ic2.api.item.IElectricItemManager;
 import mekanism.api.energy.IEnergizedItem;
-import mekanism.common.config.MekanismConfig;
-import mekanism.common.util.MekanismUtils;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.ItemStack;
 
@@ -21,11 +19,11 @@ public class IC2ItemManager implements IElectricItemManager {
     public double charge(ItemStack itemStack, double amount, int tier, boolean ignoreTransferLimit, boolean simulate) {
         if (energizedItem.canReceive(itemStack)) {
             double energyNeeded = energizedItem.getMaxEnergy(itemStack) - energizedItem.getEnergy(itemStack);
-            double energyToStore = Math.min(Math.min(amount * MekanismConfig.current().general.FROM_IC2.val(), energizedItem.getMaxEnergy(itemStack) * 0.01), energyNeeded);
+            double energyToStore = Math.min(Math.min(IC2Integration.fromEU(amount), energizedItem.getMaxEnergy(itemStack) * 0.01), energyNeeded);
             if (!simulate) {
                 energizedItem.setEnergy(itemStack, energizedItem.getEnergy(itemStack) + energyToStore);
             }
-            return MekanismUtils.clampToInt(energyToStore * MekanismConfig.current().general.TO_IC2.val());
+            return IC2Integration.toEU(energyToStore);
         }
         return 0;
     }
@@ -34,24 +32,24 @@ public class IC2ItemManager implements IElectricItemManager {
     public double discharge(ItemStack itemStack, double amount, int tier, boolean ignoreTransferLimit, boolean external,
           boolean simulate) {
         if (energizedItem.canSend(itemStack)) {
-            double energyWanted = amount * MekanismConfig.current().general.FROM_IC2.val();
+            double energyWanted = IC2Integration.fromEU(amount);
             double energyToGive = Math.min(Math.min(energyWanted, energizedItem.getMaxEnergy(itemStack) * 0.01), energizedItem.getEnergy(itemStack));
             if (!simulate) {
                 energizedItem.setEnergy(itemStack, energizedItem.getEnergy(itemStack) - energyToGive);
             }
-            return MekanismUtils.clampToInt(energyToGive * MekanismConfig.current().general.TO_IC2.val());
+            return IC2Integration.toEU(energyToGive);
         }
         return 0;
     }
 
     @Override
     public boolean canUse(ItemStack itemStack, double amount) {
-        return energizedItem.getEnergy(itemStack) >= amount * MekanismConfig.current().general.FROM_IC2.val();
+        return energizedItem.getEnergy(itemStack) >= IC2Integration.fromEU(amount);
     }
 
     @Override
     public double getCharge(ItemStack itemStack) {
-        return MekanismUtils.clampToInt(energizedItem.getEnergy(itemStack) * MekanismConfig.current().general.TO_IC2.val());
+        return IC2Integration.toEU(energizedItem.getEnergy(itemStack));
     }
 
     @Override

--- a/src/main/java/mekanism/common/integration/redstoneflux/RFIntegration.java
+++ b/src/main/java/mekanism/common/integration/redstoneflux/RFIntegration.java
@@ -1,0 +1,27 @@
+package mekanism.common.integration.redstoneflux;
+
+import mekanism.common.config.MekanismConfig;
+import mekanism.common.util.MekanismUtils;
+
+public class RFIntegration {
+
+    public static double fromRF(int rf) {
+        return rf * MekanismConfig.current().general.FROM_RF.val();
+    }
+
+    public static double fromRF(double rf) {
+        return rf * MekanismConfig.current().general.FROM_RF.val();
+    }
+
+    public static int toRF(double joules) {
+        return MekanismUtils.clampToInt(joules * MekanismConfig.current().general.TO_RF.val());
+    }
+
+    public static long toRFAsLong(double joules) {
+        return Math.round(joules * MekanismConfig.current().general.TO_RF.val());
+    }
+
+    public static double toRFAsDouble(double joules) {
+        return joules * MekanismConfig.current().general.TO_RF.val();
+    }
+}

--- a/src/main/java/mekanism/common/integration/tesla/TeslaIntegration.java
+++ b/src/main/java/mekanism/common/integration/tesla/TeslaIntegration.java
@@ -35,6 +35,10 @@ public class TeslaIntegration implements ITeslaHolder, ITeslaConsumer, ITeslaPro
         return tesla * MekanismConfig.current().general.FROM_TESLA.val();
     }
 
+    public static double fromTesla(double tesla) {
+        return tesla * MekanismConfig.current().general.FROM_TESLA.val();
+    }
+
     @Override
     @Method(modid = MekanismHooks.TESLA_MOD_ID)
     public long getStoredPower() {

--- a/src/main/java/mekanism/common/item/ItemBlockEnergyCube.java
+++ b/src/main/java/mekanism/common/item/ItemBlockEnergyCube.java
@@ -21,6 +21,7 @@ import mekanism.common.config.MekanismConfig;
 import mekanism.common.integration.MekanismHooks;
 import mekanism.common.integration.forgeenergy.ForgeEnergyItemWrapper;
 import mekanism.common.integration.ic2.IC2ItemManager;
+import mekanism.common.integration.redstoneflux.RFIntegration;
 import mekanism.common.integration.tesla.TeslaItemWrapper;
 import mekanism.common.security.ISecurityItem;
 import mekanism.common.security.ISecurityTile;
@@ -208,11 +209,11 @@ public class ItemBlockEnergyCube extends ItemBlock implements IEnergizedItem, IS
     public int receiveEnergy(ItemStack theItem, int energy, boolean simulate) {
         if (canReceive(theItem)) {
             double energyNeeded = getMaxEnergy(theItem) - getEnergy(theItem);
-            double toReceive = Math.min(energy * MekanismConfig.current().general.FROM_RF.val(), energyNeeded);
+            double toReceive = Math.min(RFIntegration.fromRF(energy), energyNeeded);
             if (!simulate) {
                 setEnergy(theItem, getEnergy(theItem) + toReceive);
             }
-            return MekanismUtils.clampToInt(toReceive * MekanismConfig.current().general.TO_RF.val());
+            return RFIntegration.toRF(toReceive);
         }
         return 0;
     }
@@ -222,11 +223,11 @@ public class ItemBlockEnergyCube extends ItemBlock implements IEnergizedItem, IS
     public int extractEnergy(ItemStack theItem, int energy, boolean simulate) {
         if (canSend(theItem)) {
             double energyRemaining = getEnergy(theItem);
-            double toSend = Math.min(energy * MekanismConfig.current().general.FROM_RF.val(), energyRemaining);
+            double toSend = Math.min(RFIntegration.fromRF(energy), energyRemaining);
             if (!simulate) {
                 setEnergy(theItem, getEnergy(theItem) - toSend);
             }
-            return MekanismUtils.clampToInt(toSend * MekanismConfig.current().general.TO_RF.val());
+            return RFIntegration.toRF(toSend);
         }
         return 0;
     }
@@ -234,13 +235,13 @@ public class ItemBlockEnergyCube extends ItemBlock implements IEnergizedItem, IS
     @Override
     @Method(modid = MekanismHooks.REDSTONEFLUX_MOD_ID)
     public int getEnergyStored(ItemStack theItem) {
-        return (int) (getEnergy(theItem) * MekanismConfig.current().general.TO_RF.val());
+        return RFIntegration.toRF(getEnergy(theItem));
     }
 
     @Override
     @Method(modid = MekanismHooks.REDSTONEFLUX_MOD_ID)
     public int getMaxEnergyStored(ItemStack theItem) {
-        return (int) (getMaxEnergy(theItem) * MekanismConfig.current().general.TO_RF.val());
+        return RFIntegration.toRF(getMaxEnergy(theItem));
     }
 
     @Override

--- a/src/main/java/mekanism/common/item/ItemBlockMachine.java
+++ b/src/main/java/mekanism/common/item/ItemBlockMachine.java
@@ -37,6 +37,7 @@ import mekanism.common.frequency.Frequency;
 import mekanism.common.integration.MekanismHooks;
 import mekanism.common.integration.forgeenergy.ForgeEnergyItemWrapper;
 import mekanism.common.integration.ic2.IC2ItemManager;
+import mekanism.common.integration.redstoneflux.RFIntegration;
 import mekanism.common.integration.tesla.TeslaItemWrapper;
 import mekanism.common.security.ISecurityItem;
 import mekanism.common.security.ISecurityTile;
@@ -563,11 +564,11 @@ public class ItemBlockMachine extends ItemBlock implements IEnergizedItem, ISpec
     public int receiveEnergy(ItemStack theItem, int energy, boolean simulate) {
         if (canReceive(theItem)) {
             double energyNeeded = getMaxEnergy(theItem) - getEnergy(theItem);
-            double toReceive = Math.min(energy * MekanismConfig.current().general.FROM_RF.val(), energyNeeded);
+            double toReceive = Math.min(RFIntegration.fromRF(energy), energyNeeded);
             if (!simulate) {
                 setEnergy(theItem, getEnergy(theItem) + toReceive);
             }
-            return MekanismUtils.clampToInt(toReceive * MekanismConfig.current().general.TO_RF.val());
+            return RFIntegration.toRF(toReceive);
         }
         return 0;
     }
@@ -577,11 +578,11 @@ public class ItemBlockMachine extends ItemBlock implements IEnergizedItem, ISpec
     public int extractEnergy(ItemStack theItem, int energy, boolean simulate) {
         if (canSend(theItem)) {
             double energyRemaining = getEnergy(theItem);
-            double toSend = Math.min(energy * MekanismConfig.current().general.FROM_RF.val(), energyRemaining);
+            double toSend = Math.min(RFIntegration.fromRF(energy), energyRemaining);
             if (!simulate) {
                 setEnergy(theItem, getEnergy(theItem) - toSend);
             }
-            return MekanismUtils.clampToInt(toSend * MekanismConfig.current().general.TO_RF.val());
+            return RFIntegration.toRF(toSend);
         }
         return 0;
     }
@@ -589,13 +590,13 @@ public class ItemBlockMachine extends ItemBlock implements IEnergizedItem, ISpec
     @Override
     @Method(modid = MekanismHooks.REDSTONEFLUX_MOD_ID)
     public int getEnergyStored(ItemStack theItem) {
-        return (int) (getEnergy(theItem) * MekanismConfig.current().general.TO_RF.val());
+        return RFIntegration.toRF(getEnergy(theItem));
     }
 
     @Override
     @Method(modid = MekanismHooks.REDSTONEFLUX_MOD_ID)
     public int getMaxEnergyStored(ItemStack theItem) {
-        return (int) (getMaxEnergy(theItem) * MekanismConfig.current().general.TO_RF.val());
+        return RFIntegration.toRF(getMaxEnergy(theItem));
     }
 
     @Override

--- a/src/main/java/mekanism/common/item/ItemEnergized.java
+++ b/src/main/java/mekanism/common/item/ItemEnergized.java
@@ -9,10 +9,10 @@ import mekanism.api.EnumColor;
 import mekanism.api.energy.IEnergizedItem;
 import mekanism.common.Mekanism;
 import mekanism.common.capabilities.ItemCapabilityWrapper;
-import mekanism.common.config.MekanismConfig;
 import mekanism.common.integration.MekanismHooks;
 import mekanism.common.integration.forgeenergy.ForgeEnergyItemWrapper;
 import mekanism.common.integration.ic2.IC2ItemManager;
+import mekanism.common.integration.redstoneflux.RFIntegration;
 import mekanism.common.integration.tesla.TeslaItemWrapper;
 import mekanism.common.util.ItemDataUtils;
 import mekanism.common.util.LangUtils;
@@ -122,36 +122,37 @@ public class ItemEnergized extends ItemMekanism implements IEnergizedItem, ISpec
     public int receiveEnergy(ItemStack theItem, int energy, boolean simulate) {
         if (canReceive(theItem)) {
             double energyNeeded = getMaxEnergy(theItem) - getEnergy(theItem);
-            double toReceive = Math.min(energy * MekanismConfig.current().general.FROM_RF.val(), energyNeeded);
+            double toReceive = Math.min(RFIntegration.fromRF(energy), energyNeeded);
             if (!simulate) {
                 setEnergy(theItem, getEnergy(theItem) + toReceive);
             }
-            return MekanismUtils.clampToInt(toReceive * MekanismConfig.current().general.TO_RF.val());
+            return RFIntegration.toRF(toReceive);
         }
         return 0;
     }
 
     @Override
+    @Method(modid = MekanismHooks.REDSTONEFLUX_MOD_ID)
     public int extractEnergy(ItemStack theItem, int energy, boolean simulate) {
         if (canSend(theItem)) {
             double energyRemaining = getEnergy(theItem);
-            double toSend = Math.min(energy * MekanismConfig.current().general.FROM_RF.val(), energyRemaining);
+            double toSend = Math.min(RFIntegration.fromRF(energy), energyRemaining);
             if (!simulate) {
                 setEnergy(theItem, getEnergy(theItem) - toSend);
             }
-            return MekanismUtils.clampToInt(toSend * MekanismConfig.current().general.TO_RF.val());
+            return RFIntegration.toRF(toSend);
         }
         return 0;
     }
 
     @Override
     public int getEnergyStored(ItemStack theItem) {
-        return MekanismUtils.clampToInt(getEnergy(theItem) * MekanismConfig.current().general.TO_RF.val());
+        return RFIntegration.toRF(getEnergy(theItem));
     }
 
     @Override
     public int getMaxEnergyStored(ItemStack theItem) {
-        return MekanismUtils.clampToInt(getMaxEnergy(theItem) * MekanismConfig.current().general.TO_RF.val());
+        return RFIntegration.toRF(getMaxEnergy(theItem));
     }
 
     @Override

--- a/src/main/java/mekanism/common/item/ItemFreeRunners.java
+++ b/src/main/java/mekanism/common/item/ItemFreeRunners.java
@@ -11,10 +11,10 @@ import mekanism.client.render.ModelCustomArmor;
 import mekanism.client.render.ModelCustomArmor.ArmorModel;
 import mekanism.common.Mekanism;
 import mekanism.common.capabilities.ItemCapabilityWrapper;
-import mekanism.common.config.MekanismConfig;
 import mekanism.common.integration.MekanismHooks;
 import mekanism.common.integration.forgeenergy.ForgeEnergyItemWrapper;
 import mekanism.common.integration.ic2.IC2ItemManager;
+import mekanism.common.integration.redstoneflux.RFIntegration;
 import mekanism.common.integration.tesla.TeslaItemWrapper;
 import mekanism.common.util.ItemDataUtils;
 import mekanism.common.util.LangUtils;
@@ -138,11 +138,11 @@ public class ItemFreeRunners extends ItemArmor implements IEnergizedItem, ISpeci
     public int receiveEnergy(ItemStack theItem, int energy, boolean simulate) {
         if (canReceive(theItem)) {
             double energyNeeded = getMaxEnergy(theItem) - getEnergy(theItem);
-            double toReceive = Math.min(energy * MekanismConfig.current().general.FROM_RF.val(), energyNeeded);
+            double toReceive = Math.min(RFIntegration.fromRF(energy), energyNeeded);
             if (!simulate) {
                 setEnergy(theItem, getEnergy(theItem) + toReceive);
             }
-            return MekanismUtils.clampToInt(toReceive * MekanismConfig.current().general.TO_RF.val());
+            return RFIntegration.toRF(toReceive);
         }
         return 0;
     }
@@ -152,11 +152,11 @@ public class ItemFreeRunners extends ItemArmor implements IEnergizedItem, ISpeci
     public int extractEnergy(ItemStack theItem, int energy, boolean simulate) {
         if (canSend(theItem)) {
             double energyRemaining = getEnergy(theItem);
-            double toSend = Math.min(energy * MekanismConfig.current().general.FROM_RF.val(), energyRemaining);
+            double toSend = Math.min(RFIntegration.fromRF(energy), energyRemaining);
             if (!simulate) {
                 setEnergy(theItem, getEnergy(theItem) - toSend);
             }
-            return MekanismUtils.clampToInt(toSend * MekanismConfig.current().general.TO_RF.val());
+            return RFIntegration.toRF(toSend);
         }
         return 0;
     }
@@ -164,13 +164,13 @@ public class ItemFreeRunners extends ItemArmor implements IEnergizedItem, ISpeci
     @Override
     @Method(modid = MekanismHooks.REDSTONEFLUX_MOD_ID)
     public int getEnergyStored(ItemStack theItem) {
-        return MekanismUtils.clampToInt(getEnergy(theItem) * MekanismConfig.current().general.TO_RF.val());
+        return RFIntegration.toRF(getEnergy(theItem));
     }
 
     @Override
     @Method(modid = MekanismHooks.REDSTONEFLUX_MOD_ID)
     public int getMaxEnergyStored(ItemStack theItem) {
-        return MekanismUtils.clampToInt(getMaxEnergy(theItem) * MekanismConfig.current().general.TO_RF.val());
+        return RFIntegration.toRF(getMaxEnergy(theItem));
     }
 
     @Override

--- a/src/main/java/mekanism/common/util/ChargeUtils.java
+++ b/src/main/java/mekanism/common/util/ChargeUtils.java
@@ -9,6 +9,8 @@ import mekanism.api.energy.IStrictEnergyStorage;
 import mekanism.common.capabilities.Capabilities;
 import mekanism.common.config.MekanismConfig;
 import mekanism.common.integration.forgeenergy.ForgeEnergyIntegration;
+import mekanism.common.integration.ic2.IC2Integration;
+import mekanism.common.integration.redstoneflux.RFIntegration;
 import mekanism.common.integration.tesla.TeslaIntegration;
 import mekanism.common.tile.prefab.TileEntityContainerBlock;
 import net.darkhax.tesla.api.ITeslaConsumer;
@@ -53,11 +55,10 @@ public final class ChargeUtils {
                 }
             } else if (MekanismUtils.useRF() && stack.getItem() instanceof IEnergyContainerItem) {
                 IEnergyContainerItem item = (IEnergyContainerItem) stack.getItem();
-                int needed = MekanismUtils.clampToInt((storer.getMaxEnergy() - storer.getEnergy()) * MekanismConfig.current().general.TO_RF.val());
-                storer.setEnergy(storer.getEnergy() + (item.extractEnergy(stack, needed, false) * MekanismConfig.current().general.FROM_RF.val()));
+                int needed = RFIntegration.toRF(storer.getMaxEnergy() - storer.getEnergy());
+                storer.setEnergy(storer.getEnergy() + RFIntegration.fromRF(item.extractEnergy(stack, needed, false)));
             } else if (MekanismUtils.useIC2() && isIC2Dischargeable(stack)) {
-                double gain = ElectricItem.manager.discharge(stack, (storer.getMaxEnergy() - storer.getEnergy()) * MekanismConfig.current().general.TO_IC2.val(),
-                      4, true, true, false) * MekanismConfig.current().general.FROM_IC2.val();
+                double gain = IC2Integration.fromEU(ElectricItem.manager.discharge(stack, IC2Integration.toEU(storer.getMaxEnergy() - storer.getEnergy()), 4, true, true, false));
                 storer.setEnergy(storer.getEnergy() + gain);
             } else if (stack.getItem() == Items.REDSTONE && storer.getEnergy() + MekanismConfig.current().general.ENERGY_PER_REDSTONE.val() <= storer.getMaxEnergy()) {
                 storer.setEnergy(storer.getEnergy() + MekanismConfig.current().general.ENERGY_PER_REDSTONE.val());
@@ -99,11 +100,10 @@ public final class ChargeUtils {
                 }
             } else if (MekanismUtils.useRF() && stack.getItem() instanceof IEnergyContainerItem) {
                 IEnergyContainerItem item = (IEnergyContainerItem) stack.getItem();
-                int toTransfer = MekanismUtils.clampToInt(storer.getEnergy() * MekanismConfig.current().general.TO_RF.val());
-                storer.setEnergy(storer.getEnergy() - (item.receiveEnergy(stack, toTransfer, false) * MekanismConfig.current().general.FROM_RF.val()));
+                int toTransfer = RFIntegration.toRF(storer.getEnergy());
+                storer.setEnergy(storer.getEnergy() - RFIntegration.fromRF(item.receiveEnergy(stack, toTransfer, false)));
             } else if (MekanismUtils.useIC2() && isIC2Chargeable(stack)) {
-                double sent = ElectricItem.manager.charge(stack, storer.getEnergy() * MekanismConfig.current().general.TO_IC2.val(), 4, true, false)
-                              * MekanismConfig.current().general.FROM_IC2.val();
+                double sent = IC2Integration.fromEU(ElectricItem.manager.charge(stack, IC2Integration.toEU(storer.getEnergy()), 4, true, false));
                 storer.setEnergy(storer.getEnergy() - sent);
             }
         }

--- a/src/main/java/mekanism/common/util/MekanismUtils.java
+++ b/src/main/java/mekanism/common/util/MekanismUtils.java
@@ -30,6 +30,8 @@ import mekanism.common.base.IUpgradeTile;
 import mekanism.common.block.states.BlockStateMachine.MachineType;
 import mekanism.common.block.states.BlockStateTransmitter.TransmitterType;
 import mekanism.common.config.MekanismConfig;
+import mekanism.common.integration.ic2.IC2Integration;
+import mekanism.common.integration.redstoneflux.RFIntegration;
 import mekanism.common.integration.tesla.TeslaIntegration;
 import mekanism.common.item.ItemBlockGasTank;
 import mekanism.common.item.ItemBlockTransmitter;
@@ -726,9 +728,9 @@ public final class MekanismUtils {
             case J:
                 return UnitDisplayUtils.getDisplayShort(energy, ElectricUnit.JOULES);
             case RF:
-                return UnitDisplayUtils.getDisplayShort(energy * MekanismConfig.current().general.TO_RF.val(), ElectricUnit.REDSTONE_FLUX);
+                return UnitDisplayUtils.getDisplayShort(RFIntegration.toRF(energy), ElectricUnit.REDSTONE_FLUX);
             case EU:
-                return UnitDisplayUtils.getDisplayShort(energy * MekanismConfig.current().general.TO_IC2.val(), ElectricUnit.ELECTRICAL_UNITS);
+                return UnitDisplayUtils.getDisplayShort(IC2Integration.toEU(energy), ElectricUnit.ELECTRICAL_UNITS);
             case T:
                 return UnitDisplayUtils.getDisplayShort(TeslaIntegration.toTesla(energy), ElectricUnit.TESLA);
         }
@@ -754,11 +756,11 @@ public final class MekanismUtils {
     public static double convertToJoules(double energy) {
         switch (MekanismConfig.current().general.energyUnit.val()) {
             case RF:
-                return energy * MekanismConfig.current().general.FROM_RF.val();
+                return RFIntegration.fromRF(energy);
             case EU:
-                return energy * MekanismConfig.current().general.FROM_IC2.val();
+                return IC2Integration.fromEU(energy);
             case T:
-                return energy * MekanismConfig.current().general.FROM_TESLA.val();
+                return TeslaIntegration.fromTesla(energy);
             default:
                 return energy;
         }
@@ -774,11 +776,11 @@ public final class MekanismUtils {
     public static double convertToDisplay(double energy) {
         switch (MekanismConfig.current().general.energyUnit.val()) {
             case RF:
-                return energy * MekanismConfig.current().general.TO_RF.val();
+                return RFIntegration.toRFAsDouble(energy);
             case EU:
-                return energy * MekanismConfig.current().general.TO_IC2.val();
+                return IC2Integration.toEU(energy);
             case T:
-                return energy * MekanismConfig.current().general.TO_RF.val() / 10;
+                return TeslaIntegration.toTesla(energy);
             default:
                 return energy;
         }

--- a/src/main/java/mekanism/generators/common/MekanismGenerators.java
+++ b/src/main/java/mekanism/generators/common/MekanismGenerators.java
@@ -15,6 +15,7 @@ import mekanism.common.Version;
 import mekanism.common.base.IModule;
 import mekanism.common.config.MekanismConfig;
 import mekanism.common.fixers.MekanismDataFixers.MekFixers;
+import mekanism.common.integration.redstoneflux.RFIntegration;
 import mekanism.common.multiblock.MultiblockManager;
 import mekanism.common.network.PacketSimpleGui;
 import mekanism.common.recipe.RecipeHandler;
@@ -125,8 +126,7 @@ public class MekanismGenerators implements IModule {
                 }
             }
 
-            BuildcraftFuelRegistry.fuel.addFuel(MekanismFluids.Ethene.getFluid(), (long) (240 * MekanismConfig.current().general.TO_RF.val() / 20 * MjAPI.MJ),
-                  40 * Fluid.BUCKET_VOLUME);
+            BuildcraftFuelRegistry.fuel.addFuel(MekanismFluids.Ethene.getFluid(), (RFIntegration.toRFAsLong(12 * MjAPI.MJ)), 40 * Fluid.BUCKET_VOLUME);
         }
     }
 

--- a/src/main/java/mekanism/generators/common/item/ItemBlockGenerator.java
+++ b/src/main/java/mekanism/generators/common/item/ItemBlockGenerator.java
@@ -19,6 +19,7 @@ import mekanism.common.config.MekanismConfig;
 import mekanism.common.integration.MekanismHooks;
 import mekanism.common.integration.forgeenergy.ForgeEnergyItemWrapper;
 import mekanism.common.integration.ic2.IC2ItemManager;
+import mekanism.common.integration.redstoneflux.RFIntegration;
 import mekanism.common.integration.tesla.TeslaItemWrapper;
 import mekanism.common.security.ISecurityItem;
 import mekanism.common.security.ISecurityTile;
@@ -289,11 +290,11 @@ public class ItemBlockGenerator extends ItemBlock implements IEnergizedItem, ISp
     public int receiveEnergy(ItemStack theItem, int energy, boolean simulate) {
         if (canReceive(theItem)) {
             double energyNeeded = getMaxEnergy(theItem) - getEnergy(theItem);
-            double toReceive = Math.min(energy * MekanismConfig.current().general.FROM_RF.val(), energyNeeded);
+            double toReceive = Math.min(RFIntegration.fromRF(energy), energyNeeded);
             if (!simulate) {
                 setEnergy(theItem, getEnergy(theItem) + toReceive);
             }
-            return MekanismUtils.clampToInt(toReceive * MekanismConfig.current().general.TO_RF.val());
+            return RFIntegration.toRF(toReceive);
         }
         return 0;
     }
@@ -303,11 +304,11 @@ public class ItemBlockGenerator extends ItemBlock implements IEnergizedItem, ISp
     public int extractEnergy(ItemStack theItem, int energy, boolean simulate) {
         if (canSend(theItem)) {
             double energyRemaining = getEnergy(theItem);
-            double toSend = Math.min(energy * MekanismConfig.current().general.FROM_RF.val(), energyRemaining);
+            double toSend = Math.min(RFIntegration.fromRF(energy), energyRemaining);
             if (!simulate) {
                 setEnergy(theItem, getEnergy(theItem) - toSend);
             }
-            return MekanismUtils.clampToInt(toSend * MekanismConfig.current().general.TO_RF.val());
+            return RFIntegration.toRF(toSend);
         }
         return 0;
     }
@@ -315,13 +316,13 @@ public class ItemBlockGenerator extends ItemBlock implements IEnergizedItem, ISp
     @Override
     @Method(modid = MekanismHooks.REDSTONEFLUX_MOD_ID)
     public int getEnergyStored(ItemStack theItem) {
-        return MekanismUtils.clampToInt(getEnergy(theItem) * MekanismConfig.current().general.TO_RF.val());
+        return RFIntegration.toRF(getEnergy(theItem));
     }
 
     @Override
     @Method(modid = MekanismHooks.REDSTONEFLUX_MOD_ID)
     public int getMaxEnergyStored(ItemStack theItem) {
-        return MekanismUtils.clampToInt(getMaxEnergy(theItem) * MekanismConfig.current().general.TO_RF.val());
+        return RFIntegration.toRF(getMaxEnergy(theItem));
     }
 
     @Override

--- a/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineValve.java
+++ b/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineValve.java
@@ -19,6 +19,8 @@ import mekanism.common.config.MekanismConfig;
 import mekanism.common.integration.MekanismHooks;
 import mekanism.common.integration.computer.IComputerIntegration;
 import mekanism.common.integration.forgeenergy.ForgeEnergyIntegration;
+import mekanism.common.integration.ic2.IC2Integration;
+import mekanism.common.integration.redstoneflux.RFIntegration;
 import mekanism.common.integration.tesla.TeslaIntegration;
 import mekanism.common.tile.TileEntityGasTank.GasMode;
 import mekanism.common.util.CableUtils;
@@ -150,11 +152,11 @@ public class TileEntityTurbineValve extends TileEntityTurbineCasing implements I
     @Method(modid = MekanismHooks.REDSTONEFLUX_MOD_ID)
     public int extractEnergy(EnumFacing from, int maxExtract, boolean simulate) {
         if (sideIsOutput(from)) {
-            double toSend = Math.min(getEnergy(), Math.min(getMaxOutput(), maxExtract * MekanismConfig.current().general.FROM_RF.val()));
+            double toSend = Math.min(getEnergy(), Math.min(getMaxOutput(), RFIntegration.fromRF(maxExtract)));
             if (!simulate) {
                 setEnergy(getEnergy() - toSend);
             }
-            return MekanismUtils.clampToInt(toSend * MekanismConfig.current().general.TO_RF.val());
+            return RFIntegration.toRF(toSend);
         }
         return 0;
     }
@@ -168,13 +170,13 @@ public class TileEntityTurbineValve extends TileEntityTurbineCasing implements I
     @Override
     @Method(modid = MekanismHooks.REDSTONEFLUX_MOD_ID)
     public int getEnergyStored(EnumFacing from) {
-        return MekanismUtils.clampToInt(getEnergy() * MekanismConfig.current().general.TO_RF.val());
+        return RFIntegration.toRF(getEnergy());
     }
 
     @Override
     @Method(modid = MekanismHooks.REDSTONEFLUX_MOD_ID)
     public int getMaxEnergyStored(EnumFacing from) {
-        return MekanismUtils.clampToInt(getMaxEnergy() * MekanismConfig.current().general.TO_RF.val());
+        return RFIntegration.toRF(getMaxEnergy());
     }
 
     @Override
@@ -221,25 +223,25 @@ public class TileEntityTurbineValve extends TileEntityTurbineCasing implements I
     @Override
     @Method(modid = MekanismHooks.IC2_MOD_ID)
     public int getStored() {
-        return MekanismUtils.clampToInt(getEnergy() * MekanismConfig.current().general.TO_IC2.val());
+        return IC2Integration.toEUAsInt(getEnergy());
     }
 
     @Override
     @Method(modid = MekanismHooks.IC2_MOD_ID)
     public void setStored(int energy) {
-        setEnergy(energy * MekanismConfig.current().general.FROM_IC2.val());
+        setEnergy(IC2Integration.fromEU(energy));
     }
 
     @Override
     @Method(modid = MekanismHooks.IC2_MOD_ID)
     public int getCapacity() {
-        return MekanismUtils.clampToInt(getMaxEnergy() * MekanismConfig.current().general.TO_IC2.val());
+        return IC2Integration.toEUAsInt(getMaxEnergy());
     }
 
     @Override
     @Method(modid = MekanismHooks.IC2_MOD_ID)
     public int getOutput() {
-        return MekanismUtils.clampToInt(getMaxOutput() * MekanismConfig.current().general.TO_IC2.val());
+        return IC2Integration.toEUAsInt(getMaxOutput());
     }
 
     @Override
@@ -251,7 +253,7 @@ public class TileEntityTurbineValve extends TileEntityTurbineCasing implements I
     @Override
     @Method(modid = MekanismHooks.IC2_MOD_ID)
     public double getOfferedEnergy() {
-        return Math.min(getEnergy(), getMaxOutput()) * MekanismConfig.current().general.TO_IC2.val();
+        return IC2Integration.toEU(Math.min(getEnergy(), getMaxOutput()));
     }
 
     @Override
@@ -262,7 +264,7 @@ public class TileEntityTurbineValve extends TileEntityTurbineCasing implements I
     @Override
     @Method(modid = MekanismHooks.IC2_MOD_ID)
     public double getOutputEnergyUnitsPerTick() {
-        return getMaxOutput() * MekanismConfig.current().general.TO_IC2.val();
+        return IC2Integration.toEU(getMaxOutput());
     }
 
     @Override
@@ -275,7 +277,7 @@ public class TileEntityTurbineValve extends TileEntityTurbineCasing implements I
     @Method(modid = MekanismHooks.IC2_MOD_ID)
     public void drawEnergy(double amount) {
         if (structure != null) {
-            double toDraw = Math.min(amount * MekanismConfig.current().general.FROM_IC2.val(), getMaxOutput());
+            double toDraw = Math.min(IC2Integration.fromEU(amount), getMaxOutput());
             setEnergy(Math.max(getEnergy() - toDraw, 0));
         }
     }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Moved the various remaining energy conversion calls into Integration classes so that it is easier to read what value is actually being converted, without all the extra code for making sure it doesn't go past the data types bound.