### PR TITLE
update ja_jp.lang

### DIFF
--- a/src/main/resources/assets/mekanism/lang/ja_jp.lang
+++ b/src/main/resources/assets/mekanism/lang/ja_jp.lang
@@ -333,7 +333,7 @@ gas.cleanLead=純粋な鉛の懸濁液
 
 # BC Fuel Gases
 gas.fuel=気化燃料
-gas.oil=気化石油
+gas.oil=気化原油
 
 # Fluids
 fluid.liquidhydrogen=液体水素
@@ -996,7 +996,7 @@ itemGroup.tabMekanism=Mekanism
 
 # Items
 item.SolarPanel.name=ソーラーパネル
-item.Hohlraum.name=ホーラム
+item.Hohlraum.name=ホールラウム
 item.TurbineBlade.name=タービンの羽
 
 # Generators


### PR DESCRIPTION
## Changes proposed in this pull request:

### line 336: unify translation into BuildCraft
* refer to https://github.com/BuildCraft/BuildCraft-Localization/blob/f4f48d826092f57c0b3e5c1186c9f015a12df461/assets/buildcraft/lang/ja_JP.lang#L77

### line 999: make more like to original pronounce
* "Hohlraum" is a borrowed term from German. 