### PR TITLE
Flamethrower can make ObsidianTNT explode.

### DIFF
--- a/src/main/java/mekanism/common/block/BlockObsidianTNT.java
+++ b/src/main/java/mekanism/common/block/BlockObsidianTNT.java
@@ -89,6 +89,20 @@ public class BlockObsidianTNT extends Block {
     }
 
     @Override
+    public boolean isFlammable(IBlockAccess world, BlockPos pos, EnumFacing face)
+    {
+        return true;
+    }
+
+    @Override
+    public boolean isFireSource(World world, BlockPos pos, EnumFacing side)
+    {
+    	  explode(world, pos);
+        world.setBlockToAir(pos);
+        return true;
+    }
+
+    @Override
     public void onEntityCollision(World world, BlockPos pos, IBlockState state, Entity entity) {
         if (entity instanceof EntityArrow && !world.isRemote) {
             EntityArrow entityarrow = (EntityArrow) entity;

--- a/src/main/java/mekanism/common/block/BlockObsidianTNT.java
+++ b/src/main/java/mekanism/common/block/BlockObsidianTNT.java
@@ -16,6 +16,7 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.Explosion;
+import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 
 public class BlockObsidianTNT extends Block {


### PR DESCRIPTION
## Flamethrower can make ObsidianTNT explode:
I've seen that flamethrower couldn't burn ObsidianTNT blocks. So I made the ObsidianTNT able to burn. When the ObsidianTNT burn, like the TNT, it will explode.
I did this feature because it seems right to make new items work together.

