### PR TITLE
Improve Transporter path finding performance and accuracy

### DIFF
--- a/src/api/java/mekanism/api/Coord4D.java
+++ b/src/api/java/mekanism/api/Coord4D.java
@@ -233,11 +233,11 @@ public class Coord4D {//TODO: Replace this with GlobalPos
      *
      * @return the distance to the defined Coord4D
      */
-    public int distanceTo(Coord4D obj) {
+    public double distanceTo(Coord4D obj) {
         int subX = x - obj.x;
         int subY = y - obj.y;
         int subZ = z - obj.z;
-        return (int) MathHelper.sqrt(subX * subX + subY * subY + subZ * subZ);
+        return MathHelper.sqrt(subX * subX + subY * subY + subZ * subZ);
     }
 
     /**

--- a/src/api/java/mekanism/api/transmitters/IBlockableConnection.java
+++ b/src/api/java/mekanism/api/transmitters/IBlockableConnection.java
@@ -1,11 +1,13 @@
 package mekanism.api.transmitters;
 
 
+import javax.annotation.Nullable;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Direction;
 
 public interface IBlockableConnection {
 
-    boolean canConnectMutual(Direction side);
+    boolean canConnectMutual(Direction side, @Nullable TileEntity cachedTile);
 
     boolean canConnect(Direction side);
 }

--- a/src/main/java/mekanism/common/base/ILogisticalTransporter.java
+++ b/src/main/java/mekanism/common/base/ILogisticalTransporter.java
@@ -1,6 +1,5 @@
 package mekanism.common.base;
 
-import mekanism.api.Coord4D;
 import mekanism.api.text.EnumColor;
 import mekanism.api.transmitters.IBlockableConnection;
 import mekanism.api.transmitters.IGridTransmitter;
@@ -14,7 +13,7 @@ import net.minecraft.util.Direction;
 
 public interface ILogisticalTransporter extends IGridTransmitter<TileEntity, InventoryNetwork, Void>, IBlockableConnection {
 
-    TransitResponse insert(Coord4D original, TransitRequest request, EnumColor color, boolean doEmit, int min);
+    TransitResponse insert(TileEntity outputter, TransitRequest request, EnumColor color, boolean doEmit, int min);
 
     TransitResponse insertRR(TileEntityLogisticalSorter outputter, TransitRequest request, EnumColor color, boolean doEmit, int min);
 

--- a/src/main/java/mekanism/common/capabilities/basic/DefaultBlockableConnection.java
+++ b/src/main/java/mekanism/common/capabilities/basic/DefaultBlockableConnection.java
@@ -1,7 +1,9 @@
 package mekanism.common.capabilities.basic;
 
+import javax.annotation.Nullable;
 import mekanism.api.transmitters.IBlockableConnection;
 import mekanism.common.capabilities.basic.DefaultStorageHelper.NullStorage;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Direction;
 import net.minecraftforge.common.capabilities.CapabilityManager;
 
@@ -12,7 +14,7 @@ public class DefaultBlockableConnection implements IBlockableConnection {
     }
 
     @Override
-    public boolean canConnectMutual(Direction side) {
+    public boolean canConnectMutual(Direction side, @Nullable TileEntity cachedTile) {
         return false;
     }
 

--- a/src/main/java/mekanism/common/capabilities/basic/DefaultLogisticalTransporter.java
+++ b/src/main/java/mekanism/common/capabilities/basic/DefaultLogisticalTransporter.java
@@ -29,7 +29,7 @@ public class DefaultLogisticalTransporter implements ILogisticalTransporter {
     }
 
     @Override
-    public TransitResponse insert(Coord4D original, TransitRequest request, EnumColor color, boolean doEmit, int min) {
+    public TransitResponse insert(TileEntity outputter, TransitRequest request, EnumColor color, boolean doEmit, int min) {
         return TransitResponse.EMPTY;
     }
 

--- a/src/main/java/mekanism/common/capabilities/basic/DefaultLogisticalTransporter.java
+++ b/src/main/java/mekanism/common/capabilities/basic/DefaultLogisticalTransporter.java
@@ -1,6 +1,7 @@
 package mekanism.common.capabilities.basic;
 
 import java.util.Collection;
+import javax.annotation.Nullable;
 import mekanism.api.Coord4D;
 import mekanism.api.text.EnumColor;
 import mekanism.api.transmitters.IGridTransmitter;
@@ -66,7 +67,7 @@ public class DefaultLogisticalTransporter implements ILogisticalTransporter {
     }
 
     @Override
-    public boolean canConnectMutual(Direction side) {
+    public boolean canConnectMutual(Direction side, @Nullable TileEntity cachedTile) {
         return false;
     }
 

--- a/src/main/java/mekanism/common/content/transporter/TransporterPathfinder.java
+++ b/src/main/java/mekanism/common/content/transporter/TransporterPathfinder.java
@@ -1,11 +1,12 @@
 package mekanism.common.content.transporter;
 
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2DoubleOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -103,7 +104,7 @@ public final class TransporterPathfinder {
 
     public static Destination getNewRRPath(ILogisticalTransporter start, TransporterStack stack, TransitRequest request, TileEntityLogisticalSorter outputter, int min) {
         List<Destination> paths = getPaths(start, stack, request, min);
-        Map<Coord4D, Destination> destPaths = new HashMap<>();
+        Map<Coord4D, Destination> destPaths = new Object2ObjectOpenHashMap<>();
         for (Destination d : paths) {
             Coord4D dest = d.getPath().get(0);
             Destination destination = destPaths.get(dest);
@@ -312,7 +313,7 @@ public final class TransporterPathfinder {
 
         private final Set<Coord4D> openSet, closedSet;
         private final Map<Coord4D, Coord4D> navMap;
-        private final Map<Coord4D, Double> gScore, fScore;
+        private final Object2DoubleOpenHashMap<Coord4D> gScore, fScore;
         private final Coord4D start;
         private final Coord4D finalNode;
         private final TransporterStack transportStack;
@@ -332,13 +333,13 @@ public final class TransporterPathfinder {
 
             transportStack = stack;
 
-            openSet = new HashSet<>();
-            closedSet = new HashSet<>();
+            openSet = new ObjectOpenHashSet<>();
+            closedSet = new ObjectOpenHashSet<>();
 
-            navMap = new HashMap<>();
+            navMap = new Object2ObjectOpenHashMap<>();
 
-            gScore = new HashMap<>();
-            fScore = new HashMap<>();
+            gScore = new Object2DoubleOpenHashMap<>();
+            fScore = new Object2DoubleOpenHashMap<>();
 
             results = new ArrayList<>();
 
@@ -374,9 +375,9 @@ public final class TransporterPathfinder {
                 Coord4D currentNode = null;
                 double lowestFScore = 0;
                 for (Coord4D node : openSet) {
-                    if (currentNode == null || fScore.get(node) < lowestFScore) {
+                    if (currentNode == null || fScore.getDouble(node) < lowestFScore) {
                         currentNode = node;
-                        lowestFScore = fScore.get(node);
+                        lowestFScore = fScore.getDouble(node);
                     }
                 }
                 if (currentNode == null) {
@@ -392,7 +393,7 @@ public final class TransporterPathfinder {
                     continue;
                 }
                 TileEntity currentNodeTile = MekanismUtils.getTileEntity(world, chunkMap, currentNode);
-                double currentScore = gScore.get(currentNode);
+                double currentScore = gScore.getDouble(currentNode);
                 for (Direction direction : EnumUtils.DIRECTIONS) {
                     Coord4D neighbor = currentNode.offset(direction);
                     TileEntity neighborEntity = MekanismUtils.getTileEntity(world, chunkMap, neighbor);
@@ -404,10 +405,10 @@ public final class TransporterPathfinder {
                         if (capability.isPresent()) {
                             tentativeG += capability.get().getCost();
                         }
-                        if (closedSet.contains(neighbor) && tentativeG >= gScore.get(neighbor)) {
+                        if (closedSet.contains(neighbor) && tentativeG >= gScore.getDouble(neighbor)) {
                             continue;
                         }
-                        if (!openSet.contains(neighbor) || tentativeG < gScore.get(neighbor)) {
+                        if (!openSet.contains(neighbor) || tentativeG < gScore.getDouble(neighbor)) {
                             navMap.put(neighbor, currentNode);
                             gScore.put(neighbor, tentativeG);
                             //Put the gScore plus estimate in the final score
@@ -455,7 +456,7 @@ public final class TransporterPathfinder {
             if (naviMap.containsKey(currentNode)) {
                 path.addAll(reconstructPath(naviMap, naviMap.get(currentNode)));
             }
-            finalScore = gScore.get(currentNode) + currentNode.distanceTo(finalNode);
+            finalScore = gScore.getDouble(currentNode) + currentNode.distanceTo(finalNode);
             return path;
         }
 

--- a/src/main/java/mekanism/common/content/transporter/TransporterStack.java
+++ b/src/main/java/mekanism/common/content/transporter/TransporterStack.java
@@ -252,9 +252,8 @@ public class TransporterStack {
         return false;
     }
 
-    public boolean canInsertToTransporter(ILogisticalTransporter transporter, Direction side) {
-        //TODO: Check if we ever have a tile already gotten that we can pass as cached
-        return (transporter.getColor() == color || transporter.getColor() == null) && transporter.canConnectMutual(side, null);
+    public boolean canInsertToTransporter(ILogisticalTransporter transporter, Direction side, @Nullable TileEntity tileFrom) {
+        return (transporter.getColor() == color || transporter.getColor() == null) && transporter.canConnectMutual(side, tileFrom);
     }
 
     public Coord4D getDest() {

--- a/src/main/java/mekanism/common/content/transporter/TransporterStack.java
+++ b/src/main/java/mekanism/common/content/transporter/TransporterStack.java
@@ -3,6 +3,7 @@ package mekanism.common.content.transporter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import javax.annotation.Nullable;
 import mekanism.api.Coord4D;
 import mekanism.api.TileNetworkList;
 import mekanism.api.text.EnumColor;
@@ -20,7 +21,6 @@ import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Direction;
-import net.minecraftforge.common.util.LazyOptional;
 import org.apache.commons.lang3.tuple.Pair;
 
 public class TransporterStack {
@@ -236,21 +236,25 @@ public class TransporterStack {
         return side == null ? Direction.DOWN : side;
     }
 
-    public boolean canInsertToTransporter(TileEntity tile, Direction from) {
+    public boolean canInsertToTransporter(TileEntity tile, Direction from, @Nullable TileEntity tileFrom) {
         Direction opposite = from.getOpposite();
-        LazyOptional<ILogisticalTransporter> transporterCap = CapabilityUtils.getCapability(tile, Capabilities.LOGISTICAL_TRANSPORTER_CAPABILITY, opposite);
+        Optional<ILogisticalTransporter> transporterCap = MekanismUtils.toOptional(CapabilityUtils.getCapability(tile, Capabilities.LOGISTICAL_TRANSPORTER_CAPABILITY, opposite));
         if (transporterCap.isPresent()) {
-            Optional<IBlockableConnection> blockableConnection = MekanismUtils.toOptional(CapabilityUtils.getCapability(tile, Capabilities.BLOCKABLE_CONNECTION_CAPABILITY, opposite));
-            if (blockableConnection.isPresent()) {
-                ILogisticalTransporter transporter = MekanismUtils.toOptional(transporterCap).get();
-                return blockableConnection.get().canConnectMutual(opposite) && (transporter.getColor() == color || transporter.getColor() == null);
+            ILogisticalTransporter transporter = transporterCap.get();
+            if (transporter.getColor() == null || transporter.getColor() == color) {
+                //If the color is valid, make sure that the connection is not blocked
+                Optional<IBlockableConnection> blockableConnection = MekanismUtils.toOptional(CapabilityUtils.getCapability(tile, Capabilities.BLOCKABLE_CONNECTION_CAPABILITY, opposite));
+                if (blockableConnection.isPresent()) {
+                    return blockableConnection.get().canConnectMutual(opposite, tileFrom);
+                }
             }
         }
         return false;
     }
 
     public boolean canInsertToTransporter(ILogisticalTransporter transporter, Direction side) {
-        return transporter.canConnectMutual(side) && (transporter.getColor() == color || transporter.getColor() == null);
+        //TODO: Check if we ever have a tile already gotten that we can pass as cached
+        return (transporter.getColor() == color || transporter.getColor() == null) && transporter.canConnectMutual(side, null);
     }
 
     public Coord4D getDest() {

--- a/src/main/java/mekanism/common/tile/TileEntityBin.java
+++ b/src/main/java/mekanism/common/tile/TileEntityBin.java
@@ -24,7 +24,6 @@ import mekanism.common.upgrade.IUpgradeData;
 import mekanism.common.util.CapabilityUtils;
 import mekanism.common.util.InventoryUtils;
 import mekanism.common.util.MekanismUtils;
-import mekanism.common.util.TransporterUtils;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.PacketBuffer;
@@ -96,7 +95,7 @@ public class TileEntityBin extends TileEntityMekanism implements IActiveState, I
                     TransitResponse response;
                     Optional<ILogisticalTransporter> capability = MekanismUtils.toOptional(CapabilityUtils.getCapability(tile, Capabilities.LOGISTICAL_TRANSPORTER_CAPABILITY, Direction.UP));
                     if (capability.isPresent()) {
-                        response = TransporterUtils.insert(this, capability.get(), TransitRequest.getFromStack(bottomStack), null, true, 0);
+                        response = capability.get().insert(this, TransitRequest.getFromStack(bottomStack), null, true, 0);
                     } else {
                         response = InventoryUtils.putStackInInventory(tile, TransitRequest.getFromStack(bottomStack), Direction.DOWN, false);
                     }

--- a/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
+++ b/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
@@ -57,7 +57,6 @@ import mekanism.common.util.ItemRegistryUtils;
 import mekanism.common.util.MekanismUtils;
 import mekanism.common.util.MinerUtils;
 import mekanism.common.util.StackUtils;
-import mekanism.common.util.TransporterUtils;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.BushBlock;
@@ -274,7 +273,7 @@ public class TileEntityDigitalMiner extends TileEntityMekanism implements IActiv
                     TransitResponse response;
                     Optional<ILogisticalTransporter> capability = MekanismUtils.toOptional(CapabilityUtils.getCapability(ejectInv, Capabilities.LOGISTICAL_TRANSPORTER_CAPABILITY, getOppositeDirection()));
                     if (capability.isPresent()) {
-                        response = TransporterUtils.insert(ejectTile, capability.get(), ejectMap, null, true, 0);
+                        response = capability.get().insert(ejectTile, ejectMap, null, true, 0);
                     } else {
                         response = InventoryUtils.putStackInInventory(ejectInv, ejectMap, getOppositeDirection(), false);
                     }

--- a/src/main/java/mekanism/common/tile/TileEntityLogisticalSorter.java
+++ b/src/main/java/mekanism/common/tile/TileEntityLogisticalSorter.java
@@ -148,9 +148,9 @@ public class TileEntityLogisticalSorter extends TileEntityMekanism implements IS
         if (capability.isPresent()) {
             ILogisticalTransporter transporter = capability.get();
             if (roundRobin) {
-                return TransporterUtils.insertRR(this, transporter, request, filterColor, true, min);
+                return transporter.insertRR(this, request, filterColor, true, min);
             }
-            return TransporterUtils.insert(this, transporter, request, filterColor, true, min);
+            return transporter.insert(this, request, filterColor, true, min);
         }
         return InventoryUtils.putStackInInventory(front, request, getDirection(), false);
     }

--- a/src/main/java/mekanism/common/tile/component/TileComponentEjector.java
+++ b/src/main/java/mekanism/common/tile/component/TileComponentEjector.java
@@ -147,7 +147,7 @@ public class TileComponentEjector implements ITileComponent {
             TransitResponse response;
             Optional<ILogisticalTransporter> capability = MekanismUtils.toOptional(CapabilityUtils.getCapability(tile, Capabilities.LOGISTICAL_TRANSPORTER_CAPABILITY, side.getOpposite()));
             if (capability.isPresent()) {
-                response = TransporterUtils.insert(this.tile, capability.get(), finalEjectMap, outputColor, true, 0);
+                response = capability.get().insert(this.tile, finalEjectMap, outputColor, true, 0);
             } else {
                 response = InventoryUtils.putStackInInventory(tile, finalEjectMap, side, false);
             }

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityLogisticalTransporter.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityLogisticalTransporter.java
@@ -141,7 +141,7 @@ public class TileEntityLogisticalTransporter extends TileEntityTransmitter<TileE
 
                 // There's a stack available to insert into the network...
                 if (!request.isEmpty()) {
-                    TransitResponse response = TransporterUtils.insert(tile, getTransmitter(), request, getTransmitter().getColor(), true, 0);
+                    TransitResponse response = getTransmitter().insert(tile, request, getTransmitter().getColor(), true, 0);
 
                     // If the insert succeeded, remove the inserted count and try again for another 10 ticks
                     if (!response.isEmpty()) {

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityTransmitter.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityTransmitter.java
@@ -78,7 +78,7 @@ public abstract class TileEntityTransmitter<A, N extends DynamicNetwork<A, N, BU
         if (isRemote()) {
             if (!dataRequest) {
                 dataRequest = true;
-                MinecraftForge.EVENT_BUS.post(new NetworkClientRequest(MekanismUtils.getTileEntity(getWorld(), getPos())));
+                MinecraftForge.EVENT_BUS.post(new NetworkClientRequest(this));
             }
         }
     }

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityUniversalCable.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityUniversalCable.java
@@ -159,7 +159,7 @@ public class TileEntityUniversalCable extends TileEntityTransmitter<EnergyAccept
 
     @Override
     public boolean isValidAcceptor(TileEntity acceptor, Direction side) {
-        return CableUtils.isValidAcceptorOnSide(MekanismUtils.getTileEntity(getWorld(), getPos()), acceptor, side);
+        return CableUtils.isValidAcceptorOnSide(this, acceptor, side);
     }
 
     @Override

--- a/src/main/java/mekanism/common/transmitters/TransmitterImpl.java
+++ b/src/main/java/mekanism/common/transmitters/TransmitterImpl.java
@@ -42,7 +42,7 @@ public class TransmitterImpl<ACCEPTOR, NETWORK extends DynamicNetwork<ACCEPTOR, 
     public Coord4D getAdjacentConnectableTransmitterCoord(Direction side) {
         Coord4D sideCoord = coord().offset(side);
         TileEntity potentialTransmitterTile = MekanismUtils.getTileEntity(world(), sideCoord.getPos());
-        if (!containingTile.canConnectMutual(side)) {
+        if (!containingTile.canConnectMutual(side, potentialTransmitterTile)) {
             return null;
         }
         Optional<IGridTransmitter<?, ?, ?>> gridTransmitter = MekanismUtils.toOptional(CapabilityUtils.getCapability(potentialTransmitterTile,

--- a/src/main/java/mekanism/common/transmitters/TransporterImpl.java
+++ b/src/main/java/mekanism/common/transmitters/TransporterImpl.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import mekanism.api.Coord4D;
 import mekanism.api.TileNetworkList;
 import mekanism.api.text.EnumColor;
@@ -128,7 +129,7 @@ public class TransporterImpl extends TransmitterImpl<TileEntity, InventoryNetwor
                         if (next != null) {
                             if (!stack.isFinal(this)) {
                                 TileEntity tile = MekanismUtils.getTileEntity(world(), next.getPos());
-                                if (stack.canInsertToTransporter(tile, stack.getSide(this))) {
+                                if (stack.canInsertToTransporter(tile, stack.getSide(this), containingTile)) {
                                     CapabilityUtils.getCapability(tile, Capabilities.LOGISTICAL_TRANSPORTER_CAPABILITY, null).ifPresent(nextTile ->
                                           nextTile.entityEntering(stack, stack.progress % 100));
                                     deletes.add(stackId);
@@ -168,7 +169,7 @@ public class TransporterImpl extends TransmitterImpl<TileEntity, InventoryNetwor
                     if (stack.isFinal(this)) {
                         tryRecalculate = checkPath(stack, Path.DEST, false) || checkPath(stack, Path.HOME, true) || stack.getPathType() == Path.NONE;
                     } else {
-                        tryRecalculate = !stack.canInsertToTransporter(MekanismUtils.getTileEntity(world(), stack.getNext(this).getPos()), stack.getSide(this));
+                        tryRecalculate = !stack.canInsertToTransporter(MekanismUtils.getTileEntity(world(), stack.getNext(this).getPos()), stack.getSide(this), containingTile);
                     }
                     if (tryRecalculate && !recalculate(stackId, stack, null)) {
                         deletes.add(stackId);
@@ -317,8 +318,8 @@ public class TransporterImpl extends TransmitterImpl<TileEntity, InventoryNetwor
     }
 
     @Override
-    public boolean canConnectMutual(Direction side) {
-        return getTileEntity().canConnectMutual(side);
+    public boolean canConnectMutual(Direction side, @Nullable TileEntity cachedTile) {
+        return getTileEntity().canConnectMutual(side, cachedTile);
     }
 
     @Override

--- a/src/main/java/mekanism/common/transmitters/TransporterImpl.java
+++ b/src/main/java/mekanism/common/transmitters/TransporterImpl.java
@@ -222,13 +222,14 @@ public class TransporterImpl extends TransmitterImpl<TileEntity, InventoryNetwor
     }
 
     @Override
-    public TransitResponse insert(Coord4D original, TransitRequest request, EnumColor color, boolean doEmit, int min) {
+    public TransitResponse insert(TileEntity outputter, TransitRequest request, EnumColor color, boolean doEmit, int min) {
+        Coord4D original = Coord4D.get(outputter);
         Direction from = coord().sideDifference(original).getOpposite();
         TransporterStack stack = new TransporterStack();
         stack.originalLocation = original;
         stack.homeLocation = original;
         stack.color = color;
-        if (!stack.canInsertToTransporter(this, from)) {
+        if (!stack.canInsertToTransporter(this, from, outputter)) {
             return TransitResponse.EMPTY;
         }
         TransitResponse response = stack.recalculatePath(request, this, min);
@@ -260,7 +261,7 @@ public class TransporterImpl extends TransmitterImpl<TileEntity, InventoryNetwor
         stack.originalLocation = Coord4D.get(outputter);
         stack.homeLocation = Coord4D.get(outputter);
         stack.color = color;
-        if (!canReceiveFrom(outputter, from) || !stack.canInsertToTransporter(this, from)) {
+        if (!canReceiveFrom(outputter, from) || !stack.canInsertToTransporter(this, from, outputter)) {
             return TransitResponse.EMPTY;
         }
         TransitResponse response = stack.recalculateRRPath(request, outputter, this, min);

--- a/src/main/java/mekanism/common/transmitters/TransporterImpl.java
+++ b/src/main/java/mekanism/common/transmitters/TransporterImpl.java
@@ -103,6 +103,9 @@ public class TransporterImpl extends TransmitterImpl<TileEntity, InventoryNetwor
             Set<Integer> deletes = new HashSet<>();
             getTileEntity().pullItems();
             Coord4D coord = coord();
+            //Note: Our calls to getTileEntity are not done with a chunkMap as we don't tend to have that many tiles we
+            // are checking at once from here and given this gets called each tick, it would cause unnecessary garbage
+            // collection to occur actually causing the tick time to go up slightly.
             for (Entry<Integer, TransporterStack> entry : transit.entrySet()) {
                 int stackId = entry.getKey();
                 TransporterStack stack = entry.getValue();
@@ -187,7 +190,7 @@ public class TransporterImpl extends TransmitterImpl<TileEntity, InventoryNetwor
 
                 // Finally, notify clients and mark chunk for save
                 //TODO: Check
-                Mekanism.packetHandler.sendToAllTracking(msg, getTileEntity().getWorld(), coord.getPos());
+                Mekanism.packetHandler.sendToAllTracking(msg, world(), coord.getPos());
                 MekanismUtils.saveChunk(getTileEntity());
             }
         }

--- a/src/main/java/mekanism/common/transmitters/grid/EnergyNetwork.java
+++ b/src/main/java/mekanism/common/transmitters/grid/EnergyNetwork.java
@@ -1,8 +1,10 @@
 package mekanism.common.transmitters.grid;
 
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import mekanism.api.Coord4D;
@@ -18,6 +20,7 @@ import mekanism.common.util.text.EnergyDisplay;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Direction;
 import net.minecraft.util.text.ITextComponent;
+import net.minecraft.world.chunk.IChunk;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Event;
 
@@ -91,12 +94,13 @@ public class EnergyNetwork extends DynamicNetwork<EnergyAcceptorWrapper, EnergyN
     private double tickEmit(double energyToSend) {
         Set<EnergyAcceptorTarget> targets = new HashSet<>();
         int totalHandlers = 0;
+        Map<Long, IChunk> chunkMap = new Long2ObjectOpenHashMap<>();
         for (Coord4D coord : possibleAcceptors) {
             EnumSet<Direction> sides = acceptorDirections.get(coord);
             if (sides == null || sides.isEmpty()) {
                 continue;
             }
-            TileEntity tile = MekanismUtils.getTileEntity(getWorld(), coord.getPos());
+            TileEntity tile = MekanismUtils.getTileEntity(getWorld(), chunkMap, coord);
             if (tile == null) {
                 continue;
             }

--- a/src/main/java/mekanism/common/transmitters/grid/FluidNetwork.java
+++ b/src/main/java/mekanism/common/transmitters/grid/FluidNetwork.java
@@ -1,8 +1,10 @@
 package mekanism.common.transmitters.grid;
 
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import mekanism.api.Coord4D;
@@ -17,6 +19,7 @@ import mekanism.common.util.PipeUtils;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Direction;
 import net.minecraft.util.text.ITextComponent;
+import net.minecraft.world.chunk.IChunk;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fluids.FluidStack;
@@ -107,12 +110,13 @@ public class FluidNetwork extends DynamicNetwork<IFluidHandler, FluidNetwork, Fl
     private int tickEmit(@Nonnull FluidStack fluidToSend) {
         Set<FluidHandlerTarget> availableAcceptors = new HashSet<>();
         int totalHandlers = 0;
+        Map<Long, IChunk> chunkMap = new Long2ObjectOpenHashMap<>();
         for (Coord4D coord : possibleAcceptors) {
             EnumSet<Direction> sides = acceptorDirections.get(coord);
             if (sides == null || sides.isEmpty()) {
                 continue;
             }
-            TileEntity tile = MekanismUtils.getTileEntity(getWorld(), coord.getPos());
+            TileEntity tile = MekanismUtils.getTileEntity(getWorld(), chunkMap, coord);
             if (tile == null) {
                 continue;
             }

--- a/src/main/java/mekanism/common/transmitters/grid/GasNetwork.java
+++ b/src/main/java/mekanism/common/transmitters/grid/GasNetwork.java
@@ -1,8 +1,10 @@
 package mekanism.common.transmitters.grid;
 
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import mekanism.api.Action;
@@ -22,6 +24,7 @@ import mekanism.common.util.text.TextComponentUtil;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Direction;
 import net.minecraft.util.text.ITextComponent;
+import net.minecraft.world.chunk.IChunk;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.Event;
 
@@ -125,12 +128,13 @@ public class GasNetwork extends DynamicNetwork<IGasHandler, GasNetwork, GasStack
         Set<GasHandlerTarget> availableAcceptors = new HashSet<>();
         int totalHandlers = 0;
         Gas type = stack.getType();
+        Map<Long, IChunk> chunkMap = new Long2ObjectOpenHashMap<>();
         for (Coord4D coord : possibleAcceptors) {
             EnumSet<Direction> sides = acceptorDirections.get(coord);
             if (sides == null || sides.isEmpty()) {
                 continue;
             }
-            TileEntity tile = MekanismUtils.getTileEntity(getWorld(), coord.getPos());
+            TileEntity tile = MekanismUtils.getTileEntity(getWorld(), chunkMap, coord);
             if (tile == null) {
                 continue;
             }

--- a/src/main/java/mekanism/common/transmitters/grid/InventoryNetwork.java
+++ b/src/main/java/mekanism/common/transmitters/grid/InventoryNetwork.java
@@ -45,7 +45,7 @@ public class InventoryNetwork extends DynamicNetwork<TileEntity, InventoryNetwor
             if (sides == null || sides.isEmpty()) {
                 continue;
             }
-            TileEntity acceptor = MekanismUtils.getTileEntity(getWorld(), chunkMap, coord.getPos());
+            TileEntity acceptor = MekanismUtils.getTileEntity(getWorld(), chunkMap, coord);
             if (acceptor == null) {
                 continue;
             }

--- a/src/main/java/mekanism/common/transmitters/grid/InventoryNetwork.java
+++ b/src/main/java/mekanism/common/transmitters/grid/InventoryNetwork.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import mekanism.api.Coord4D;
 import mekanism.api.transmitters.DynamicNetwork;
@@ -17,6 +18,7 @@ import mekanism.common.util.MekanismUtils;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Direction;
 import net.minecraft.util.text.ITextComponent;
+import net.minecraft.world.chunk.IChunk;
 
 public class InventoryNetwork extends DynamicNetwork<TileEntity, InventoryNetwork, Void> {
 
@@ -33,7 +35,7 @@ public class InventoryNetwork extends DynamicNetwork<TileEntity, InventoryNetwor
         register();
     }
 
-    public List<AcceptorData> calculateAcceptors(TransitRequest request, TransporterStack stack) {
+    public List<AcceptorData> calculateAcceptors(TransitRequest request, TransporterStack stack, Map<Long, IChunk> chunkMap) {
         List<AcceptorData> toReturn = new ArrayList<>();
         for (Coord4D coord : possibleAcceptors) {
             if (coord == null || coord.equals(stack.homeLocation)) {
@@ -43,7 +45,7 @@ public class InventoryNetwork extends DynamicNetwork<TileEntity, InventoryNetwor
             if (sides == null || sides.isEmpty()) {
                 continue;
             }
-            TileEntity acceptor = MekanismUtils.getTileEntity(getWorld(), coord.getPos());
+            TileEntity acceptor = MekanismUtils.getTileEntity(getWorld(), chunkMap, coord.getPos());
             if (acceptor == null) {
                 continue;
             }

--- a/src/main/java/mekanism/common/util/MekanismUtils.java
+++ b/src/main/java/mekanism/common/util/MekanismUtils.java
@@ -65,6 +65,8 @@ import net.minecraft.world.ILightReader;
 import net.minecraft.world.IWorld;
 import net.minecraft.world.IWorldReader;
 import net.minecraft.world.World;
+import net.minecraft.world.chunk.ChunkStatus;
+import net.minecraft.world.chunk.IChunk;
 import net.minecraftforge.common.UsernameCache;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.fluids.FluidAttributes;
@@ -875,6 +877,50 @@ public final class MekanismUtils {
             warnedFails.add(uuid);
         }
         return ret != null ? ret : "<???>";
+    }
+
+    /**
+     * Gets a tile entity if the location is loaded by getting the chunk from the passed in cache of chunks rather than directly using the world. We then store our chunk
+     * we found back in the cache so as to more quickly be able to lookup chunks if we are doing lots of lookups at once (For example the transporter pathfinding)
+     *
+     * @param world    - world
+     * @param chunkMap - cached chunk ma
+     * @param coord    - coordinates
+     *
+     * @return tile entity if found, null if either not found or not loaded
+     */
+    @Nullable
+    public static TileEntity getTileEntity(@Nonnull IWorld world, @Nonnull Map<Long, IChunk> chunkMap, @Nonnull Coord4D coord) {
+        return getTileEntity(world, chunkMap, coord.getPos());
+    }
+
+    /**
+     * Gets a tile entity if the location is loaded by getting the chunk from the passed in cache of chunks rather than directly using the world. We then store our chunk
+     * we found back in the cache so as to more quickly be able to lookup chunks if we are doing lots of lookups at once (For example the transporter pathfinding)
+     *
+     * @param world    - world
+     * @param chunkMap - cached chunk ma
+     * @param pos      - position
+     *
+     * @return tile entity if found, null if either not found or not loaded
+     */
+    @Nullable
+    public static TileEntity getTileEntity(@Nonnull IWorld world, @Nonnull Map<Long, IChunk> chunkMap, @Nonnull BlockPos pos) {
+        int chunkX = pos.getX() >> 4;
+        int chunkZ = pos.getZ() >> 4;
+        long combinedChunk = (((long) chunkX) << 32) | (chunkZ & 0xFFFFFFFFL);
+        //We get the chunk rather than the world so we can cache the chunk improving the overall
+        // performance for retrieving a bunch of chunks in the general vicinity
+        IChunk chunk = chunkMap.get(combinedChunk);
+        if (chunk == null) {
+            //Get the chunk but don't force load it
+            chunk = world.getChunk(chunkX, chunkZ, ChunkStatus.FULL, false);
+            if (chunk != null) {
+                chunkMap.put(combinedChunk, chunk);
+            }
+        }
+        //Get the tile entity using the chunk we found/had cached
+        return getTileEntity(chunk, pos);
     }
 
     /**

--- a/src/main/java/mekanism/common/util/MekanismUtils.java
+++ b/src/main/java/mekanism/common/util/MekanismUtils.java
@@ -890,7 +890,8 @@ public final class MekanismUtils {
      * @return tile entity if found, null if either not found or not loaded
      */
     @Nullable
-    public static TileEntity getTileEntity(@Nonnull IWorld world, @Nonnull Map<Long, IChunk> chunkMap, @Nonnull Coord4D coord) {
+    @Contract("null, _, _ -> null")
+    public static TileEntity getTileEntity(@Nullable IWorld world, @Nonnull Map<Long, IChunk> chunkMap, @Nonnull Coord4D coord) {
         return getTileEntity(world, chunkMap, coord.getPos());
     }
 
@@ -905,7 +906,12 @@ public final class MekanismUtils {
      * @return tile entity if found, null if either not found or not loaded
      */
     @Nullable
-    public static TileEntity getTileEntity(@Nonnull IWorld world, @Nonnull Map<Long, IChunk> chunkMap, @Nonnull BlockPos pos) {
+    @Contract("null, _, _ -> null")
+    public static TileEntity getTileEntity(@Nullable IWorld world, @Nonnull Map<Long, IChunk> chunkMap, @Nonnull BlockPos pos) {
+        if (world == null) {
+            //Allow the world to be nullable to remove warnings when we are calling things from a place that world could be null
+            return null;
+        }
         int chunkX = pos.getX() >> 4;
         int chunkZ = pos.getZ() >> 4;
         long combinedChunk = (((long) chunkX) << 32) | (chunkZ & 0xFFFFFFFFL);

--- a/src/main/java/mekanism/common/util/TransporterUtils.java
+++ b/src/main/java/mekanism/common/util/TransporterUtils.java
@@ -5,11 +5,8 @@ import java.util.List;
 import mekanism.api.text.EnumColor;
 import mekanism.common.base.ILogisticalTransporter;
 import mekanism.common.capabilities.Capabilities;
-import mekanism.common.content.transporter.TransitRequest;
-import mekanism.common.content.transporter.TransitRequest.TransitResponse;
 import mekanism.common.content.transporter.TransporterManager;
 import mekanism.common.content.transporter.TransporterStack;
-import mekanism.common.tile.TileEntityLogisticalSorter;
 import net.minecraft.block.Block;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Direction;
@@ -25,15 +22,6 @@ public final class TransporterUtils {
             return false;
         }
         return InventoryUtils.isItemHandler(tile, side.getOpposite());
-    }
-
-    //TODO: Decide if we want to inline this and insertRR
-    public static TransitResponse insert(TileEntity outputter, ILogisticalTransporter transporter, TransitRequest request, EnumColor color, boolean doEmit, int min) {
-        return transporter.insert(outputter, request, color, doEmit, min);
-    }
-
-    public static TransitResponse insertRR(TileEntityLogisticalSorter outputter, ILogisticalTransporter transporter, TransitRequest request, EnumColor color, boolean doEmit, int min) {
-        return transporter.insertRR(outputter, request, color, doEmit, min);
     }
 
     public static EnumColor increment(EnumColor color) {

--- a/src/main/java/mekanism/common/util/TransporterUtils.java
+++ b/src/main/java/mekanism/common/util/TransporterUtils.java
@@ -2,7 +2,6 @@ package mekanism.common.util;
 
 import java.util.Arrays;
 import java.util.List;
-import mekanism.api.Coord4D;
 import mekanism.api.text.EnumColor;
 import mekanism.common.base.ILogisticalTransporter;
 import mekanism.common.capabilities.Capabilities;
@@ -28,8 +27,9 @@ public final class TransporterUtils {
         return InventoryUtils.isItemHandler(tile, side.getOpposite());
     }
 
+    //TODO: Decide if we want to inline this and insertRR
     public static TransitResponse insert(TileEntity outputter, ILogisticalTransporter transporter, TransitRequest request, EnumColor color, boolean doEmit, int min) {
-        return transporter.insert(Coord4D.get(outputter), request, color, doEmit, min);
+        return transporter.insert(outputter, request, color, doEmit, min);
     }
 
     public static TransitResponse insertRR(TileEntityLogisticalSorter outputter, ILogisticalTransporter transporter, TransitRequest request, EnumColor color, boolean doEmit, int min) {


### PR DESCRIPTION
Changes:
- Move things around a bit so more parts of the Transporter path finder make use of being able to use a temporary map as a cache for chunk lookup. (Speeds up `getTileEntity` calls a fair bit)
- Cleaned up logic around how path finding works, so that returning to the start location is properly handled. (#5335 ended up causing #5843 )
- Fixed a case where path finding exited too early due to a non direct path that works, and having a second arbitrary path just connected to the same network that "quickly" left the range so had a low score but was not in range of our max distance check. Previously we just exited, and now in that case we just stop checking that path but continue checking other potential paths we may have. (Image below)

![2020-02-04_11 07 07](https://user-images.githubusercontent.com/1203288/73762736-86015480-473e-11ea-88d1-665c71337d26.png)

The path to the left in the image does not lead towards the destination chest. Before this PR breaking that path off of the network would make items transfer from one chest to the other but adding it back would cause them to stop transferring. Now with this PR it just ignores checking that alternate path once it gets out of range.