### PR TITLE
Multiblock structure logic improvements

### DIFF
--- a/src/generators/java/mekanism/generators/client/render/RenderFissionReactor.java
+++ b/src/generators/java/mekanism/generators/client/render/RenderFissionReactor.java
@@ -1,8 +1,8 @@
 package mekanism.generators.client.render;
 
+import javax.annotation.ParametersAreNonnullByDefault;
 import com.mojang.blaze3d.matrix.MatrixStack;
 import com.mojang.blaze3d.vertex.IVertexBuilder;
-import javax.annotation.ParametersAreNonnullByDefault;
 import mekanism.api.Coord4D;
 import mekanism.client.render.MekanismRenderType;
 import mekanism.client.render.MekanismRenderer;
@@ -54,13 +54,13 @@ public class RenderFissionReactor extends MekanismTileEntityRenderer<TileEntityF
                 }
             }
             if (!tile.getMultiblock().fluidCoolantTank.isEmpty()) {
-                int height = tile.getMultiblock().height - 2;
+                int height = tile.getMultiblock().height() - 2;
                 if (height >= 1) {
                     FluidRenderData data = new FluidRenderData(tile.getMultiblock().fluidCoolantTank.getFluid());
                     data.location = new Coord4D(tile.getMultiblock().renderLocation, tile.getWorld());
                     data.height = height;
-                    data.length = tile.getMultiblock().length;
-                    data.width = tile.getMultiblock().width;
+                    data.length = tile.getMultiblock().length();
+                    data.width = tile.getMultiblock().width();
                     int glow = data.calculateGlowLight(light);
                     matrix.push();
                     matrix.translate(data.location.x - pos.getX(), data.location.y - pos.getY(), data.location.z - pos.getZ());
@@ -70,13 +70,13 @@ public class RenderFissionReactor extends MekanismTileEntityRenderer<TileEntityF
                 }
             }
             if (!tile.getMultiblock().heatedCoolantTank.isEmpty()) {
-                int height = tile.getMultiblock().height - 2;
+                int height = tile.getMultiblock().height() - 2;
                 if (height >= 1) {
                     GasRenderData data = new GasRenderData(tile.getMultiblock().heatedCoolantTank.getStack());
                     data.location = new Coord4D(tile.getMultiblock().renderLocation, tile.getWorld());
                     data.height = height;
-                    data.length = tile.getMultiblock().length;
-                    data.width = tile.getMultiblock().width;
+                    data.length = tile.getMultiblock().length();
+                    data.width = tile.getMultiblock().width();
                     matrix.push();
                     matrix.scale(0.998F, 0.998F, 0.998F);
                     matrix.translate(data.location.x - pos.getX() + 0.001, data.location.y - pos.getY() + 0.001, data.location.z - pos.getZ() + 0.001);

--- a/src/generators/java/mekanism/generators/client/render/RenderIndustrialTurbine.java
+++ b/src/generators/java/mekanism/generators/client/render/RenderIndustrialTurbine.java
@@ -1,8 +1,8 @@
 package mekanism.generators.client.render;
 
+import javax.annotation.ParametersAreNonnullByDefault;
 import com.mojang.blaze3d.matrix.MatrixStack;
 import com.mojang.blaze3d.vertex.IVertexBuilder;
-import javax.annotation.ParametersAreNonnullByDefault;
 import mekanism.api.Coord4D;
 import mekanism.client.render.MekanismRenderType;
 import mekanism.client.render.MekanismRenderer;
@@ -45,14 +45,14 @@ public class RenderIndustrialTurbine extends MekanismTileEntityRenderer<TileEnti
                 matrix.pop();
             }
             profiler.endSection();
-            if (!tile.getMultiblock().gasTank.isEmpty() && tile.getMultiblock().length > 0) {
-                int height = tile.getMultiblock().lowerVolume / (tile.getMultiblock().length * tile.getMultiblock().width);
+            if (!tile.getMultiblock().gasTank.isEmpty() && tile.getMultiblock().length() > 0) {
+                int height = tile.getMultiblock().lowerVolume / (tile.getMultiblock().length() * tile.getMultiblock().width());
                 if (height >= 1) {
                     GasRenderData data = new GasRenderData(tile.getMultiblock().gasTank.getStack());
                     data.location = new Coord4D(tile.getMultiblock().renderLocation, tile.getWorld());
                     data.height = height;
-                    data.length = tile.getMultiblock().length;
-                    data.width = tile.getMultiblock().width;
+                    data.length = tile.getMultiblock().length();
+                    data.width = tile.getMultiblock().width();
                     matrix.push();
                     matrix.translate(data.location.x - pos.getX(), data.location.y - pos.getY(), data.location.z - pos.getZ());
                     Model3D gasModel = ModelRenderer.getModel(data, 1);

--- a/src/generators/java/mekanism/generators/common/content/fission/FissionReactorMultiblockData.java
+++ b/src/generators/java/mekanism/generators/common/content/fission/FissionReactorMultiblockData.java
@@ -29,7 +29,6 @@ import mekanism.generators.common.tile.fission.TileEntityFissionReactorCasing;
 import mekanism.generators.common.tile.fission.TileEntityFissionReactorPort;
 import net.minecraft.tags.FluidTags;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
 public class FissionReactorMultiblockData extends MultiblockData {
@@ -188,8 +187,8 @@ public class FissionReactorMultiblockData extends MultiblockData {
                     radiation += wasteTank.getStored() * wasteTank.getStack().get(GasAttributes.Radiation.class).getRadioactivity();
                 }
                 radiation *= MekanismGeneratorsConfig.generators.fissionMeltdownRadiationMultiplier.get();
-                Mekanism.radiationManager.radiate(new Coord4D(getCenter(), world), radiation);
-                Mekanism.radiationManager.createMeltdown(world, new Coord4D(minLocation, world), new Coord4D(maxLocation, world), heatCapacitor.getHeat(), EXPLOSION_CHANCE);
+                Mekanism.radiationManager.radiate(new Coord4D(bounds.getCenter(), world), radiation);
+                Mekanism.radiationManager.createMeltdown(world, new Coord4D(bounds.getMinPos(), world), new Coord4D(bounds.getMaxPos(), world), heatCapacitor.getHeat(), EXPLOSION_CHANCE);
             }
         }
     }
@@ -240,10 +239,7 @@ public class FissionReactorMultiblockData extends MultiblockData {
     }
 
     public boolean handlesSound(TileEntityFissionReactorCasing tile) {
-        BlockPos pos = tile.getPos();
-        return (pos.getX() == minLocation.getX() || pos.getX() == maxLocation.getX()) &&
-               (pos.getY() == minLocation.getY() || pos.getY() == maxLocation.getY()) &&
-               (pos.getZ() == minLocation.getZ() || pos.getZ() == maxLocation.getZ());
+        return bounds.isOnCorner(tile.getPos());
 
     }
 
@@ -269,20 +265,11 @@ public class FissionReactorMultiblockData extends MultiblockData {
             wasteTank.insert(wasteToAdd, Action.EXECUTE, AutomationType.INTERNAL);
             if (leftoverWaste > 0) {
                 double radioactivity = wasteToAdd.getType().get(GasAttributes.Radiation.class).getRadioactivity();
-                Mekanism.radiationManager.radiate(new Coord4D(getCenter(), world), leftoverWaste * radioactivity);
+                Mekanism.radiationManager.radiate(new Coord4D(bounds.getCenter(), world), leftoverWaste * radioactivity);
             }
         }
         // update previous burn
         lastBurnRate = toBurn;
-    }
-
-    public BlockPos getCenter() {
-        if (minLocation == null || maxLocation == null) {
-            return null;
-        }
-        return new BlockPos((minLocation.getX() + maxLocation.getX()) / 2,
-              (minLocation.getY() + maxLocation.getY()) / 2,
-              (minLocation.getZ() + maxLocation.getZ()) / 2);
     }
 
     @Override

--- a/src/generators/java/mekanism/generators/common/content/fusion/FusionReactorMultiblockData.java
+++ b/src/generators/java/mekanism/generators/common/content/fusion/FusionReactorMultiblockData.java
@@ -121,8 +121,8 @@ public class FusionReactorMultiblockData extends MultiblockData {
                 heatHandlers.add((ITileHeatHandler) tile);
             }
         }
-        deathZone = new AxisAlignedBB(minLocation.getX() + 1, minLocation.getY() + 1, minLocation.getZ() + 1,
-              maxLocation.getX(), maxLocation.getY(), maxLocation.getZ());
+        deathZone = new AxisAlignedBB(bounds.getMinPos().getX() + 1, bounds.getMinPos().getY() + 1, bounds.getMinPos().getZ() + 1,
+              bounds.getMaxPos().getX(), bounds.getMaxPos().getY(), bounds.getMaxPos().getZ());
     }
 
     public void addTemperatureFromEnergyInput(FloatingLong energyAdded) {

--- a/src/generators/java/mekanism/generators/common/content/fusion/FusionReactorMultiblockData.java
+++ b/src/generators/java/mekanism/generators/common/content/fusion/FusionReactorMultiblockData.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import java.util.Set;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import mekanism.api.Action;
+import mekanism.api.NBTConstants;
 import mekanism.api.chemical.gas.IGasHandler;
 import mekanism.api.chemical.gas.IGasTank;
 import mekanism.api.fluid.IExtendedFluidTank;
@@ -25,6 +26,7 @@ import mekanism.common.lib.multiblock.MultiblockData;
 import mekanism.common.registries.MekanismGases;
 import mekanism.common.util.HeatUtils;
 import mekanism.common.util.MekanismUtils;
+import mekanism.common.util.NBTUtils;
 import mekanism.generators.common.GeneratorTags;
 import mekanism.generators.common.config.MekanismGeneratorsConfig;
 import mekanism.generators.common.item.ItemHohlraum;
@@ -34,6 +36,7 @@ import mekanism.generators.common.tile.fusion.TileEntityFusionReactorBlock;
 import mekanism.generators.common.tile.fusion.TileEntityFusionReactorPort;
 import net.minecraft.entity.Entity;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.tags.FluidTags;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.DamageSource;
@@ -121,8 +124,22 @@ public class FusionReactorMultiblockData extends MultiblockData {
                 heatHandlers.add((ITileHeatHandler) tile);
             }
         }
-        deathZone = new AxisAlignedBB(bounds.getMinPos().getX() + 1, bounds.getMinPos().getY() + 1, bounds.getMinPos().getZ() + 1,
-              bounds.getMaxPos().getX(), bounds.getMaxPos().getY(), bounds.getMaxPos().getZ());
+        deathZone = new AxisAlignedBB(getMinPos().getX() + 1, getMinPos().getY() + 1, getMinPos().getZ() + 1,
+              getMaxPos().getX(), getMaxPos().getY(), getMaxPos().getZ());
+    }
+
+    @Override
+    public void readUpdateTag(CompoundNBT tag) {
+        super.readUpdateTag(tag);
+        NBTUtils.setDoubleIfPresent(tag, NBTConstants.PLASMA_TEMP, this::setLastPlasmaTemp);
+        NBTUtils.setBooleanIfPresent(tag, NBTConstants.BURNING, this::setBurning);
+    }
+
+    @Override
+    public void writeUpdateTag(CompoundNBT tag) {
+        super.writeUpdateTag(tag);
+        tag.putDouble(NBTConstants.PLASMA_TEMP, getLastPlasmaTemp());
+        tag.putBoolean(NBTConstants.BURNING, isBurning());
     }
 
     public void addTemperatureFromEnergyInput(FloatingLong energyAdded) {

--- a/src/generators/java/mekanism/generators/common/content/turbine/TurbineValidator.java
+++ b/src/generators/java/mekanism/generators/common/content/turbine/TurbineValidator.java
@@ -60,8 +60,8 @@ public class TurbineValidator extends CuboidStructureValidator<TurbineMultiblock
         if (structure.length % 2 != 1 || structure.width % 2 != 1) {
             return FormationResult.fail(GeneratorsLang.TURBINE_INVALID_EVEN_LENGTH);
         }
-        int centerX = structure.minLocation.getX() + (structure.length - 1) / 2;
-        int centerZ = structure.minLocation.getZ() + (structure.width - 1) / 2;
+        int centerX = structure.bounds.getMinPos().getX() + (structure.length - 1) / 2;
+        int centerZ = structure.bounds.getMinPos().getZ() + (structure.width - 1) / 2;
 
         BlockPos complex = null;
 
@@ -98,7 +98,7 @@ public class TurbineValidator extends CuboidStructureValidator<TurbineMultiblock
             return FormationResult.fail(GeneratorsLang.TURBINE_INVALID_MISSING_COMPLEX);
         }
 
-        int rotors = complex.getY() - structure.minLocation.getY() + 1;
+        int rotors = complex.getY() - structure.bounds.getMinPos().getY() + 1;
         int innerRadius = (Math.min(structure.length, structure.width) - 3) / 2;
         if (innerRadius < rotors / 4) {
             return FormationResult.fail(GeneratorsLang.TURBINE_INVALID_TOO_NARROW);
@@ -134,7 +134,7 @@ public class TurbineValidator extends CuboidStructureValidator<TurbineMultiblock
         int blades = 0;
 
         // Starting from the complex, walk down and count the number of rotors/blades in the structure
-        for (int y = complex.getY() - 1; y > structure.minLocation.getY(); y--) {
+        for (int y = complex.getY() - 1; y > structure.bounds.getMinPos().getY(); y--) {
             TileEntityTurbineRotor rotor = MekanismUtils.getTileEntity(TileEntityTurbineRotor.class, world, new BlockPos(centerX, y, centerZ));
             if (rotor == null) {
                 // Not a contiguous set of rotors

--- a/src/generators/java/mekanism/generators/common/content/turbine/TurbineValidator.java
+++ b/src/generators/java/mekanism/generators/common/content/turbine/TurbineValidator.java
@@ -57,11 +57,11 @@ public class TurbineValidator extends CuboidStructureValidator<TurbineMultiblock
 
     @Override
     public FormationResult postcheck(TurbineMultiblockData structure, Set<BlockPos> innerNodes) {
-        if (structure.length % 2 != 1 || structure.width % 2 != 1) {
+        if (structure.length() % 2 != 1 || structure.width() % 2 != 1) {
             return FormationResult.fail(GeneratorsLang.TURBINE_INVALID_EVEN_LENGTH);
         }
-        int centerX = structure.bounds.getMinPos().getX() + (structure.length - 1) / 2;
-        int centerZ = structure.bounds.getMinPos().getZ() + (structure.width - 1) / 2;
+        int centerX = structure.getMinPos().getX() + (structure.length() - 1) / 2;
+        int centerZ = structure.getMinPos().getZ() + (structure.width() - 1) / 2;
 
         BlockPos complex = null;
 
@@ -98,8 +98,8 @@ public class TurbineValidator extends CuboidStructureValidator<TurbineMultiblock
             return FormationResult.fail(GeneratorsLang.TURBINE_INVALID_MISSING_COMPLEX);
         }
 
-        int rotors = complex.getY() - structure.bounds.getMinPos().getY() + 1;
-        int innerRadius = (Math.min(structure.length, structure.width) - 3) / 2;
+        int rotors = complex.getY() - structure.getMinPos().getY() + 1;
+        int innerRadius = (Math.min(structure.length(), structure.width()) - 3) / 2;
         if (innerRadius < rotors / 4) {
             return FormationResult.fail(GeneratorsLang.TURBINE_INVALID_TOO_NARROW);
         }
@@ -134,7 +134,7 @@ public class TurbineValidator extends CuboidStructureValidator<TurbineMultiblock
         int blades = 0;
 
         // Starting from the complex, walk down and count the number of rotors/blades in the structure
-        for (int y = complex.getY() - 1; y > structure.bounds.getMinPos().getY(); y--) {
+        for (int y = complex.getY() - 1; y > structure.getMinPos().getY(); y--) {
             TileEntityTurbineRotor rotor = MekanismUtils.getTileEntity(TileEntityTurbineRotor.class, world, new BlockPos(centerX, y, centerZ));
             if (rotor == null) {
                 // Not a contiguous set of rotors
@@ -171,7 +171,7 @@ public class TurbineValidator extends CuboidStructureValidator<TurbineMultiblock
                 structure.vents++;
             }
         }
-        structure.lowerVolume = structure.length * structure.width * turbineHeight;
+        structure.lowerVolume = structure.length() * structure.width() * turbineHeight;
         structure.complex = complex;
         return FormationResult.SUCCESS;
     }

--- a/src/generators/java/mekanism/generators/common/tile/fission/TileEntityFissionReactorCasing.java
+++ b/src/generators/java/mekanism/generators/common/tile/fission/TileEntityFissionReactorCasing.java
@@ -4,19 +4,15 @@ import javax.annotation.Nonnull;
 import mekanism.api.NBTConstants;
 import mekanism.api.providers.IBlockProvider;
 import mekanism.api.text.EnumColor;
-import mekanism.common.lib.multiblock.IValveHandler;
 import mekanism.common.lib.multiblock.MultiblockManager;
 import mekanism.common.tile.prefab.TileEntityMultiblock;
 import mekanism.common.util.NBTUtils;
 import mekanism.generators.common.MekanismGenerators;
 import mekanism.generators.common.content.fission.FissionReactorMultiblockData;
-import mekanism.generators.common.content.fission.FissionReactorValidator.FormedAssembly;
 import mekanism.generators.common.registries.GeneratorsBlocks;
 import net.minecraft.nbt.CompoundNBT;
-import net.minecraft.nbt.ListNBT;
-import net.minecraftforge.common.util.Constants.NBT;
 
-public class TileEntityFissionReactorCasing extends TileEntityMultiblock<FissionReactorMultiblockData> implements IValveHandler<FissionReactorMultiblockData> {
+public class TileEntityFissionReactorCasing extends TileEntityMultiblock<FissionReactorMultiblockData> {
 
     private boolean handleSound;
     private boolean prevBurning;
@@ -93,21 +89,6 @@ public class TileEntityFissionReactorCasing extends TileEntityMultiblock<Fission
         updateTag.putBoolean(NBTConstants.HANDLE_SOUND, getMultiblock().isFormed() && getMultiblock().handlesSound(this));
         if (getMultiblock().isFormed()) {
             updateTag.putDouble(NBTConstants.BURNING, getMultiblock().lastBurnRate);
-            if (isMaster) {
-                updateTag.putFloat(NBTConstants.SCALE, getMultiblock().prevCoolantScale);
-                updateTag.putFloat(NBTConstants.SCALE_ALT, getMultiblock().prevFuelScale);
-                updateTag.putFloat(NBTConstants.SCALE_ALT_2, getMultiblock().prevHeatedCoolantScale);
-                updateTag.putFloat(NBTConstants.SCALE_ALT_3, getMultiblock().prevWasteScale);
-                updateTag.putInt(NBTConstants.VOLUME, getMultiblock().getVolume());
-                updateTag.put(NBTConstants.FLUID_STORED, getMultiblock().fluidCoolantTank.getFluid().writeToNBT(new CompoundNBT()));
-                updateTag.put(NBTConstants.GAS_STORED, getMultiblock().fuelTank.getStack().write(new CompoundNBT()));
-                updateTag.put(NBTConstants.GAS_STORED_ALT, getMultiblock().heatedCoolantTank.getStack().write(new CompoundNBT()));
-                updateTag.put(NBTConstants.GAS_STORED_ALT_2, getMultiblock().wasteTank.getStack().write(new CompoundNBT()));
-                writeValves(updateTag);
-                ListNBT list = new ListNBT();
-                getMultiblock().assemblies.forEach(assembly -> list.add(assembly.write()));
-                updateTag.put(NBTConstants.ASSEMBLIES, list);
-            }
         }
         return updateTag;
     }
@@ -118,25 +99,6 @@ public class TileEntityFissionReactorCasing extends TileEntityMultiblock<Fission
         NBTUtils.setBooleanIfPresent(tag, NBTConstants.HANDLE_SOUND, value -> handleSound = value);
         if (getMultiblock().isFormed()) {
             NBTUtils.setDoubleIfPresent(tag, NBTConstants.BURNING, value -> getMultiblock().lastBurnRate = value);
-            if (isMaster) {
-                NBTUtils.setFloatIfPresent(tag, NBTConstants.SCALE, scale -> getMultiblock().prevCoolantScale = scale);
-                NBTUtils.setFloatIfPresent(tag, NBTConstants.SCALE_ALT, scale -> getMultiblock().prevFuelScale = scale);
-                NBTUtils.setFloatIfPresent(tag, NBTConstants.SCALE_ALT_2, scale -> getMultiblock().prevHeatedCoolantScale = scale);
-                NBTUtils.setFloatIfPresent(tag, NBTConstants.SCALE_ALT_3, scale -> getMultiblock().prevWasteScale = scale);
-                NBTUtils.setIntIfPresent(tag, NBTConstants.VOLUME, value -> getMultiblock().setVolume(value));
-                NBTUtils.setFluidStackIfPresent(tag, NBTConstants.FLUID_STORED, value -> getMultiblock().fluidCoolantTank.setStack(value));
-                NBTUtils.setGasStackIfPresent(tag, NBTConstants.GAS_STORED, value -> getMultiblock().fuelTank.setStack(value));
-                NBTUtils.setGasStackIfPresent(tag, NBTConstants.GAS_STORED_ALT, value -> getMultiblock().heatedCoolantTank.setStack(value));
-                NBTUtils.setGasStackIfPresent(tag, NBTConstants.GAS_STORED_ALT_2, value -> getMultiblock().wasteTank.setStack(value));
-                readValves(tag);
-                getMultiblock().assemblies.clear();
-                if (tag.contains(NBTConstants.ASSEMBLIES)) {
-                    ListNBT list = tag.getList(NBTConstants.ASSEMBLIES, NBT.TAG_COMPOUND);
-                    for (int i = 0; i < list.size(); i++) {
-                        getMultiblock().assemblies.add(FormedAssembly.read(list.getCompound(i)));
-                    }
-                }
-            }
         }
     }
 }

--- a/src/generators/java/mekanism/generators/common/tile/fission/TileEntityFissionReactorCasing.java
+++ b/src/generators/java/mekanism/generators/common/tile/fission/TileEntityFissionReactorCasing.java
@@ -16,7 +16,7 @@ import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.nbt.ListNBT;
 import net.minecraftforge.common.util.Constants.NBT;
 
-public class TileEntityFissionReactorCasing extends TileEntityMultiblock<FissionReactorMultiblockData> implements IValveHandler {
+public class TileEntityFissionReactorCasing extends TileEntityMultiblock<FissionReactorMultiblockData> implements IValveHandler<FissionReactorMultiblockData> {
 
     private boolean handleSound;
     private boolean prevBurning;

--- a/src/generators/java/mekanism/generators/common/tile/fission/TileEntityFissionReactorPort.java
+++ b/src/generators/java/mekanism/generators/common/tile/fission/TileEntityFissionReactorPort.java
@@ -102,7 +102,7 @@ public class TileEntityFissionReactorPort extends TileEntityFissionReactorCasing
     public FluidStack insertFluid(FluidStack stack, Direction side, Action action) {
         FluidStack ret = super.insertFluid(stack, side, action);
         if (ret.getAmount() < stack.getAmount() && action.execute()) {
-            triggerValveTransfer();
+            getMultiblock().triggerValveTransfer(this);
         }
         return ret;
     }

--- a/src/generators/java/mekanism/generators/common/tile/fusion/TileEntityFusionReactorBlock.java
+++ b/src/generators/java/mekanism/generators/common/tile/fusion/TileEntityFusionReactorBlock.java
@@ -1,17 +1,13 @@
 package mekanism.generators.common.tile.fusion;
 
-import javax.annotation.Nonnull;
-import mekanism.api.NBTConstants;
 import mekanism.api.providers.IBlockProvider;
 import mekanism.common.inventory.container.MekanismContainer;
 import mekanism.common.inventory.container.sync.dynamic.SyncMapper;
 import mekanism.common.lib.multiblock.MultiblockManager;
 import mekanism.common.tile.prefab.TileEntityMultiblock;
-import mekanism.common.util.NBTUtils;
 import mekanism.generators.common.MekanismGenerators;
 import mekanism.generators.common.content.fusion.FusionReactorMultiblockData;
 import mekanism.generators.common.registries.GeneratorsBlocks;
-import net.minecraft.nbt.CompoundNBT;
 
 public class TileEntityFusionReactorBlock extends TileEntityMultiblock<FusionReactorMultiblockData> {
 
@@ -36,26 +32,6 @@ public class TileEntityFusionReactorBlock extends TileEntityMultiblock<FusionRea
     @Override
     protected boolean canBeMaster() {
         return false;
-    }
-
-    @Nonnull
-    @Override
-    public CompoundNBT getReducedUpdateTag() {
-        CompoundNBT updateTag = super.getReducedUpdateTag();
-        if (getMultiblock().isFormed() && isMaster) {
-            updateTag.putDouble(NBTConstants.PLASMA_TEMP, getMultiblock().getLastPlasmaTemp());
-            updateTag.putBoolean(NBTConstants.BURNING, getMultiblock().isBurning());
-        }
-        return updateTag;
-    }
-
-    @Override
-    public void handleUpdateTag(@Nonnull CompoundNBT tag) {
-        super.handleUpdateTag(tag);
-        if (getMultiblock().isFormed() && isMaster) {
-            NBTUtils.setDoubleIfPresent(tag, NBTConstants.PLASMA_TEMP, getMultiblock()::setLastPlasmaTemp);
-            NBTUtils.setBooleanIfPresent(tag, NBTConstants.BURNING, getMultiblock()::setBurning);
-        }
     }
 
     public void setInjectionRateFromPacket(int rate) {

--- a/src/generators/java/mekanism/generators/common/tile/turbine/TileEntityTurbineCasing.java
+++ b/src/generators/java/mekanism/generators/common/tile/turbine/TileEntityTurbineCasing.java
@@ -1,17 +1,13 @@
 package mekanism.generators.common.tile.turbine;
 
 import javax.annotation.Nonnull;
-import mekanism.api.NBTConstants;
 import mekanism.api.providers.IBlockProvider;
 import mekanism.common.lib.multiblock.MultiblockManager;
 import mekanism.common.tile.interfaces.IHasGasMode;
 import mekanism.common.tile.prefab.TileEntityMultiblock;
-import mekanism.common.util.NBTUtils;
 import mekanism.generators.common.MekanismGenerators;
 import mekanism.generators.common.content.turbine.TurbineMultiblockData;
 import mekanism.generators.common.registries.GeneratorsBlocks;
-import net.minecraft.nbt.CompoundNBT;
-import net.minecraft.nbt.NBTUtil;
 
 public class TileEntityTurbineCasing extends TileEntityMultiblock<TurbineMultiblockData> implements IHasGasMode {
 
@@ -39,34 +35,5 @@ public class TileEntityTurbineCasing extends TileEntityMultiblock<TurbineMultibl
     @Override
     public MultiblockManager<TurbineMultiblockData> getManager() {
         return MekanismGenerators.turbineManager;
-    }
-
-    @Nonnull
-    @Override
-    public CompoundNBT getReducedUpdateTag() {
-        CompoundNBT updateTag = super.getReducedUpdateTag();
-        if (getMultiblock().isFormed() && isMaster) {
-            updateTag.putFloat(NBTConstants.SCALE, getMultiblock().prevSteamScale);
-            updateTag.putInt(NBTConstants.VOLUME, getMultiblock().getVolume());
-            updateTag.putInt(NBTConstants.LOWER_VOLUME, getMultiblock().lowerVolume);
-            updateTag.put(NBTConstants.GAS_STORED, getMultiblock().gasTank.getStack().write(new CompoundNBT()));
-            updateTag.put(NBTConstants.COMPLEX, NBTUtil.writeBlockPos(getMultiblock().complex));
-            updateTag.putFloat(NBTConstants.ROTATION, getMultiblock().clientRotation);
-        }
-        return updateTag;
-    }
-
-    @Override
-    public void handleUpdateTag(@Nonnull CompoundNBT tag) {
-        super.handleUpdateTag(tag);
-        if (getMultiblock().isFormed() && isMaster) {
-            NBTUtils.setFloatIfPresent(tag, NBTConstants.SCALE, scale -> getMultiblock().prevSteamScale = scale);
-            NBTUtils.setIntIfPresent(tag, NBTConstants.VOLUME, value -> getMultiblock().setVolume(value));
-            NBTUtils.setIntIfPresent(tag, NBTConstants.LOWER_VOLUME, value -> getMultiblock().lowerVolume = value);
-            NBTUtils.setGasStackIfPresent(tag, NBTConstants.GAS_STORED, value -> getMultiblock().gasTank.setStack(value));
-            NBTUtils.setBlockPosIfPresent(tag, NBTConstants.COMPLEX, value -> getMultiblock().complex = value);
-            NBTUtils.setFloatIfPresent(tag, NBTConstants.ROTATION, value -> getMultiblock().clientRotation = value);
-            TurbineMultiblockData.clientRotationMap.put(getMultiblock().inventoryID, getMultiblock().clientRotation);
-        }
     }
 }

--- a/src/main/java/mekanism/client/ClientRegistration.java
+++ b/src/main/java/mekanism/client/ClientRegistration.java
@@ -124,7 +124,7 @@ import mekanism.client.render.tileentity.RenderSecurityDesk;
 import mekanism.client.render.tileentity.RenderSeismicVibrator;
 import mekanism.client.render.tileentity.RenderSolarNeutronActivator;
 import mekanism.client.render.tileentity.RenderTeleporter;
-import mekanism.client.render.tileentity.RenderThermalEvaporationController;
+import mekanism.client.render.tileentity.RenderThermalEvaporationPlant;
 import mekanism.client.render.tileentity.RenderThermoelectricBoiler;
 import mekanism.client.render.transmitter.RenderLogisticalTransporter;
 import mekanism.client.render.transmitter.RenderMechanicalPipe;
@@ -201,7 +201,7 @@ public class ClientRegistration {
         ClientRegistrationUtil.bindTileEntityRenderer(MekanismTileEntityTypes.SEISMIC_VIBRATOR, RenderSeismicVibrator::new);
         ClientRegistrationUtil.bindTileEntityRenderer(MekanismTileEntityTypes.SOLAR_NEUTRON_ACTIVATOR, RenderSolarNeutronActivator::new);
         ClientRegistrationUtil.bindTileEntityRenderer(MekanismTileEntityTypes.TELEPORTER, RenderTeleporter::new);
-        ClientRegistrationUtil.bindTileEntityRenderer(RenderThermalEvaporationController::new, MekanismTileEntityTypes.THERMAL_EVAPORATION_CONTROLLER,
+        ClientRegistrationUtil.bindTileEntityRenderer(RenderThermalEvaporationPlant::new, MekanismTileEntityTypes.THERMAL_EVAPORATION_CONTROLLER,
               MekanismTileEntityTypes.THERMAL_EVAPORATION_BLOCK, MekanismTileEntityTypes.THERMAL_EVAPORATION_VALVE);
         ClientRegistrationUtil.bindTileEntityRenderer(MekanismTileEntityTypes.INDUSTRIAL_ALARM, RenderIndustrialAlarm::new);
         ClientRegistrationUtil.bindTileEntityRenderer(RenderSPS::new, MekanismTileEntityTypes.SPS_CASING, MekanismTileEntityTypes.SPS_PORT);

--- a/src/main/java/mekanism/client/gui/GuiMatrixStats.java
+++ b/src/main/java/mekanism/client/gui/GuiMatrixStats.java
@@ -78,7 +78,7 @@ public class GuiMatrixStats extends GuiMekanismTile<TileEntityInductionCasing, E
         drawString(EnergyDisplay.of(tile.getMultiblock().getLastOutput(), tile.getMultiblock().getTransferCap()).getTextComponent(), 59, 55, titleTextColor());
         drawString(MekanismLang.MATRIX_DIMENSIONS.translate(), 8, 82, 0x797979);
         if (tile.getMultiblock().isFormed()) {
-            drawString(MekanismLang.MATRIX_DIMENSION_REPRESENTATION.translate(tile.getMultiblock().width, tile.getMultiblock().height, tile.getMultiblock().length), 14, 91, titleTextColor());
+            drawString(MekanismLang.MATRIX_DIMENSION_REPRESENTATION.translate(tile.getMultiblock().width(), tile.getMultiblock().height(), tile.getMultiblock().length()), 14, 91, titleTextColor());
         }
         drawString(MekanismLang.MATRIX_CONSTITUENTS.translate(), 8, 102, 0x797979);
         drawString(MekanismLang.MATRIX_CELLS.translate(tile.getMultiblock().getCellCount()), 14, 111, titleTextColor());

--- a/src/main/java/mekanism/client/gui/GuiThermalEvaporationController.java
+++ b/src/main/java/mekanism/client/gui/GuiThermalEvaporationController.java
@@ -31,7 +31,7 @@ public class GuiThermalEvaporationController extends GuiMekanismTile<TileEntityT
         super.init();
         addButton(new GuiInnerScreen(this, 48, 19, 80, 40, () -> Arrays.asList(
               getStruct().translate(),
-              MekanismLang.EVAPORATION_HEIGHT.translate(tile.getMultiblock().height),
+              MekanismLang.EVAPORATION_HEIGHT.translate(tile.getMultiblock().height()),
               MekanismLang.TEMPERATURE.translate(MekanismUtils.getTemperatureDisplay(tile.getMultiblock().getTemp(), TemperatureUnit.KELVIN, true)),
               MekanismLang.FLUID_PRODUCTION.translate(Math.round(tile.getMultiblock().lastGain * 100D) / 100D)
         )).spacing(1));

--- a/src/main/java/mekanism/client/render/tileentity/RenderDynamicTank.java
+++ b/src/main/java/mekanism/client/render/tileentity/RenderDynamicTank.java
@@ -1,9 +1,9 @@
 package mekanism.client.render.tileentity;
 
-import com.mojang.blaze3d.matrix.MatrixStack;
-import com.mojang.blaze3d.vertex.IVertexBuilder;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import com.mojang.blaze3d.matrix.MatrixStack;
+import com.mojang.blaze3d.vertex.IVertexBuilder;
 import mekanism.api.Coord4D;
 import mekanism.client.render.MekanismRenderType;
 import mekanism.client.render.MekanismRenderer;
@@ -36,9 +36,9 @@ public class RenderDynamicTank extends MekanismTileEntityRenderer<TileEntityDyna
             RenderData data = getRenderData(tile.getMultiblock());
             if (data != null) {
                 data.location = new Coord4D(tile.getMultiblock().renderLocation, tile.getWorld());
-                data.height = tile.getMultiblock().height - 2;
-                data.length = tile.getMultiblock().length;
-                data.width = tile.getMultiblock().width;
+                data.height = tile.getMultiblock().height() - 2;
+                data.length = tile.getMultiblock().length();
+                data.width = tile.getMultiblock().width();
                 matrix.push();
 
                 IVertexBuilder buffer = renderer.getBuffer(MekanismRenderType.resizableCuboid());

--- a/src/main/java/mekanism/client/render/tileentity/RenderSPS.java
+++ b/src/main/java/mekanism/client/render/tileentity/RenderSPS.java
@@ -45,8 +45,8 @@ public class RenderSPS extends MekanismTileEntityRenderer<TileEntitySPSCasing> {
 
     @Override
     protected void render(TileEntitySPSCasing tile, float partialTick, MatrixStack matrix, IRenderTypeBuffer renderer, int light, int overlayLight, IProfiler profiler) {
-        if (tile.isMaster && tile.getMultiblock().isFormed() && tile.getMultiblock().renderLocation != null && tile.getMultiblock().bounds != null) {
-            Vec3d center = new Vec3d(tile.getMultiblock().bounds.getMinPos()).add(new Vec3d(tile.getMultiblock().bounds.getMaxPos())).add(new Vec3d(1, 1, 1)).scale(0.5);
+        if (tile.isMaster && tile.getMultiblock().isFormed() && tile.getMultiblock().renderLocation != null && tile.getMultiblock().getBounds() != null) {
+            Vec3d center = new Vec3d(tile.getMultiblock().getMinPos()).add(new Vec3d(tile.getMultiblock().getMaxPos())).add(new Vec3d(1, 1, 1)).scale(0.5);
             Vec3d renderCenter = center.subtract(tile.getPos().getX(), tile.getPos().getY(), tile.getPos().getZ());
             if (!minecraft.isGamePaused()) {
                 for (CoilData data : tile.getMultiblock().coilData.coilMap.values()) {
@@ -62,7 +62,7 @@ public class RenderSPS extends MekanismTileEntityRenderer<TileEntitySPSCasing> {
             if (!minecraft.isGamePaused() && !tile.getMultiblock().lastReceivedEnergy.isZero()) {
                 if (rand.nextDouble() < getBoundedScale(energyScale, 0.01F, 0.4F)) {
                     CuboidSide side = CuboidSide.SIDES[rand.nextInt(6)];
-                    Plane plane = Plane.getInnerCuboidPlane(tile.getMultiblock().bounds, side);
+                    Plane plane = Plane.getInnerCuboidPlane(tile.getMultiblock().getBounds(), side);
                     Vec3d endPos = plane.getRandomPoint(rand).subtract(tile.getPos().getX(), tile.getPos().getY(), tile.getPos().getZ());
                     BoltData data = new BoltData(renderCenter, endPos, 1, 15, 0.01F * getBoundedScale(energyScale, 0.5F, 5));
                     edgeBolts.update(Objects.hashCode(side.hashCode(), endPos.hashCode()), data, partialTick);

--- a/src/main/java/mekanism/client/render/tileentity/RenderSPS.java
+++ b/src/main/java/mekanism/client/render/tileentity/RenderSPS.java
@@ -14,7 +14,6 @@ import mekanism.common.content.sps.SPSMultiblockData;
 import mekanism.common.content.sps.SPSMultiblockData.CoilData;
 import mekanism.common.lib.Color;
 import mekanism.common.lib.math.Plane;
-import mekanism.common.lib.math.voxel.VoxelCuboid;
 import mekanism.common.lib.math.voxel.VoxelCuboid.CuboidSide;
 import mekanism.common.particle.custom.CustomEffect;
 import mekanism.common.particle.custom.SPSOrbitEffect;
@@ -46,8 +45,8 @@ public class RenderSPS extends MekanismTileEntityRenderer<TileEntitySPSCasing> {
 
     @Override
     protected void render(TileEntitySPSCasing tile, float partialTick, MatrixStack matrix, IRenderTypeBuffer renderer, int light, int overlayLight, IProfiler profiler) {
-        if (tile.isMaster && tile.getMultiblock().isFormed() && tile.getMultiblock().renderLocation != null) {
-            Vec3d center = new Vec3d(tile.getMultiblock().minLocation).add(new Vec3d(tile.getMultiblock().maxLocation)).add(new Vec3d(1, 1, 1)).scale(0.5);
+        if (tile.isMaster && tile.getMultiblock().isFormed() && tile.getMultiblock().renderLocation != null && tile.getMultiblock().bounds != null) {
+            Vec3d center = new Vec3d(tile.getMultiblock().bounds.getMinPos()).add(new Vec3d(tile.getMultiblock().bounds.getMaxPos())).add(new Vec3d(1, 1, 1)).scale(0.5);
             Vec3d renderCenter = center.subtract(tile.getPos().getX(), tile.getPos().getY(), tile.getPos().getZ());
             if (!minecraft.isGamePaused()) {
                 for (CoilData data : tile.getMultiblock().coilData.coilMap.values()) {
@@ -63,7 +62,7 @@ public class RenderSPS extends MekanismTileEntityRenderer<TileEntitySPSCasing> {
             if (!minecraft.isGamePaused() && !tile.getMultiblock().lastReceivedEnergy.isZero()) {
                 if (rand.nextDouble() < getBoundedScale(energyScale, 0.01F, 0.4F)) {
                     CuboidSide side = CuboidSide.SIDES[rand.nextInt(6)];
-                    Plane plane = Plane.getInnerCuboidPlane(new VoxelCuboid(tile.getMultiblock().minLocation, tile.getMultiblock().maxLocation), side);
+                    Plane plane = Plane.getInnerCuboidPlane(tile.getMultiblock().bounds, side);
                     Vec3d endPos = plane.getRandomPoint(rand).subtract(tile.getPos().getX(), tile.getPos().getY(), tile.getPos().getZ());
                     BoltData data = new BoltData(renderCenter, endPos, 1, 15, 0.01F * getBoundedScale(energyScale, 0.5F, 5));
                     edgeBolts.update(Objects.hashCode(side.hashCode(), endPos.hashCode()), data, partialTick);

--- a/src/main/java/mekanism/client/render/tileentity/RenderThermalEvaporationPlant.java
+++ b/src/main/java/mekanism/client/render/tileentity/RenderThermalEvaporationPlant.java
@@ -16,9 +16,9 @@ import net.minecraft.profiler.IProfiler;
 import net.minecraft.util.math.BlockPos;
 
 @ParametersAreNonnullByDefault
-public class RenderThermalEvaporationController extends MekanismTileEntityRenderer<TileEntityThermalEvaporationBlock> {
+public class RenderThermalEvaporationPlant extends MekanismTileEntityRenderer<TileEntityThermalEvaporationBlock> {
 
-    public RenderThermalEvaporationController(TileEntityRendererDispatcher renderer) {
+    public RenderThermalEvaporationPlant(TileEntityRendererDispatcher renderer) {
         super(renderer);
     }
 
@@ -27,8 +27,8 @@ public class RenderThermalEvaporationController extends MekanismTileEntityRender
           IProfiler profiler) {
         if (tile.isMaster && tile.getMultiblock().isFormed() && tile.getMultiblock().renderLocation != null && !tile.getMultiblock().inputTank.isEmpty()) {
             FluidRenderData data = new FluidRenderData(tile.getMultiblock().inputTank.getFluid());
-            data.location = new Coord4D(tile.getMultiblock().renderLocation, tile.getWorld());
-            data.height = tile.getMultiblock().height - 2;
+            data.location = new Coord4D(tile.getMultiblock().renderLocation.add(1, 0, 1), tile.getWorld());
+            data.height = tile.getMultiblock().height() - 2;
             data.length = 2;
             data.width = 2;
             matrix.push();

--- a/src/main/java/mekanism/client/render/tileentity/RenderThermoelectricBoiler.java
+++ b/src/main/java/mekanism/client/render/tileentity/RenderThermoelectricBoiler.java
@@ -1,8 +1,8 @@
 package mekanism.client.render.tileentity;
 
+import javax.annotation.ParametersAreNonnullByDefault;
 import com.mojang.blaze3d.matrix.MatrixStack;
 import com.mojang.blaze3d.vertex.IVertexBuilder;
-import javax.annotation.ParametersAreNonnullByDefault;
 import mekanism.api.Coord4D;
 import mekanism.client.render.MekanismRenderType;
 import mekanism.client.render.MekanismRenderer;
@@ -31,13 +31,12 @@ public class RenderThermoelectricBoiler extends MekanismTileEntityRenderer<TileE
             IVertexBuilder buffer = null;
             if (!tile.getMultiblock().waterTank.isEmpty()) {
                 int height = tile.getMultiblock().upperRenderLocation.y - 1 - tile.getMultiblock().renderLocation.getY();
-                ;
                 if (height >= 1) {
                     FluidRenderData data = new FluidRenderData(tile.getMultiblock().waterTank.getFluid());
                     data.location = new Coord4D(tile.getMultiblock().renderLocation, tile.getWorld());
                     data.height = height;
-                    data.length = tile.getMultiblock().length;
-                    data.width = tile.getMultiblock().width;
+                    data.length = tile.getMultiblock().length();
+                    data.width = tile.getMultiblock().width();
                     int glow = data.calculateGlowLight(light);
                     matrix.push();
                     matrix.translate(data.location.x - pos.getX(), data.location.y - pos.getY(), data.location.z - pos.getZ());
@@ -49,13 +48,13 @@ public class RenderThermoelectricBoiler extends MekanismTileEntityRenderer<TileE
                 }
             }
             if (!tile.getMultiblock().steamTank.isEmpty()) {
-                int height = tile.getMultiblock().renderLocation.getY() + tile.getMultiblock().height - 2 - tile.getMultiblock().upperRenderLocation.y;
+                int height = tile.getMultiblock().renderLocation.getY() + tile.getMultiblock().height() - 2 - tile.getMultiblock().upperRenderLocation.y;
                 if (height >= 1) {
                     GasRenderData data = new GasRenderData(tile.getMultiblock().steamTank.getStack());
                     data.location = tile.getMultiblock().upperRenderLocation;
                     data.height = height;
-                    data.length = tile.getMultiblock().length;
-                    data.width = tile.getMultiblock().width;
+                    data.length = tile.getMultiblock().length();
+                    data.width = tile.getMultiblock().width();
                     if (buffer == null) {
                         buffer = renderer.getBuffer(MekanismRenderType.resizableCuboid());
                     }

--- a/src/main/java/mekanism/common/Mekanism.java
+++ b/src/main/java/mekanism/common/Mekanism.java
@@ -23,6 +23,9 @@ import mekanism.common.capabilities.Capabilities;
 import mekanism.common.command.CommandMek;
 import mekanism.common.command.builders.BuildCommand;
 import mekanism.common.command.builders.Builders.BoilerBuilder;
+import mekanism.common.command.builders.Builders.EvaporationBuilder;
+import mekanism.common.command.builders.Builders.MatrixBuilder;
+import mekanism.common.command.builders.Builders.TankBuilder;
 import mekanism.common.config.MekanismConfig;
 import mekanism.common.config.MekanismModConfig;
 import mekanism.common.content.boiler.BoilerMultiblockData;
@@ -273,6 +276,9 @@ public class Mekanism {
 
     private void serverStarting(FMLServerStartingEvent event) {
         BuildCommand.register("boiler", new BoilerBuilder());
+        BuildCommand.register("matrix", new MatrixBuilder());
+        BuildCommand.register("tank", new TankBuilder());
+        BuildCommand.register("evaporation", new EvaporationBuilder());
         event.getCommandDispatcher().register(CommandMek.register());
         Modules.processSupportedContainers();
     }

--- a/src/main/java/mekanism/common/command/builders/BuildCommand.java
+++ b/src/main/java/mekanism/common/command/builders/BuildCommand.java
@@ -1,9 +1,9 @@
 package mekanism.common.command.builders;
 
-import com.mojang.brigadier.builder.ArgumentBuilder;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.Stack;
+import com.mojang.brigadier.builder.ArgumentBuilder;
 import mekanism.common.util.MekanismUtils;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
@@ -19,7 +19,21 @@ import net.minecraft.world.World;
 
 public class BuildCommand {
 
-    public static final ArgumentBuilder<CommandSource, ?> COMMAND = Commands.literal("build");
+    public static final ArgumentBuilder<CommandSource, ?> COMMAND = Commands.literal("build")
+        .then(Commands.literal("remove")
+            .requires(cs -> cs.hasPermissionLevel(4))
+            .executes(ctx -> {
+                CommandSource source = ctx.getSource();
+                Entity entity = source.getEntity();
+                if (entity instanceof ServerPlayerEntity) {
+                    ServerPlayerEntity player = (ServerPlayerEntity) ctx.getSource().getEntity();
+                    BlockRayTraceResult result = MekanismUtils.rayTrace(player, 100);
+                    if (result.getType() != RayTraceResult.Type.MISS) {
+                        destroy(player.getEntityWorld(), result.getPos());
+                    }
+                }
+                return 0;
+            }));
 
     public static void register(String name, StructureBuilder builder) {
         COMMAND.then(Commands.literal(name)
@@ -33,19 +47,6 @@ public class BuildCommand {
                       if (result.getType() != RayTraceResult.Type.MISS) {
                           BlockPos pos = result.getPos().offset(Direction.UP);
                           builder.build(player.getEntityWorld(), pos);
-                      }
-                  }
-                  return 0;
-              })).then(Commands.literal("remove")
-              .requires(cs -> cs.hasPermissionLevel(4))
-              .executes(ctx -> {
-                  CommandSource source = ctx.getSource();
-                  Entity entity = source.getEntity();
-                  if (entity instanceof ServerPlayerEntity) {
-                      ServerPlayerEntity player = (ServerPlayerEntity) ctx.getSource().getEntity();
-                      BlockRayTraceResult result = MekanismUtils.rayTrace(player, 100);
-                      if (result.getType() != RayTraceResult.Type.MISS) {
-                          destroy(player.getEntityWorld(), result.getPos());
                       }
                   }
                   return 0;

--- a/src/main/java/mekanism/common/command/builders/Builders.java
+++ b/src/main/java/mekanism/common/command/builders/Builders.java
@@ -2,6 +2,7 @@ package mekanism.common.command.builders;
 
 import mekanism.common.registries.MekanismBlocks;
 import net.minecraft.block.Block;
+import net.minecraft.block.Blocks;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
@@ -25,6 +26,70 @@ public class Builders {
         @Override
         protected Block getCasing() {
             return MekanismBlocks.BOILER_CASING.getBlock();
+        }
+    }
+
+    public static class TankBuilder extends StructureBuilder {
+
+        public TankBuilder() {
+            super(18, 18, 18);
+        }
+
+        @Override
+        public void build(World world, BlockPos start) {
+            buildFrame(world, start);
+            buildWalls(world, start);
+        }
+
+        @Override
+        protected Block getCasing() {
+            return MekanismBlocks.DYNAMIC_TANK.getBlock();
+        }
+    }
+
+    public static class MatrixBuilder extends StructureBuilder {
+
+        public MatrixBuilder() {
+            super(18, 18, 18);
+        }
+
+        @Override
+        public void build(World world, BlockPos start) {
+            buildFrame(world, start);
+            buildWalls(world, start);
+            for(int y = 1; y < 16; y++) {
+                buildInteriorLayer(world, start, y, MekanismBlocks.ULTIMATE_INDUCTION_CELL.getBlock());
+            }
+            buildInteriorLayer(world, start, 16, MekanismBlocks.ULTIMATE_INDUCTION_PROVIDER.getBlock());
+        }
+
+        @Override
+        protected Block getCasing() {
+            return MekanismBlocks.INDUCTION_CASING.getBlock();
+        }
+    }
+
+    public static class EvaporationBuilder extends StructureBuilder {
+
+        public EvaporationBuilder() {
+            super(4, 18, 4);
+        }
+
+        @Override
+        public void build(World world, BlockPos start) {
+            buildFrame(world, start);
+            buildWalls(world, start);
+            for (int x = start.getX() + 1; x <= start.getX() + 2; x++) {
+                for (int z = start.getZ() + 1; z <= start.getZ() + 2; z++) {
+                    world.setBlockState(new BlockPos(x, start.getY() + 17, z), Blocks.AIR.getDefaultState());
+                }
+            }
+            world.setBlockState(start.add(1, 1, 0), MekanismBlocks.THERMAL_EVAPORATION_CONTROLLER.getBlock().getDefaultState());
+        }
+
+        @Override
+        protected Block getCasing() {
+            return MekanismBlocks.THERMAL_EVAPORATION_BLOCK.getBlock();
         }
     }
 }

--- a/src/main/java/mekanism/common/content/boiler/BoilerValidator.java
+++ b/src/main/java/mekanism/common/content/boiler/BoilerValidator.java
@@ -63,8 +63,8 @@ public class BoilerValidator extends CuboidStructureValidator<BoilerMultiblockDa
 
         //Ensure that a full horizontal plane of dispersers exist, surrounding the found disperser
         BlockPos pos = new BlockPos(structure.renderLocation.getX(), initDisperser.getY(), structure.renderLocation.getZ());
-        for (int x = 1; x < structure.length - 1; x++) {
-            for (int z = 1; z < structure.width - 1; z++) {
+        for (int x = 1; x < structure.length() - 1; x++) {
+            for (int z = 1; z < structure.width() - 1; z++) {
                 BlockPos shifted = pos.add(x, 0, z);
                 TileEntityPressureDisperser tile = MekanismUtils.getTileEntity(TileEntityPressureDisperser.class, world, shifted);
                 if (tile == null) {
@@ -92,9 +92,9 @@ public class BoilerValidator extends CuboidStructureValidator<BoilerMultiblockDa
         int totalAir = 0;
 
         //Find the first available block in the structure for water storage (including casings)
-        for (int x = structure.renderLocation.getX(); x < structure.renderLocation.getX() + structure.length; x++) {
+        for (int x = structure.renderLocation.getX(); x < structure.renderLocation.getX() + structure.length(); x++) {
             for (int y = structure.renderLocation.getY(); y < initDisperser.getY(); y++) {
-                for (int z = structure.renderLocation.getZ(); z < structure.renderLocation.getZ() + structure.width; z++) {
+                for (int z = structure.renderLocation.getZ(); z < structure.renderLocation.getZ() + structure.width(); z++) {
                     BlockPos airPos = new BlockPos(x, y, z);
                     if (world.isAirBlock(airPos) || isFrameCompatible(world.getTileEntity(airPos))) {
                         initAir = airPos;
@@ -106,8 +106,8 @@ public class BoilerValidator extends CuboidStructureValidator<BoilerMultiblockDa
 
         //Gradle build requires these fields to be final
         final BlockPos renderLocation = structure.renderLocation;
-        final int volLength = structure.length;
-        final int volWidth = structure.width;
+        final int volLength = structure.length();
+        final int volWidth = structure.width();
         structure.setWaterVolume(FormationProtocol.explore(initAir, coord ->
               coord.getY() >= renderLocation.getY() - 1 && coord.getY() < initDisperser.getY() &&
               coord.getX() >= renderLocation.getX() && coord.getX() < renderLocation.getX() + volLength &&
@@ -119,8 +119,8 @@ public class BoilerValidator extends CuboidStructureValidator<BoilerMultiblockDa
             return FormationResult.fail(MekanismLang.BOILER_INVALID_AIR_POCKETS);
         }
 
-        int steamHeight = (structure.renderLocation.getY() + structure.height - 2) - initDisperser.getY();
-        structure.setSteamVolume(structure.width * structure.length * steamHeight);
+        int steamHeight = (structure.renderLocation.getY() + structure.height() - 2) - initDisperser.getY();
+        structure.setSteamVolume(structure.width() * structure.length() * steamHeight);
         structure.upperRenderLocation = new Coord4D(structure.renderLocation.getX(), initDisperser.getY() + 1, structure.renderLocation.getZ(), world.getDimension().getType());
         return FormationResult.SUCCESS;
     }

--- a/src/main/java/mekanism/common/content/evaporation/EvaporationMultiblockData.java
+++ b/src/main/java/mekanism/common/content/evaporation/EvaporationMultiblockData.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import mekanism.api.IEvaporationSolar;
+import mekanism.api.NBTConstants;
 import mekanism.api.annotations.NonNull;
 import mekanism.api.heat.HeatAPI;
 import mekanism.api.recipes.FluidToFluidRecipe;
@@ -24,19 +25,22 @@ import mekanism.common.inventory.container.slot.ContainerSlotType;
 import mekanism.common.inventory.container.sync.dynamic.ContainerSync;
 import mekanism.common.inventory.slot.FluidInventorySlot;
 import mekanism.common.inventory.slot.OutputInventorySlot;
+import mekanism.common.lib.multiblock.IValveHandler;
 import mekanism.common.lib.multiblock.MultiblockData;
 import mekanism.common.recipe.MekanismRecipeType;
 import mekanism.common.tile.interfaces.ITileCachedRecipeHolder;
 import mekanism.common.tile.multiblock.TileEntityThermalEvaporationBlock;
 import mekanism.common.util.CapabilityUtils;
 import mekanism.common.util.MekanismUtils;
+import mekanism.common.util.NBTUtils;
+import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Direction;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.fluids.FluidStack;
 
-public class EvaporationMultiblockData extends MultiblockData implements ITileCachedRecipeHolder<FluidToFluidRecipe> {
+public class EvaporationMultiblockData extends MultiblockData implements ITileCachedRecipeHolder<FluidToFluidRecipe>, IValveHandler {
 
     private static final int MAX_OUTPUT = 10_000;
     private static final int MAX_HEIGHT = 18;
@@ -88,7 +92,7 @@ public class EvaporationMultiblockData extends MultiblockData implements ITileCa
     public void onCreated(World world) {
         super.onCreated(world);
         // update the heat capacity now that we've read
-        heatCapacitor.setHeatCapacity(MekanismConfig.general.evaporationHeatCapacity.get() * height, true);
+        heatCapacitor.setHeatCapacity(MekanismConfig.general.evaporationHeatCapacity.get() * height(), true);
         updateSolars(world);
     }
 
@@ -110,9 +114,25 @@ public class EvaporationMultiblockData extends MultiblockData implements ITileCa
         return needsPacket;
     }
 
+    @Override
+    public void readUpdateTag(CompoundNBT tag) {
+        super.readUpdateTag(tag);
+        NBTUtils.setFluidStackIfPresent(tag, NBTConstants.FLUID_STORED, fluid -> inputTank.setStack(fluid));
+        NBTUtils.setFloatIfPresent(tag, NBTConstants.SCALE, scale -> prevScale = scale);
+        readValves(tag);
+    }
+
+    @Override
+    public void writeUpdateTag(CompoundNBT tag) {
+        super.writeUpdateTag(tag);
+        tag.put(NBTConstants.FLUID_STORED, inputTank.getFluid().writeToNBT(new CompoundNBT()));
+        tag.putFloat(NBTConstants.SCALE, prevScale);
+        writeValves(tag);
+    }
+
     private void updateTemperature(World world) {
         if (!temperatureSet) {
-            biomeTemp = world.getBiomeManager().getBiome(bounds.getMinPos()).getTemperature(bounds.getMinPos());
+            biomeTemp = world.getBiomeManager().getBiome(getMinPos()).getTemperature(getMinPos());
             temperatureSet = true;
         }
         heatCapacitor.handleHeat(MekanismConfig.general.evaporationSolarMultiplier.get() * getActiveSolars() * heatCapacitor.getHeatCapacity());
@@ -129,7 +149,7 @@ public class EvaporationMultiblockData extends MultiblockData implements ITileCa
         heatCapacitor.handleHeat(heatCapacitor.getHeatCapacity() * incr);
 
         totalLoss = incr < 0 ? -incr / heatCapacitor.getHeatCapacity() : 0;
-        tempMultiplier = (Math.min(MAX_MULTIPLIER_TEMP, heatCapacitor.getTemperature()) - HeatAPI.AMBIENT_TEMP) * MekanismConfig.general.evaporationTempMultiplier.get() * ((double) height / MAX_HEIGHT);
+        tempMultiplier = (Math.min(MAX_MULTIPLIER_TEMP, heatCapacitor.getTemperature()) - HeatAPI.AMBIENT_TEMP) * MekanismConfig.general.evaporationTempMultiplier.get() * ((double) height() / MAX_HEIGHT);
         updateHeatCapacitors(null);
     }
 
@@ -138,7 +158,7 @@ public class EvaporationMultiblockData extends MultiblockData implements ITileCa
     }
 
     public int getMaxFluid() {
-        return height * 4 * TankMultiblockData.FLUID_PER_TANK;
+        return height() * 4 * TankMultiblockData.FLUID_PER_TANK;
     }
 
     @Nonnull
@@ -216,15 +236,15 @@ public class EvaporationMultiblockData extends MultiblockData implements ITileCa
     }
 
     public boolean isSolarSpot(BlockPos pos) {
-        return pos.getY() == bounds.getMaxPos().getY() && bounds.isOnCorner(pos);
+        return pos.getY() == getMaxPos().getY() && getBounds().isOnCorner(pos);
     }
 
     public void updateSolars(World world) {
         solars = new IEvaporationSolar[4];
-        addSolarPanel(MekanismUtils.getTileEntity(world, bounds.getMaxPos()), 0);
-        addSolarPanel(MekanismUtils.getTileEntity(world, bounds.getMaxPos().add(-3, 0, 0)), 1);
-        addSolarPanel(MekanismUtils.getTileEntity(world, bounds.getMaxPos().add(0, 0, -3)), 2);
-        addSolarPanel(MekanismUtils.getTileEntity(world, bounds.getMaxPos().add(-3, 0, -3)), 3);
+        addSolarPanel(MekanismUtils.getTileEntity(world, getMaxPos()), 0);
+        addSolarPanel(MekanismUtils.getTileEntity(world, getMaxPos().add(-3, 0, 0)), 1);
+        addSolarPanel(MekanismUtils.getTileEntity(world, getMaxPos().add(0, 0, -3)), 2);
+        addSolarPanel(MekanismUtils.getTileEntity(world, getMaxPos().add(-3, 0, -3)), 3);
     }
 
     @Override

--- a/src/main/java/mekanism/common/content/evaporation/EvaporationMultiblockData.java
+++ b/src/main/java/mekanism/common/content/evaporation/EvaporationMultiblockData.java
@@ -24,7 +24,6 @@ import mekanism.common.inventory.container.slot.ContainerSlotType;
 import mekanism.common.inventory.container.sync.dynamic.ContainerSync;
 import mekanism.common.inventory.slot.FluidInventorySlot;
 import mekanism.common.inventory.slot.OutputInventorySlot;
-import mekanism.common.lib.math.voxel.VoxelCuboid;
 import mekanism.common.lib.multiblock.MultiblockData;
 import mekanism.common.recipe.MekanismRecipeType;
 import mekanism.common.tile.interfaces.ITileCachedRecipeHolder;
@@ -113,7 +112,7 @@ public class EvaporationMultiblockData extends MultiblockData implements ITileCa
 
     private void updateTemperature(World world) {
         if (!temperatureSet) {
-            biomeTemp = world.getBiomeManager().getBiome(minLocation).getTemperature(minLocation);
+            biomeTemp = world.getBiomeManager().getBiome(bounds.getMinPos()).getTemperature(bounds.getMinPos());
             temperatureSet = true;
         }
         heatCapacitor.handleHeat(MekanismConfig.general.evaporationSolarMultiplier.get() * getActiveSolars() * heatCapacitor.getHeatCapacity());
@@ -217,15 +216,15 @@ public class EvaporationMultiblockData extends MultiblockData implements ITileCa
     }
 
     public boolean isSolarSpot(BlockPos pos) {
-        return pos.getY() == maxLocation.getY() && new VoxelCuboid(minLocation, maxLocation).isOnCorner(pos);
+        return pos.getY() == bounds.getMaxPos().getY() && bounds.isOnCorner(pos);
     }
 
     public void updateSolars(World world) {
         solars = new IEvaporationSolar[4];
-        addSolarPanel(MekanismUtils.getTileEntity(world, maxLocation), 0);
-        addSolarPanel(MekanismUtils.getTileEntity(world, maxLocation.add(-3, 0, 0)), 1);
-        addSolarPanel(MekanismUtils.getTileEntity(world, maxLocation.add(0, 0, -3)), 2);
-        addSolarPanel(MekanismUtils.getTileEntity(world, maxLocation.add(-3, 0, -3)), 3);
+        addSolarPanel(MekanismUtils.getTileEntity(world, bounds.getMaxPos()), 0);
+        addSolarPanel(MekanismUtils.getTileEntity(world, bounds.getMaxPos().add(-3, 0, 0)), 1);
+        addSolarPanel(MekanismUtils.getTileEntity(world, bounds.getMaxPos().add(0, 0, -3)), 2);
+        addSolarPanel(MekanismUtils.getTileEntity(world, bounds.getMaxPos().add(-3, 0, -3)), 3);
     }
 
     @Override

--- a/src/main/java/mekanism/common/content/sps/SPSMultiblockData.java
+++ b/src/main/java/mekanism/common/content/sps/SPSMultiblockData.java
@@ -136,7 +136,7 @@ public class SPSMultiblockData extends MultiblockData {
     }
 
     public boolean handlesSound(TileEntitySPSCasing tile) {
-        return tile.getPos().equals(minLocation.add(3, 0, 0)) || tile.getPos().equals(minLocation.add(3, 0, 7));
+        return tile.getPos().equals(bounds.getMinPos().add(3, 0, 0)) || tile.getPos().equals(bounds.getMaxPos().add(3, 0, 7));
     }
 
     public static class SyncableCoilData {

--- a/src/main/java/mekanism/common/content/sps/SPSMultiblockData.java
+++ b/src/main/java/mekanism/common/content/sps/SPSMultiblockData.java
@@ -11,6 +11,7 @@ import mekanism.api.math.FloatingLong;
 import mekanism.common.capabilities.chemical.MultiblockGasTank;
 import mekanism.common.config.MekanismConfig;
 import mekanism.common.inventory.container.sync.dynamic.ContainerSync;
+import mekanism.common.lib.multiblock.IValveHandler;
 import mekanism.common.lib.multiblock.MultiblockData;
 import mekanism.common.registries.MekanismGases;
 import mekanism.common.tile.multiblock.TileEntitySPSCasing;
@@ -23,7 +24,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.Constants.NBT;
 
-public class SPSMultiblockData extends MultiblockData {
+public class SPSMultiblockData extends MultiblockData implements IValveHandler {
 
     private static final long MAX_OUTPUT_GAS = 1_000;
 
@@ -91,6 +92,20 @@ public class SPSMultiblockData extends MultiblockData {
         return needsPacket;
     }
 
+    @Override
+    public void readUpdateTag(CompoundNBT tag) {
+        super.readUpdateTag(tag);
+        coilData.read(tag);
+        lastReceivedEnergy = FloatingLong.parseFloatingLong(tag.getString(NBTConstants.ENERGY_USAGE));
+    }
+
+    @Override
+    public void writeUpdateTag(CompoundNBT tag) {
+        super.writeUpdateTag(tag);
+        coilData.write(tag);
+        tag.putString(NBTConstants.ENERGY_USAGE, lastReceivedEnergy.toString());
+    }
+
     private void process(long operations) {
         if (operations == 0)
             return;
@@ -136,7 +151,7 @@ public class SPSMultiblockData extends MultiblockData {
     }
 
     public boolean handlesSound(TileEntitySPSCasing tile) {
-        return tile.getPos().equals(bounds.getMinPos().add(3, 0, 0)) || tile.getPos().equals(bounds.getMaxPos().add(3, 0, 7));
+        return tile.getPos().equals(getMinPos().add(3, 0, 0)) || tile.getPos().equals(getMaxPos().add(3, 0, 7));
     }
 
     public static class SyncableCoilData {

--- a/src/main/java/mekanism/common/content/tank/TankMultiblockData.java
+++ b/src/main/java/mekanism/common/content/tank/TankMultiblockData.java
@@ -2,6 +2,7 @@ package mekanism.common.content.tank;
 
 import java.util.ArrayList;
 import java.util.List;
+import mekanism.api.NBTConstants;
 import mekanism.api.chemical.gas.BasicGasTank;
 import mekanism.api.chemical.gas.IGasTank;
 import mekanism.api.chemical.infuse.BasicInfusionTank;
@@ -23,13 +24,16 @@ import mekanism.common.capabilities.fluid.MultiblockFluidTank;
 import mekanism.common.inventory.container.slot.ContainerSlotType;
 import mekanism.common.inventory.container.sync.dynamic.ContainerSync;
 import mekanism.common.inventory.slot.HybridInventorySlot;
+import mekanism.common.lib.multiblock.IValveHandler;
 import mekanism.common.lib.multiblock.MultiblockData;
 import mekanism.common.tile.interfaces.IFluidContainerManager.ContainerEditMode;
 import mekanism.common.tile.multiblock.TileEntityDynamicTank;
 import mekanism.common.util.MekanismUtils;
+import mekanism.common.util.NBTUtils;
+import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.world.World;
 
-public class TankMultiblockData extends MultiblockData {
+public class TankMultiblockData extends MultiblockData implements IValveHandler {
 
     public static final int FLUID_PER_TANK = 64_000;
 
@@ -88,6 +92,22 @@ public class TankMultiblockData extends MultiblockData {
             needsPacket = true;
         }
         return needsPacket;
+    }
+
+    @Override
+    public void readUpdateTag(CompoundNBT tag) {
+        super.readUpdateTag(tag);
+        tag.putFloat(NBTConstants.SCALE, prevScale);
+        mergedTank.addToUpdateTag(tag);
+        readValves(tag);
+    }
+
+    @Override
+    public void writeUpdateTag(CompoundNBT tag) {
+        super.writeUpdateTag(tag);
+        NBTUtils.setFloatIfPresent(tag, NBTConstants.SCALE, scale -> prevScale = scale);
+        mergedTank.readFromUpdateTag(tag);
+        writeValves(tag);
     }
 
     private float getScale() {

--- a/src/main/java/mekanism/common/integration/theoneprobe/TOPProvider.java
+++ b/src/main/java/mekanism/common/integration/theoneprobe/TOPProvider.java
@@ -25,8 +25,10 @@ import mekanism.api.text.ILangEntry;
 import mekanism.common.Mekanism;
 import mekanism.common.MekanismLang;
 import mekanism.common.capabilities.Capabilities;
-import mekanism.common.lib.multiblock.IMultiblockBase;
+import mekanism.common.lib.multiblock.IMultiblock;
+import mekanism.common.lib.multiblock.IStructuralMultiblock;
 import mekanism.common.lib.multiblock.MultiblockData;
+import mekanism.common.lib.multiblock.Structure;
 import mekanism.common.tile.base.TileEntityUpdateable;
 import mekanism.common.util.CapabilityUtils;
 import mekanism.common.util.MekanismUtils;
@@ -108,8 +110,14 @@ public class TOPProvider implements IProbeInfoProvider, Function<ITheOneProbe, V
 
     @Nullable
     private MultiblockData getMultiblock(@Nonnull TileEntity tile) {
-        if (tile instanceof IMultiblockBase) {
-            return ((IMultiblockBase) tile).getMultiblockData();
+        if (tile instanceof IMultiblock) {
+            return ((IMultiblock<?>) tile).getMultiblock();
+        } else if (tile instanceof IStructuralMultiblock) {
+            for (Structure s : ((IStructuralMultiblock) tile).getStructureMap().values()) {
+                if (s.isValid()) {
+                    return s.getMultiblockData();
+                }
+            }
         }
         return null;
     }

--- a/src/main/java/mekanism/common/lib/math/voxel/VoxelCuboid.java
+++ b/src/main/java/mekanism/common/lib/math/voxel/VoxelCuboid.java
@@ -120,6 +120,14 @@ public class VoxelCuboid implements IShape {
     }
 
     @Override
+    public int hashCode() {
+        int result = 1;
+        result = 31 * result + maxPos.hashCode();
+        result = 31 * result + minPos.hashCode();
+        return result;
+    }
+
+    @Override
     public boolean equals(Object obj) {
         if (!(obj instanceof VoxelCuboid)) {
             return false;

--- a/src/main/java/mekanism/common/lib/math/voxel/VoxelCuboid.java
+++ b/src/main/java/mekanism/common/lib/math/voxel/VoxelCuboid.java
@@ -38,6 +38,12 @@ public class VoxelCuboid implements IShape {
         return maxPos;
     }
 
+    public BlockPos getCenter() {
+        return new BlockPos((minPos.getX() + maxPos.getX()) / 2,
+                            (minPos.getY() + maxPos.getY()) / 2,
+                            (minPos.getZ() + maxPos.getZ()) / 2);
+    }
+
     public Direction getSide(BlockPos pos) {
         if (pos.getX() == minPos.getX()) {
             return Direction.WEST;
@@ -160,6 +166,10 @@ public class VoxelCuboid implements IShape {
         INSIDE,
         OUTSIDE,
         WALLS;
+
+        public boolean isWall() {
+            return this == WALLS;
+        }
     }
 
     public enum CuboidSide {

--- a/src/main/java/mekanism/common/lib/multiblock/FormationProtocol.java
+++ b/src/main/java/mekanism/common/lib/multiblock/FormationProtocol.java
@@ -70,7 +70,7 @@ public class FormationProtocol<T extends MultiblockData> {
         T structureFound = result.structureFound;
 
         if (structureFound != null && structureFound.locations.contains(pointer.getTilePos())) {
-            pointer.setMultiblockData(structureFound);
+            pointer.setMultiblockData(manager, structureFound);
             structureFound.setFormedForce(true);
             MultiblockCache<T> cache = manager.createCache();
             UUID idToUse = null;

--- a/src/main/java/mekanism/common/lib/multiblock/IMultiblock.java
+++ b/src/main/java/mekanism/common/lib/multiblock/IMultiblock.java
@@ -7,7 +7,7 @@ public interface IMultiblock<T extends MultiblockData> extends IMultiblockBase {
     T createMultiblock();
 
     default T getMultiblock() {
-        return (T) IMultiblockBase.super.getMultiblockData();
+        return (T) IMultiblockBase.super.getMultiblockData(getManager());
     }
 
     @Override
@@ -24,6 +24,30 @@ public interface IMultiblock<T extends MultiblockData> extends IMultiblockBase {
     void setCache(MultiblockCache<T> cache);
 
     boolean isMaster();
+
+    Structure getStructure();
+
+    void setStructure(Structure structure);
+
+    @Override
+    default void setStructure(MultiblockManager<?> manager, Structure structure) {
+        if (manager == getManager()) {
+            setStructure(structure);
+        }
+    }
+
+    @Override
+    default Structure getStructure(MultiblockManager<?> manager) {
+        if (manager == getManager()) {
+            return getStructure();
+        }
+        return null;
+    }
+
+    @Override
+    default boolean hasStructure(Structure structure) {
+        return getStructure() == structure;
+    }
 
     default boolean hasCache() {
         return getCache() != null;

--- a/src/main/java/mekanism/common/lib/multiblock/IMultiblockBase.java
+++ b/src/main/java/mekanism/common/lib/multiblock/IMultiblockBase.java
@@ -8,27 +8,29 @@ import net.minecraft.util.Hand;
 
 public interface IMultiblockBase extends ITileWrapper {
 
-    default MultiblockData getMultiblockData() {
-        MultiblockData data = getStructure().getMultiblockData();
+    default MultiblockData getMultiblockData(MultiblockManager<?> manager) {
+        MultiblockData data = getStructure(manager).getMultiblockData();
         if (data != null && data.isFormed()) {
             return data;
         }
         return getDefaultData();
     }
 
-    default void setMultiblockData(MultiblockData multiblockData) {
-        getStructure().setMultiblockData(multiblockData);
+    default void setMultiblockData(MultiblockManager<?> manager, MultiblockData multiblockData) {
+        getStructure(manager).setMultiblockData(multiblockData);
     }
 
     MultiblockData getDefaultData();
 
     ActionResultType onActivate(PlayerEntity player, Hand hand, ItemStack stack);
 
-    Structure getStructure();
+    Structure getStructure(MultiblockManager<?> manager);
 
-    void setStructure(Structure structure);
+    boolean hasStructure(Structure structure);
 
-    default void resetStructure() {
-        setStructure(new Structure(this));
+    void setStructure(MultiblockManager<?> manager, Structure structure);
+
+    default void resetStructure(MultiblockManager<?> manager) {
+        setStructure(manager, new Structure(this));
     }
 }

--- a/src/main/java/mekanism/common/lib/multiblock/IStructuralMultiblock.java
+++ b/src/main/java/mekanism/common/lib/multiblock/IStructuralMultiblock.java
@@ -1,6 +1,10 @@
 package mekanism.common.lib.multiblock;
 
+import java.util.Map;
+
 public interface IStructuralMultiblock extends IMultiblockBase {
 
     boolean canInterface(MultiblockManager<?> manager);
+
+    Map<MultiblockManager<?>, Structure> getStructureMap();
 }

--- a/src/main/java/mekanism/common/lib/multiblock/IValveHandler.java
+++ b/src/main/java/mekanism/common/lib/multiblock/IValveHandler.java
@@ -10,7 +10,7 @@ import net.minecraft.util.Direction;
 import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.common.util.Constants.NBT;
 
-public interface IValveHandler<T extends MultiblockData> extends IMultiblock<T> {
+public interface IValveHandler {
 
     default void writeValves(CompoundNBT updateTag) {
         ListNBT valves = new ListNBT();
@@ -39,10 +39,10 @@ public interface IValveHandler<T extends MultiblockData> extends IMultiblock<T> 
         }
     }
 
-    default void triggerValveTransfer() {
-        if (getMultiblock().isFormed()) {
+    default void triggerValveTransfer(IMultiblock<?> multiblock) {
+        if (multiblock.getMultiblock().isFormed()) {
             for (ValveData data : getValveData()) {
-                if (getTilePos().equals(data.location)) {
+                if (multiblock.getTilePos().equals(data.location)) {
                     data.onTransfer();
                     break;
                 }
@@ -50,9 +50,7 @@ public interface IValveHandler<T extends MultiblockData> extends IMultiblock<T> 
         }
     }
 
-    default Collection<ValveData> getValveData() {
-        return getMultiblock().valves;
-    }
+    Collection<ValveData> getValveData();
 
     class ValveData {
 

--- a/src/main/java/mekanism/common/lib/multiblock/IValveHandler.java
+++ b/src/main/java/mekanism/common/lib/multiblock/IValveHandler.java
@@ -10,7 +10,7 @@ import net.minecraft.util.Direction;
 import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.common.util.Constants.NBT;
 
-public interface IValveHandler extends IMultiblockBase {
+public interface IValveHandler<T extends MultiblockData> extends IMultiblock<T> {
 
     default void writeValves(CompoundNBT updateTag) {
         ListNBT valves = new ListNBT();
@@ -40,7 +40,7 @@ public interface IValveHandler extends IMultiblockBase {
     }
 
     default void triggerValveTransfer() {
-        if (getMultiblockData().isFormed()) {
+        if (getMultiblock().isFormed()) {
             for (ValveData data : getValveData()) {
                 if (getTilePos().equals(data.location)) {
                     data.onTransfer();
@@ -51,7 +51,7 @@ public interface IValveHandler extends IMultiblockBase {
     }
 
     default Collection<ValveData> getValveData() {
-        return getMultiblockData().valves;
+        return getMultiblock().valves;
     }
 
     class ValveData {

--- a/src/main/java/mekanism/common/lib/multiblock/MultiblockData.java
+++ b/src/main/java/mekanism/common/lib/multiblock/MultiblockData.java
@@ -1,6 +1,7 @@
 package mekanism.common.lib.multiblock;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
@@ -12,6 +13,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import mekanism.api.Action;
+import mekanism.api.NBTConstants;
 import mekanism.api.chemical.gas.IGasTank;
 import mekanism.api.chemical.gas.IMekanismGasHandler;
 import mekanism.api.chemical.infuse.IInfusionTank;
@@ -37,6 +39,9 @@ import mekanism.common.tile.prefab.TileEntityInternalMultiblock;
 import mekanism.common.tile.prefab.TileEntityMultiblock;
 import mekanism.common.util.EnumUtils;
 import mekanism.common.util.MekanismUtils;
+import mekanism.common.util.NBTUtils;
+import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.nbt.NBTUtil;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Direction;
 import net.minecraft.util.math.BlockPos;
@@ -49,9 +54,6 @@ public class MultiblockData implements IMekanismInventory, IMekanismFluidHandler
     public Set<BlockPos> internalLocations = new ObjectOpenHashSet<>();
     public Set<ValveData> valves = new ObjectOpenHashSet<>();
 
-    @ContainerSync(tags = "stats")
-    public int length, width, height;
-
     @ContainerSync(getter = "getVolume", setter = "setVolume")
     private int volume;
 
@@ -62,7 +64,7 @@ public class MultiblockData implements IMekanismInventory, IMekanismFluidHandler
     @Nullable//may be null if structure has not been fully sent
     public BlockPos renderLocation;
 
-    public VoxelCuboid bounds;
+    private VoxelCuboid bounds = new VoxelCuboid(0, 0, 0);
 
     @ContainerSync
     private boolean formed;
@@ -108,11 +110,8 @@ public class MultiblockData implements IMekanismInventory, IMekanismFluidHandler
             VoxelCuboid cuboid = (VoxelCuboid) shape;
             bounds = cuboid;
             renderLocation = cuboid.getMinPos().offset(Direction.UP);
-            length = cuboid.length();
-            height = cuboid.height();
-            width = cuboid.width();
-            setVolume(length * width * height);
-            return length >= 3 && length <= FormationProtocol.MAX_SIZE && height >= 3 && height <= FormationProtocol.MAX_SIZE && width >= 3 && width <= FormationProtocol.MAX_SIZE;
+            setVolume(bounds.length() * bounds.width() * bounds.height());
+            return true;
         }
         return false;
     }
@@ -182,6 +181,52 @@ public class MultiblockData implements IMekanismInventory, IMekanismFluidHandler
         formed = false;
     }
 
+    public void readUpdateTag(CompoundNBT tag) {
+        NBTUtils.setIntIfPresent(tag, NBTConstants.VOLUME, value -> setVolume(value));
+        NBTUtils.setBlockPosIfPresent(tag, NBTConstants.RENDER_LOCATION, value -> renderLocation = value);
+        bounds = new VoxelCuboid(NBTUtil.readBlockPos(tag.getCompound(NBTConstants.MIN)),
+                                 NBTUtil.readBlockPos(tag.getCompound(NBTConstants.MAX)));
+        if (tag.hasUniqueId(NBTConstants.INVENTORY_ID)) {
+            inventoryID = tag.getUniqueId(NBTConstants.INVENTORY_ID);
+        } else {
+            inventoryID = null;
+        }
+    }
+
+    public void writeUpdateTag(CompoundNBT tag) {
+        tag.putInt(NBTConstants.VOLUME, getVolume());
+        tag.put(NBTConstants.RENDER_LOCATION, NBTUtil.writeBlockPos(renderLocation));
+        tag.put(NBTConstants.MIN, NBTUtil.writeBlockPos(bounds.getMinPos()));
+        tag.put(NBTConstants.MAX, NBTUtil.writeBlockPos(bounds.getMaxPos()));
+        if (inventoryID != null) {
+            tag.putUniqueId(NBTConstants.INVENTORY_ID, inventoryID);
+        }
+    }
+
+    public int length() {
+        return bounds.length();
+    }
+
+    public int width() {
+        return bounds.width();
+    }
+
+    public int height() {
+        return bounds.height();
+    }
+
+    public BlockPos getMinPos() {
+        return bounds.getMinPos();
+    }
+
+    public BlockPos getMaxPos() {
+        return bounds.getMaxPos();
+    }
+
+    public VoxelCuboid getBounds() {
+        return bounds;
+    }
+
     @Nonnull
     @Override
     public List<IInventorySlot> getInventorySlots(@Nullable Direction side) {
@@ -240,6 +285,10 @@ public class MultiblockData implements IMekanismInventory, IMekanismFluidHandler
         return directionsToEmit;
     }
 
+    public Collection<ValveData> getValveData() {
+        return valves;
+    }
+
     @Override
     public void onContentsChanged() {
     }
@@ -248,9 +297,7 @@ public class MultiblockData implements IMekanismInventory, IMekanismFluidHandler
     public int hashCode() {
         int code = 1;
         code = 31 * code + locations.hashCode();
-        code = 31 * code + length;
-        code = 31 * code + width;
-        code = 31 * code + height;
+        code = 31 * code + bounds.hashCode();
         code = 31 * code + getVolume();
         return code;
     }
@@ -264,7 +311,7 @@ public class MultiblockData implements IMekanismInventory, IMekanismFluidHandler
         if (!data.locations.equals(locations)) {
             return false;
         }
-        if (data.length != length || data.width != width || data.height != height) {
+        if (!data.bounds.equals(bounds)) {
             return false;
         }
         return data.getVolume() == getVolume();

--- a/src/main/java/mekanism/common/lib/multiblock/MultiblockData.java
+++ b/src/main/java/mekanism/common/lib/multiblock/MultiblockData.java
@@ -62,7 +62,7 @@ public class MultiblockData implements IMekanismInventory, IMekanismFluidHandler
     @Nullable//may be null if structure has not been fully sent
     public BlockPos renderLocation;
 
-    public BlockPos minLocation, maxLocation;
+    public VoxelCuboid bounds;
 
     @ContainerSync
     private boolean formed;
@@ -106,12 +106,11 @@ public class MultiblockData implements IMekanismInventory, IMekanismFluidHandler
     public boolean setShape(IShape shape) {
         if (shape instanceof VoxelCuboid) {
             VoxelCuboid cuboid = (VoxelCuboid) shape;
-            minLocation = cuboid.getMinPos();
-            maxLocation = cuboid.getMaxPos();
-            renderLocation = minLocation.offset(Direction.UP);
-            length = Math.abs(maxLocation.getX() - minLocation.getX()) + 1;
-            height = Math.abs(maxLocation.getY() - minLocation.getY()) + 1;
-            width = Math.abs(maxLocation.getZ() - minLocation.getZ()) + 1;
+            bounds = cuboid;
+            renderLocation = cuboid.getMinPos().offset(Direction.UP);
+            length = cuboid.length();
+            height = cuboid.height();
+            width = cuboid.width();
             setVolume(length * width * height);
             return length >= 3 && length <= FormationProtocol.MAX_SIZE && height >= 3 && height <= FormationProtocol.MAX_SIZE && width >= 3 && width <= FormationProtocol.MAX_SIZE;
         }

--- a/src/main/java/mekanism/common/lib/multiblock/Structure.java
+++ b/src/main/java/mekanism/common/lib/multiblock/Structure.java
@@ -74,7 +74,7 @@ public class Structure {
         return minorPlaneMap.computeIfAbsent(axis, k -> new TreeMap<>(Integer::compare));
     }
 
-    public TreeMap<Integer, VoxelPlane> getAxisMap(Axis axis) {
+    public TreeMap<Integer, VoxelPlane> getMajorAxisMap(Axis axis) {
         return planeMap.computeIfAbsent(axis, k -> new TreeMap<>(Integer::compare));
     }
 
@@ -109,7 +109,7 @@ public class Structure {
             });
             for (Axis axis : s.minorPlaneMap.keySet()) {
                 Map<Integer, VoxelPlane> minorMap = getMinorAxisMap(axis);
-                Map<Integer, VoxelPlane> majorMap = getAxisMap(axis);
+                Map<Integer, VoxelPlane> majorMap = getMajorAxisMap(axis);
                 s.minorPlaneMap.get(axis).forEach((key, value) -> {
                     if (majorMap.containsKey(key)) {
                         majorMap.get(key).merge(value);
@@ -128,7 +128,7 @@ public class Structure {
                 });
             }
             for (Axis axis : s.planeMap.keySet()) {
-                Map<Integer, VoxelPlane> map = getAxisMap(axis);
+                Map<Integer, VoxelPlane> map = getMajorAxisMap(axis);
                 s.planeMap.get(axis).forEach((key, value) -> {
                     VoxelPlane p = map.get(key);
                     if (p != null) {

--- a/src/main/java/mekanism/common/lib/multiblock/Structure.java
+++ b/src/main/java/mekanism/common/lib/multiblock/Structure.java
@@ -168,7 +168,11 @@ public class Structure {
     private static void validate(IMultiblockBase node) {
         if (node instanceof IMultiblock) {
             IMultiblock<?> multiblock = (IMultiblock<?>) node;
-            multiblock.resetStructure(multiblock.getManager());
+            if (!multiblock.getStructure().isValid()) {
+                // only validate if necessary; this will already be valid if we recursively call validate()
+                // from a structural multiblock's perspective
+                multiblock.resetStructure(multiblock.getManager());
+            }
         } else if (node instanceof IStructuralMultiblock) {
             ((IStructuralMultiblock) node).resetStructure(null);
         }

--- a/src/main/java/mekanism/common/lib/multiblock/StructureHelper.java
+++ b/src/main/java/mekanism/common/lib/multiblock/StructureHelper.java
@@ -64,6 +64,10 @@ public class StructureHelper {
             Axis axis = side.getAxis(), horizontal = side.getAxis().horizontal(), vertical = side.getAxis().vertical();
             TreeMap<Integer, VoxelPlane> map = structure.getMajorAxisMap(axis);
             Map.Entry<Integer, VoxelPlane> entry = side.getFace().isPositive() ? map.lastEntry() : map.firstEntry();
+            // fail fast if the plane doesn't exist
+            if (entry == null) {
+                return null;
+            }
             VoxelPlane plane = entry.getValue();
             // handle missing blocks based on tolerance value
             missing += plane.getMissing();

--- a/src/main/java/mekanism/common/lib/multiblock/StructureHelper.java
+++ b/src/main/java/mekanism/common/lib/multiblock/StructureHelper.java
@@ -4,14 +4,13 @@ import java.util.EnumSet;
 import java.util.Map;
 import java.util.TreeMap;
 import mekanism.common.lib.math.voxel.VoxelCuboid;
-import mekanism.common.lib.math.voxel.VoxelPlane;
 import mekanism.common.lib.math.voxel.VoxelCuboid.CuboidBuilder;
 import mekanism.common.lib.math.voxel.VoxelCuboid.CuboidSide;
 import mekanism.common.lib.math.voxel.VoxelCuboid.CuboidSide.Face;
+import mekanism.common.lib.math.voxel.VoxelPlane;
 import mekanism.common.lib.multiblock.Structure.Axis;
 
 public class StructureHelper {
-
 
     /**
      * Fetch a cuboid with all 6 sides present. Quicker than using the below algorithm with all sides.
@@ -24,7 +23,7 @@ public class StructureHelper {
     public static VoxelCuboid fetchCuboid(Structure structure, VoxelCuboid minBounds, VoxelCuboid maxBounds) {
         VoxelCuboid prev = null;
         for (Axis axis : Axis.AXES) {
-            TreeMap<Integer, VoxelPlane> map = structure.getAxisMap(axis);
+            TreeMap<Integer, VoxelPlane> map = structure.getMajorAxisMap(axis);
             Map.Entry<Integer, VoxelPlane> first = map.firstEntry(), last = map.lastEntry();
             if (first == null || !first.getValue().equals(last.getValue()) || !first.getValue().isFull()) {
                 return null;
@@ -63,7 +62,7 @@ public class StructureHelper {
         CuboidBuilder builder = new CuboidBuilder();
         for (CuboidSide side : sides) {
             Axis axis = side.getAxis(), horizontal = side.getAxis().horizontal(), vertical = side.getAxis().vertical();
-            TreeMap<Integer, VoxelPlane> map = structure.getAxisMap(axis);
+            TreeMap<Integer, VoxelPlane> map = structure.getMajorAxisMap(axis);
             Map.Entry<Integer, VoxelPlane> entry = side.getFace().isPositive() ? map.lastEntry() : map.firstEntry();
             VoxelPlane plane = entry.getValue();
             // handle missing blocks based on tolerance value

--- a/src/main/java/mekanism/common/tile/multiblock/TileEntityBoilerCasing.java
+++ b/src/main/java/mekanism/common/tile/multiblock/TileEntityBoilerCasing.java
@@ -1,20 +1,16 @@
 package mekanism.common.tile.multiblock;
 
 import javax.annotation.Nonnull;
-import mekanism.api.NBTConstants;
 import mekanism.api.providers.IBlockProvider;
 import mekanism.common.Mekanism;
 import mekanism.common.capabilities.holder.heat.IHeatCapacitorHolder;
 import mekanism.common.content.boiler.BoilerMultiblockData;
-import mekanism.common.lib.multiblock.IValveHandler;
 import mekanism.common.lib.multiblock.MultiblockManager;
 import mekanism.common.registries.MekanismBlocks;
 import mekanism.common.tile.base.SubstanceType;
 import mekanism.common.tile.prefab.TileEntityMultiblock;
-import mekanism.common.util.NBTUtils;
-import net.minecraft.nbt.CompoundNBT;
 
-public class TileEntityBoilerCasing extends TileEntityMultiblock<BoilerMultiblockData> implements IValveHandler<BoilerMultiblockData> {
+public class TileEntityBoilerCasing extends TileEntityMultiblock<BoilerMultiblockData> {
 
     public TileEntityBoilerCasing() {
         this(MekanismBlocks.BOILER_CASING);
@@ -48,39 +44,5 @@ public class TileEntityBoilerCasing extends TileEntityMultiblock<BoilerMultibloc
             return false;
         }
         return super.persists(type);
-    }
-
-    @Nonnull
-    @Override
-    public CompoundNBT getReducedUpdateTag() {
-        CompoundNBT updateTag = super.getReducedUpdateTag();
-        if (getMultiblock().isFormed() && isMaster) {
-            updateTag.putFloat(NBTConstants.SCALE, getMultiblock().prevWaterScale);
-            updateTag.putFloat(NBTConstants.SCALE_ALT, getMultiblock().prevSteamScale);
-            updateTag.putInt(NBTConstants.VOLUME, getMultiblock().getWaterVolume());
-            updateTag.putInt(NBTConstants.LOWER_VOLUME, getMultiblock().getSteamVolume());
-            updateTag.put(NBTConstants.FLUID_STORED, getMultiblock().waterTank.getFluid().writeToNBT(new CompoundNBT()));
-            updateTag.put(NBTConstants.GAS_STORED, getMultiblock().steamTank.getStack().write(new CompoundNBT()));
-            updateTag.put(NBTConstants.RENDER_Y, getMultiblock().upperRenderLocation.write(new CompoundNBT()));
-            updateTag.putBoolean(NBTConstants.HOT, getMultiblock().clientHot);
-            writeValves(updateTag);
-        }
-        return updateTag;
-    }
-
-    @Override
-    public void handleUpdateTag(@Nonnull CompoundNBT tag) {
-        super.handleUpdateTag(tag);
-        if (isMaster && getMultiblock().isFormed()) {
-            NBTUtils.setFloatIfPresent(tag, NBTConstants.SCALE, scale -> getMultiblock().prevWaterScale = scale);
-            NBTUtils.setFloatIfPresent(tag, NBTConstants.SCALE_ALT, scale -> getMultiblock().prevSteamScale = scale);
-            NBTUtils.setIntIfPresent(tag, NBTConstants.VOLUME, value -> getMultiblock().setWaterVolume(value));
-            NBTUtils.setIntIfPresent(tag, NBTConstants.LOWER_VOLUME, value -> getMultiblock().setSteamVolume(value));
-            NBTUtils.setFluidStackIfPresent(tag, NBTConstants.FLUID_STORED, value -> getMultiblock().waterTank.setStack(value));
-            NBTUtils.setGasStackIfPresent(tag, NBTConstants.GAS_STORED, value -> getMultiblock().steamTank.setStack(value));
-            NBTUtils.setCoord4DIfPresent(tag, NBTConstants.RENDER_Y, value -> getMultiblock().upperRenderLocation = value);
-            NBTUtils.setBooleanIfPresent(tag, NBTConstants.HOT, value -> getMultiblock().clientHot = value);
-            readValves(tag);
-        }
     }
 }

--- a/src/main/java/mekanism/common/tile/multiblock/TileEntityBoilerCasing.java
+++ b/src/main/java/mekanism/common/tile/multiblock/TileEntityBoilerCasing.java
@@ -14,7 +14,7 @@ import mekanism.common.tile.prefab.TileEntityMultiblock;
 import mekanism.common.util.NBTUtils;
 import net.minecraft.nbt.CompoundNBT;
 
-public class TileEntityBoilerCasing extends TileEntityMultiblock<BoilerMultiblockData> implements IValveHandler {
+public class TileEntityBoilerCasing extends TileEntityMultiblock<BoilerMultiblockData> implements IValveHandler<BoilerMultiblockData> {
 
     public TileEntityBoilerCasing() {
         this(MekanismBlocks.BOILER_CASING);

--- a/src/main/java/mekanism/common/tile/multiblock/TileEntityBoilerValve.java
+++ b/src/main/java/mekanism/common/tile/multiblock/TileEntityBoilerValve.java
@@ -86,7 +86,7 @@ public class TileEntityBoilerValve extends TileEntityBoilerCasing {
     public FluidStack insertFluid(FluidStack stack, Direction side, Action action) {
         FluidStack ret = super.insertFluid(stack, side, action);
         if (ret.getAmount() < stack.getAmount() && action.execute()) {
-            triggerValveTransfer();
+            getMultiblock().triggerValveTransfer(this);
         }
         return ret;
     }

--- a/src/main/java/mekanism/common/tile/multiblock/TileEntityDynamicTank.java
+++ b/src/main/java/mekanism/common/tile/multiblock/TileEntityDynamicTank.java
@@ -19,7 +19,7 @@ import net.minecraft.util.ActionResultType;
 import net.minecraft.util.Hand;
 import net.minecraftforge.items.CapabilityItemHandler;
 
-public class TileEntityDynamicTank extends TileEntityMultiblock<TankMultiblockData> implements IFluidContainerManager, IValveHandler {
+public class TileEntityDynamicTank extends TileEntityMultiblock<TankMultiblockData> implements IFluidContainerManager, IValveHandler<TankMultiblockData> {
 
     public TileEntityDynamicTank() {
         this(MekanismBlocks.DYNAMIC_TANK);

--- a/src/main/java/mekanism/common/tile/multiblock/TileEntityDynamicTank.java
+++ b/src/main/java/mekanism/common/tile/multiblock/TileEntityDynamicTank.java
@@ -1,25 +1,21 @@
 package mekanism.common.tile.multiblock;
 
 import javax.annotation.Nonnull;
-import mekanism.api.NBTConstants;
 import mekanism.api.providers.IBlockProvider;
 import mekanism.common.Mekanism;
 import mekanism.common.content.tank.TankMultiblockData;
-import mekanism.common.lib.multiblock.IValveHandler;
 import mekanism.common.lib.multiblock.MultiblockManager;
 import mekanism.common.registries.MekanismBlocks;
 import mekanism.common.tile.interfaces.IFluidContainerManager;
 import mekanism.common.tile.prefab.TileEntityMultiblock;
 import mekanism.common.util.FluidUtils;
-import mekanism.common.util.NBTUtils;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.util.ActionResultType;
 import net.minecraft.util.Hand;
 import net.minecraftforge.items.CapabilityItemHandler;
 
-public class TileEntityDynamicTank extends TileEntityMultiblock<TankMultiblockData> implements IFluidContainerManager, IValveHandler<TankMultiblockData> {
+public class TileEntityDynamicTank extends TileEntityMultiblock<TankMultiblockData> implements IFluidContainerManager {
 
     public TileEntityDynamicTank() {
         this(MekanismBlocks.DYNAMIC_TANK);
@@ -69,29 +65,5 @@ public class TileEntityDynamicTank extends TileEntityMultiblock<TankMultiblockDa
             return false;
         }
         return FluidUtils.handleTankInteraction(player, hand, itemStack, getMultiblock().getFluidTank());
-    }
-
-    @Nonnull
-    @Override
-    public CompoundNBT getReducedUpdateTag() {
-        CompoundNBT updateTag = super.getReducedUpdateTag();
-        if (getMultiblock().isFormed() && isMaster) {
-            updateTag.putFloat(NBTConstants.SCALE, getMultiblock().prevScale);
-            updateTag.putInt(NBTConstants.VOLUME, getMultiblock().getVolume());
-            getMultiblock().mergedTank.addToUpdateTag(updateTag);
-            writeValves(updateTag);
-        }
-        return updateTag;
-    }
-
-    @Override
-    public void handleUpdateTag(@Nonnull CompoundNBT tag) {
-        super.handleUpdateTag(tag);
-        if (getMultiblock().isFormed() && isMaster) {
-            NBTUtils.setFloatIfPresent(tag, NBTConstants.SCALE, scale -> getMultiblock().prevScale = scale);
-            NBTUtils.setIntIfPresent(tag, NBTConstants.VOLUME, value -> getMultiblock().setVolume(value));
-            getMultiblock().mergedTank.readFromUpdateTag(tag);
-            readValves(tag);
-        }
     }
 }

--- a/src/main/java/mekanism/common/tile/multiblock/TileEntityDynamicValve.java
+++ b/src/main/java/mekanism/common/tile/multiblock/TileEntityDynamicValve.java
@@ -71,7 +71,7 @@ public class TileEntityDynamicValve extends TileEntityDynamicTank {
     public FluidStack insertFluid(@Nonnull FluidStack stack, Direction side, @Nonnull Action action) {
         FluidStack ret = super.insertFluid(stack, side, action);
         if (action.execute() && ret.getAmount() < stack.getAmount()) {
-            triggerValveTransfer();
+            getMultiblock().triggerValveTransfer(this);
         }
         return ret;
     }

--- a/src/main/java/mekanism/common/tile/multiblock/TileEntitySPSCasing.java
+++ b/src/main/java/mekanism/common/tile/multiblock/TileEntitySPSCasing.java
@@ -8,6 +8,7 @@ import mekanism.api.math.FloatingLong;
 import mekanism.api.providers.IBlockProvider;
 import mekanism.common.Mekanism;
 import mekanism.common.content.sps.SPSMultiblockData;
+import mekanism.common.lib.math.voxel.VoxelCuboid;
 import mekanism.common.lib.multiblock.MultiblockManager;
 import mekanism.common.particle.custom.SPSOrbitEffect;
 import mekanism.common.registries.MekanismBlocks;
@@ -71,8 +72,8 @@ public class TileEntitySPSCasing extends TileEntityMultiblock<SPSMultiblockData>
             updateTag.putDouble(NBTConstants.LAST_PROCESSED, getMultiblock().lastProcessed);
             if (isMaster) {
                 getMultiblock().coilData.write(updateTag);
-                updateTag.put(NBTConstants.MIN, NBTUtil.writeBlockPos(getMultiblock().minLocation));
-                updateTag.put(NBTConstants.MAX, NBTUtil.writeBlockPos(getMultiblock().maxLocation));
+                updateTag.put(NBTConstants.MIN, NBTUtil.writeBlockPos(getMultiblock().bounds.getMinPos()));
+                updateTag.put(NBTConstants.MAX, NBTUtil.writeBlockPos(getMultiblock().bounds.getMaxPos()));
                 updateTag.putString(NBTConstants.ENERGY_USAGE, getMultiblock().lastReceivedEnergy.toString());
             }
         }
@@ -87,8 +88,8 @@ public class TileEntitySPSCasing extends TileEntityMultiblock<SPSMultiblockData>
             getMultiblock().lastProcessed = tag.getDouble(NBTConstants.LAST_PROCESSED);
             if (isMaster) {
                 getMultiblock().coilData.read(tag);
-                getMultiblock().minLocation = NBTUtil.readBlockPos(tag.getCompound(NBTConstants.MIN));
-                getMultiblock().maxLocation = NBTUtil.readBlockPos(tag.getCompound(NBTConstants.MAX));
+                getMultiblock().bounds = new VoxelCuboid(NBTUtil.readBlockPos(tag.getCompound(NBTConstants.MIN)),
+                                                         NBTUtil.readBlockPos(tag.getCompound(NBTConstants.MAX)));
                 getMultiblock().lastReceivedEnergy = FloatingLong.parseFloatingLong(tag.getString(NBTConstants.ENERGY_USAGE));
             }
         }

--- a/src/main/java/mekanism/common/tile/multiblock/TileEntitySPSCasing.java
+++ b/src/main/java/mekanism/common/tile/multiblock/TileEntitySPSCasing.java
@@ -4,18 +4,15 @@ import java.util.LinkedList;
 import java.util.Queue;
 import javax.annotation.Nonnull;
 import mekanism.api.NBTConstants;
-import mekanism.api.math.FloatingLong;
 import mekanism.api.providers.IBlockProvider;
 import mekanism.common.Mekanism;
 import mekanism.common.content.sps.SPSMultiblockData;
-import mekanism.common.lib.math.voxel.VoxelCuboid;
 import mekanism.common.lib.multiblock.MultiblockManager;
 import mekanism.common.particle.custom.SPSOrbitEffect;
 import mekanism.common.registries.MekanismBlocks;
 import mekanism.common.tile.prefab.TileEntityMultiblock;
 import mekanism.common.util.NBTUtils;
 import net.minecraft.nbt.CompoundNBT;
-import net.minecraft.nbt.NBTUtil;
 
 public class TileEntitySPSCasing extends TileEntityMultiblock<SPSMultiblockData> {
 
@@ -70,12 +67,6 @@ public class TileEntitySPSCasing extends TileEntityMultiblock<SPSMultiblockData>
         updateTag.putBoolean(NBTConstants.HANDLE_SOUND, getMultiblock().isFormed() && getMultiblock().handlesSound(this));
         if (getMultiblock().isFormed()) {
             updateTag.putDouble(NBTConstants.LAST_PROCESSED, getMultiblock().lastProcessed);
-            if (isMaster) {
-                getMultiblock().coilData.write(updateTag);
-                updateTag.put(NBTConstants.MIN, NBTUtil.writeBlockPos(getMultiblock().bounds.getMinPos()));
-                updateTag.put(NBTConstants.MAX, NBTUtil.writeBlockPos(getMultiblock().bounds.getMaxPos()));
-                updateTag.putString(NBTConstants.ENERGY_USAGE, getMultiblock().lastReceivedEnergy.toString());
-            }
         }
         return updateTag;
     }
@@ -86,12 +77,6 @@ public class TileEntitySPSCasing extends TileEntityMultiblock<SPSMultiblockData>
         NBTUtils.setBooleanIfPresent(tag, NBTConstants.HANDLE_SOUND, value -> handleSound = value);
         if (getMultiblock().isFormed()) {
             getMultiblock().lastProcessed = tag.getDouble(NBTConstants.LAST_PROCESSED);
-            if (isMaster) {
-                getMultiblock().coilData.read(tag);
-                getMultiblock().bounds = new VoxelCuboid(NBTUtil.readBlockPos(tag.getCompound(NBTConstants.MIN)),
-                                                         NBTUtil.readBlockPos(tag.getCompound(NBTConstants.MAX)));
-                getMultiblock().lastReceivedEnergy = FloatingLong.parseFloatingLong(tag.getString(NBTConstants.ENERGY_USAGE));
-            }
         }
     }
 }

--- a/src/main/java/mekanism/common/tile/multiblock/TileEntityThermalEvaporationBlock.java
+++ b/src/main/java/mekanism/common/tile/multiblock/TileEntityThermalEvaporationBlock.java
@@ -1,18 +1,12 @@
 package mekanism.common.tile.multiblock;
 
-import javax.annotation.Nonnull;
-import mekanism.api.NBTConstants;
 import mekanism.api.providers.IBlockProvider;
 import mekanism.common.Mekanism;
 import mekanism.common.content.evaporation.EvaporationMultiblockData;
-import mekanism.common.inventory.container.MekanismContainer;
-import mekanism.common.inventory.container.sync.dynamic.SyncMapper;
 import mekanism.common.lib.multiblock.MultiblockManager;
 import mekanism.common.registries.MekanismBlocks;
 import mekanism.common.tile.prefab.TileEntityMultiblock;
-import mekanism.common.util.NBTUtils;
 import net.minecraft.block.Block;
-import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.util.math.BlockPos;
 
 public class TileEntityThermalEvaporationBlock extends TileEntityMultiblock<EvaporationMultiblockData> {
@@ -35,32 +29,6 @@ public class TileEntityThermalEvaporationBlock extends TileEntityMultiblock<Evap
                 }
             }
         }
-    }
-
-    @Nonnull
-    @Override
-    public CompoundNBT getReducedUpdateTag() {
-        CompoundNBT updateTag = super.getReducedUpdateTag();
-        if (getMultiblock().isFormed() && isMaster) {
-            updateTag.put(NBTConstants.FLUID_STORED, getMultiblock().inputTank.getFluid().writeToNBT(new CompoundNBT()));
-            updateTag.putFloat(NBTConstants.SCALE, getMultiblock().prevScale);
-        }
-        return updateTag;
-    }
-
-    @Override
-    public void handleUpdateTag(@Nonnull CompoundNBT tag) {
-        super.handleUpdateTag(tag);
-        if (isMaster && getMultiblock().isFormed()) {
-            NBTUtils.setFluidStackIfPresent(tag, NBTConstants.FLUID_STORED, fluid -> getMultiblock().inputTank.setStack(fluid));
-            NBTUtils.setFloatIfPresent(tag, NBTConstants.SCALE, scale -> getMultiblock().prevScale = scale);
-        }
-    }
-
-    @Override
-    public void addContainerTrackers(MekanismContainer container) {
-        super.addContainerTrackers(container);
-        SyncMapper.setup(container, getMultiblock().getClass(), this::getMultiblock, "stats");
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/multiblock/TileEntityThermalEvaporationController.java
+++ b/src/main/java/mekanism/common/tile/multiblock/TileEntityThermalEvaporationController.java
@@ -6,6 +6,7 @@ public class TileEntityThermalEvaporationController extends TileEntityThermalEva
 
     public TileEntityThermalEvaporationController() {
         super(MekanismBlocks.THERMAL_EVAPORATION_CONTROLLER);
+        delaySupplier = () -> 0;
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/multiblock/TileEntityThermalEvaporationValve.java
+++ b/src/main/java/mekanism/common/tile/multiblock/TileEntityThermalEvaporationValve.java
@@ -1,11 +1,14 @@
 package mekanism.common.tile.multiblock;
 
 import javax.annotation.Nonnull;
+import mekanism.api.Action;
 import mekanism.common.capabilities.holder.fluid.IFluidTankHolder;
 import mekanism.common.capabilities.holder.heat.IHeatCapacitorHolder;
 import mekanism.common.capabilities.holder.slot.IInventorySlotHolder;
 import mekanism.common.registries.MekanismBlocks;
 import mekanism.common.tile.base.SubstanceType;
+import net.minecraft.util.Direction;
+import net.minecraftforge.fluids.FluidStack;
 
 public class TileEntityThermalEvaporationValve extends TileEntityThermalEvaporationBlock {
 
@@ -43,6 +46,15 @@ public class TileEntityThermalEvaporationValve extends TileEntityThermalEvaporat
     @Override
     public boolean persistInventory() {
         return false;
+    }
+
+    @Override
+    public FluidStack insertFluid(FluidStack stack, Direction side, Action action) {
+        FluidStack ret = super.insertFluid(stack, side, action);
+        if (ret.getAmount() < stack.getAmount() && action.execute()) {
+            getMultiblock().triggerValveTransfer(this);
+        }
+        return ret;
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityStructuralMultiblock.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityStructuralMultiblock.java
@@ -1,13 +1,17 @@
 package mekanism.common.tile.prefab;
 
+import java.util.HashMap;
+import java.util.Map;
 import mekanism.api.IConfigurable;
 import mekanism.api.providers.IBlockProvider;
 import mekanism.common.capabilities.Capabilities;
 import mekanism.common.capabilities.resolver.basic.BasicCapabilityResolver;
+import mekanism.common.lib.math.voxel.VoxelCuboid;
 import mekanism.common.lib.multiblock.FormationProtocol.FormationResult;
 import mekanism.common.lib.multiblock.IMultiblock;
 import mekanism.common.lib.multiblock.IStructuralMultiblock;
 import mekanism.common.lib.multiblock.MultiblockData;
+import mekanism.common.lib.multiblock.MultiblockManager;
 import mekanism.common.lib.multiblock.Structure;
 import mekanism.common.tile.base.TileEntityMekanism;
 import net.minecraft.entity.player.PlayerEntity;
@@ -18,7 +22,8 @@ import net.minecraft.util.Hand;
 
 public abstract class TileEntityStructuralMultiblock extends TileEntityMekanism implements IStructuralMultiblock, IConfigurable {
 
-    private Structure structure = Structure.INVALID;
+    private Map<MultiblockManager<?>, Structure> structures = new HashMap<>();
+    private final Structure invalidStructure = Structure.INVALID;
 
     private MultiblockData defaultMultiblock = new MultiblockData(this);
 
@@ -33,40 +38,61 @@ public abstract class TileEntityStructuralMultiblock extends TileEntityMekanism 
     }
 
     @Override
-    public void setStructure(Structure structure) {
-        this.structure = structure;
+    public void setStructure(MultiblockManager<?> manager, Structure structure) {
+        structures.put(manager, structure);
     }
 
     @Override
-    public Structure getStructure() {
-        return structure;
+    public Structure getStructure(MultiblockManager<?> manager) {
+        return structures.getOrDefault(manager, invalidStructure);
+    }
+
+    @Override
+    public boolean hasStructure(Structure structure) {
+        return structures.get(structure.getManager()) == structure;
+    }
+
+    @Override
+    public Map<MultiblockManager<?>, Structure> getStructureMap() {
+        return structures;
     }
 
     @Override
     public void onUpdateServer() {
         super.onUpdateServer();
-        if (ticker >= 3)
-            structure.tick(this);
+        structures.entrySet().removeIf(entry -> !entry.getValue().isValid());
+        if (ticker >= 3 && structures.isEmpty())
+            invalidStructure.tick(this);
     }
 
     @Override
     public ActionResultType onActivate(PlayerEntity player, Hand hand, ItemStack stack) {
-        IMultiblock<?> master = getStructure().getController();
-        if (master != null) {
-            return master.onActivate(player, hand, stack);
+        for (Structure s : structures.values()) {
+            System.out.println(s.hashCode() + " " + s.size() + " " + (s.getManager() != null ? s.getManager().getName() : null));
+        }
+        for (Map.Entry<MultiblockManager<?>, Structure> entry : structures.entrySet()) {
+            IMultiblock<?> master = entry.getValue().getController();
+            if (master != null && getMultiblockData(entry.getKey()).isFormed()) {
+                // make sure this block is on the structure first
+                if (new VoxelCuboid(entry.getValue().getMultiblockData().minLocation, entry.getValue().getMultiblockData().maxLocation).isOnSide(getPos())) {
+                    return master.onActivate(player, hand, stack);
+                }
+            }
         }
         return ActionResultType.PASS;
     }
 
     @Override
     public ActionResultType onRightClick(PlayerEntity player, Direction side) {
-        if (!getWorld().isRemote() && !getMultiblockData().isFormed()) {
-            IMultiblock<?> master = getStructure().getController();
-            if (master != null) {
-                FormationResult result = getStructure().runUpdate(this);
-                if (!result.isFormed() && result.getResultText() != null) {
-                    player.sendMessage(result.getResultText());
-                    return ActionResultType.SUCCESS;
+        if (!getWorld().isRemote()) {
+            for (Structure s : structures.values()) {
+                IMultiblock<?> master = s.getController();
+                if (master != null && !s.getMultiblockData().isFormed()) {
+                    FormationResult result = s.runUpdate(this);
+                    if (!result.isFormed() && result.getResultText() != null) {
+                        player.sendMessage(result.getResultText());
+                        return ActionResultType.SUCCESS;
+                    }
                 }
             }
         }
@@ -82,7 +108,7 @@ public abstract class TileEntityStructuralMultiblock extends TileEntityMekanism 
     public void remove() {
         super.remove();
         if (!world.isRemote()) {
-            structure.invalidate(world);
+            structures.values().forEach(s -> s.invalidate(world));
         }
     }
 
@@ -90,7 +116,7 @@ public abstract class TileEntityStructuralMultiblock extends TileEntityMekanism 
     public void onChunkUnloaded() {
         super.onChunkUnloaded();
         if (!world.isRemote()) {
-            structure.invalidate(world);
+            structures.values().forEach(s -> s.invalidate(world));
         }
     }
 }

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityStructuralMultiblock.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityStructuralMultiblock.java
@@ -70,7 +70,7 @@ public abstract class TileEntityStructuralMultiblock extends TileEntityMekanism 
             IMultiblock<?> master = entry.getValue().getController();
             if (master != null && getMultiblockData(entry.getKey()).isFormed()) {
                 // make sure this block is on the structure first
-                if (entry.getValue().getMultiblockData().bounds.getRelativeLocation(getPos()).isWall()) {
+                if (entry.getValue().getMultiblockData().getBounds().getRelativeLocation(getPos()).isWall()) {
                     return master.onActivate(player, hand, stack);
                 }
             }

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityStructuralMultiblock.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityStructuralMultiblock.java
@@ -6,7 +6,6 @@ import mekanism.api.IConfigurable;
 import mekanism.api.providers.IBlockProvider;
 import mekanism.common.capabilities.Capabilities;
 import mekanism.common.capabilities.resolver.basic.BasicCapabilityResolver;
-import mekanism.common.lib.math.voxel.VoxelCuboid;
 import mekanism.common.lib.multiblock.FormationProtocol.FormationResult;
 import mekanism.common.lib.multiblock.IMultiblock;
 import mekanism.common.lib.multiblock.IStructuralMultiblock;
@@ -67,14 +66,11 @@ public abstract class TileEntityStructuralMultiblock extends TileEntityMekanism 
 
     @Override
     public ActionResultType onActivate(PlayerEntity player, Hand hand, ItemStack stack) {
-        for (Structure s : structures.values()) {
-            System.out.println(s.hashCode() + " " + s.size() + " " + (s.getManager() != null ? s.getManager().getName() : null));
-        }
         for (Map.Entry<MultiblockManager<?>, Structure> entry : structures.entrySet()) {
             IMultiblock<?> master = entry.getValue().getController();
             if (master != null && getMultiblockData(entry.getKey()).isFormed()) {
                 // make sure this block is on the structure first
-                if (new VoxelCuboid(entry.getValue().getMultiblockData().minLocation, entry.getValue().getMultiblockData().maxLocation).isOnSide(getPos())) {
+                if (entry.getValue().getMultiblockData().bounds.getRelativeLocation(getPos()).isWall()) {
                     return master.onActivate(player, hand, stack);
                 }
             }
@@ -87,7 +83,7 @@ public abstract class TileEntityStructuralMultiblock extends TileEntityMekanism 
         if (!getWorld().isRemote()) {
             for (Structure s : structures.values()) {
                 IMultiblock<?> master = s.getController();
-                if (master != null && !s.getMultiblockData().isFormed()) {
+                if (master != null && !getMultiblockData(s.getManager()).isFormed()) {
                     FormationResult result = s.runUpdate(this);
                     if (!result.isFormed() && result.getResultText() != null) {
                         player.sendMessage(result.getResultText());


### PR DESCRIPTION
## Changes proposed in this pull request:
These changes will allow for multiblocks (of differing types) to be placed adjacently again. This is done by allowing 'structural multiblocks' to hold references to multiple structures at one time, or from another perspective, allow multiple structures to hold references to the same structural multiblock. 

**Implementation notes:**
- Structural multiblocks are able to determine which multiblock to 'activate' when right-clicked by running a quick VoxelCuboid check for each structure to determine which one they exist relative to as a 'wall.'
- Structures now hold references to an additional 'majorPlaneMap.' Planes in the original, now-renamed 'minorPlaneMap' will be promoted to the majorPlaneMap when they (a) are at least 2x2 in dimensions, and (b) contain at least one 'controller' IMultiblock. All multiblock calculations now only use majorPlaneMap. This allows us to make sure we don't try to run formation logic on planes of structural multiblocks that exist within other multiblock structures.
- VoxelPlanes now keep track of an 'outsideSet' of blocks which are not contained within the plane's primary bounds. Primary bounds are determined by the bounds of contained 'IMultiblocks,' so we don't try to reference structural multiblocks that aren't a part of the target plane. Each time another plane is merged, the bounds are updated accordingly and the outsideSet is scanned to see which blocks should be added to the primary plane. A side effect of this is that VoxelPlane's size(), length() and width() calculations are now based on the 'primary bounds' of the plane, and won't include any structural multiblocks that don't fit.

**Future improvements:**
We currently have structural multiblocks associate structures only containing structural multiblocks (without controllers) with a null key, but still allow structural merging. When IMultiblocks are placed adjacently to these structures, the formation algorithm doesn't merge with this null-associated structure, but rather traverses through all the structural multiblocks, adding each to its structure. It may be possible in the future to handle this null-associated structure more efficiently by directly merging primary multiblocks with these null structures, but it will take very careful edge-case analysis to make sure we don't duplicate contained blocks or planes.

**Summary:**
These changes are in-depth and certainly further complicate structures, but the performance overhead is minimal and won't require people to rebuild adjacent multiblocks.