### PR TITLE
Add thread safety to world gen, spawn eggs, parrot sounds.

### DIFF
--- a/src/additions/java/mekanism/additions/common/MekanismAdditions.java
+++ b/src/additions/java/mekanism/additions/common/MekanismAdditions.java
@@ -31,6 +31,7 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundEvents;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.fml.DeferredWorkQueue;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.config.ModConfig;
@@ -104,16 +105,20 @@ public class MekanismAdditions implements IModule {
     }
 
     private void commonSetup(FMLCommonSetupEvent event) {
-        SpawnHelper.addSpawns();
-        registerSpawnEggDelayed(AdditionsItems.BABY_CREEPER_SPAWN_EGG, AdditionsItems.BABY_ENDERMAN_SPAWN_EGG, AdditionsItems.BABY_SKELETON_SPAWN_EGG,
-              AdditionsItems.BABY_STRAY_SPAWN_EGG, AdditionsItems.BABY_WITHER_SKELETON_SPAWN_EGG);
-        //Add parrot sound imitations for baby mobs
-        //Note: There is no imitation sound for endermen
-        ParrotEntity.IMITATION_SOUND_EVENTS.put(AdditionsEntityTypes.BABY_CREEPER.getEntityType(), SoundEvents.ENTITY_PARROT_IMITATE_CREEPER);
-        ParrotEntity.IMITATION_SOUND_EVENTS.put(AdditionsEntityTypes.BABY_SKELETON.getEntityType(), SoundEvents.ENTITY_PARROT_IMITATE_SKELETON);
-        ParrotEntity.IMITATION_SOUND_EVENTS.put(AdditionsEntityTypes.BABY_STRAY.getEntityType(), SoundEvents.ENTITY_PARROT_IMITATE_STRAY);
-        ParrotEntity.IMITATION_SOUND_EVENTS.put(AdditionsEntityTypes.BABY_WITHER_SKELETON.getEntityType(), SoundEvents.ENTITY_PARROT_IMITATE_WITHER_SKELETON);
-        Mekanism.logger.info("Loaded 'Mekanism: Additions' module.");
+        //Note: This deprecation can be safely ignored - Forge hasn't added the proposed replacement for it yet.
+        //noinspection deprecation
+        DeferredWorkQueue.runLater(() -> {
+            SpawnHelper.addSpawns();
+            registerSpawnEggDelayed(AdditionsItems.BABY_CREEPER_SPAWN_EGG, AdditionsItems.BABY_ENDERMAN_SPAWN_EGG, AdditionsItems.BABY_SKELETON_SPAWN_EGG,
+                  AdditionsItems.BABY_STRAY_SPAWN_EGG, AdditionsItems.BABY_WITHER_SKELETON_SPAWN_EGG);
+            //Add parrot sound imitations for baby mobs
+            //Note: There is no imitation sound for endermen
+            ParrotEntity.IMITATION_SOUND_EVENTS.put(AdditionsEntityTypes.BABY_CREEPER.getEntityType(), SoundEvents.ENTITY_PARROT_IMITATE_CREEPER);
+            ParrotEntity.IMITATION_SOUND_EVENTS.put(AdditionsEntityTypes.BABY_SKELETON.getEntityType(), SoundEvents.ENTITY_PARROT_IMITATE_SKELETON);
+            ParrotEntity.IMITATION_SOUND_EVENTS.put(AdditionsEntityTypes.BABY_STRAY.getEntityType(), SoundEvents.ENTITY_PARROT_IMITATE_STRAY);
+            ParrotEntity.IMITATION_SOUND_EVENTS.put(AdditionsEntityTypes.BABY_WITHER_SKELETON.getEntityType(), SoundEvents.ENTITY_PARROT_IMITATE_WITHER_SKELETON);
+            Mekanism.logger.info("Loaded 'Mekanism: Additions' module.");
+        });
     }
 
     @SafeVarargs

--- a/src/main/java/mekanism/common/Mekanism.java
+++ b/src/main/java/mekanism/common/Mekanism.java
@@ -67,6 +67,7 @@ import net.minecraftforge.event.world.ChunkDataEvent;
 import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.fml.DeferredWorkQueue;
 import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
@@ -291,7 +292,8 @@ public class Mekanism {
         FuelHandler.addGas(MekanismGases.HYDROGEN, 1, MekanismConfig.general.FROM_H2.get());
 
         //Register the mod's world generators
-        GenHandler.setupWorldGeneration();
+        //noinspection deprecation
+        DeferredWorkQueue.runLater(GenHandler::setupWorldGeneration);
 
         //Register player tracker
         MinecraftForge.EVENT_BUS.register(new CommonPlayerTracker());

--- a/src/main/java/mekanism/common/world/GenHandler.java
+++ b/src/main/java/mekanism/common/world/GenHandler.java
@@ -25,7 +25,6 @@ import net.minecraft.world.gen.placement.CountRangeConfig;
 import net.minecraft.world.gen.placement.FrequencyConfig;
 import net.minecraft.world.gen.placement.Placement;
 import net.minecraft.world.server.ServerWorld;
-import net.minecraftforge.fml.DeferredWorkQueue;
 import net.minecraftforge.registries.ForgeRegistries;
 
 public class GenHandler {

--- a/src/main/java/mekanism/common/world/GenHandler.java
+++ b/src/main/java/mekanism/common/world/GenHandler.java
@@ -25,6 +25,7 @@ import net.minecraft.world.gen.placement.CountRangeConfig;
 import net.minecraft.world.gen.placement.FrequencyConfig;
 import net.minecraft.world.gen.placement.Placement;
 import net.minecraft.world.server.ServerWorld;
+import net.minecraftforge.fml.DeferredWorkQueue;
 import net.minecraftforge.registries.ForgeRegistries;
 
 public class GenHandler {
@@ -39,26 +40,29 @@ public class GenHandler {
     private static ConfiguredFeature<?, ?> SALT_RETROGEN_FEATURE;
 
     public static void setupWorldGeneration() {
-        COPPER_FEATURE = getOreFeature(MekanismBlocks.COPPER_ORE, MekanismConfig.world.copper, Feature.ORE);
-        TIN_FEATURE = getOreFeature(MekanismBlocks.TIN_ORE, MekanismConfig.world.tin, Feature.ORE);
-        OSMIUM_FEATURE = getOreFeature(MekanismBlocks.OSMIUM_ORE, MekanismConfig.world.osmium, Feature.ORE);
-        SALT_FEATURE = getSaltFeature(MekanismBlocks.SALT_BLOCK, MekanismConfig.world.salt, Placement.COUNT_TOP_SOLID);
-        //Retrogen features
-        if (MekanismConfig.world.enableRegeneration.get()) {
-            COPPER_RETROGEN_FEATURE = getOreFeature(MekanismBlocks.COPPER_ORE, MekanismConfig.world.copper, MekanismFeatures.ORE_RETROGEN.getFeature());
-            TIN_RETROGEN_FEATURE = getOreFeature(MekanismBlocks.TIN_ORE, MekanismConfig.world.tin, MekanismFeatures.ORE_RETROGEN.getFeature());
-            OSMIUM_RETROGEN_FEATURE = getOreFeature(MekanismBlocks.OSMIUM_ORE, MekanismConfig.world.osmium, MekanismFeatures.ORE_RETROGEN.getFeature());
-            SALT_RETROGEN_FEATURE = getSaltFeature(MekanismBlocks.SALT_BLOCK, MekanismConfig.world.salt, MekanismPlacements.TOP_SOLID_RETROGEN.getPlacement());
-        }
-        ForgeRegistries.BIOMES.forEach(biome -> {
-            if (isValidBiome(biome)) {
-                //Add ores
-                addFeature(biome, COPPER_FEATURE);
-                addFeature(biome, TIN_FEATURE);
-                addFeature(biome, OSMIUM_FEATURE);
-                //Add salt
-                addFeature(biome, SALT_FEATURE);
+        //noinspection deprecation
+        DeferredWorkQueue.runLater(() -> {
+            COPPER_FEATURE = getOreFeature(MekanismBlocks.COPPER_ORE, MekanismConfig.world.copper, Feature.ORE);
+            TIN_FEATURE = getOreFeature(MekanismBlocks.TIN_ORE, MekanismConfig.world.tin, Feature.ORE);
+            OSMIUM_FEATURE = getOreFeature(MekanismBlocks.OSMIUM_ORE, MekanismConfig.world.osmium, Feature.ORE);
+            SALT_FEATURE = getSaltFeature(MekanismBlocks.SALT_BLOCK, MekanismConfig.world.salt, Placement.COUNT_TOP_SOLID);
+            //Retrogen features
+            if (MekanismConfig.world.enableRegeneration.get()) {
+                COPPER_RETROGEN_FEATURE = getOreFeature(MekanismBlocks.COPPER_ORE, MekanismConfig.world.copper, MekanismFeatures.ORE_RETROGEN.getFeature());
+                TIN_RETROGEN_FEATURE = getOreFeature(MekanismBlocks.TIN_ORE, MekanismConfig.world.tin, MekanismFeatures.ORE_RETROGEN.getFeature());
+                OSMIUM_RETROGEN_FEATURE = getOreFeature(MekanismBlocks.OSMIUM_ORE, MekanismConfig.world.osmium, MekanismFeatures.ORE_RETROGEN.getFeature());
+                SALT_RETROGEN_FEATURE = getSaltFeature(MekanismBlocks.SALT_BLOCK, MekanismConfig.world.salt, MekanismPlacements.TOP_SOLID_RETROGEN.getPlacement());
             }
+            ForgeRegistries.BIOMES.forEach(biome -> {
+                if (isValidBiome(biome)) {
+                    //Add ores
+                    addFeature(biome, COPPER_FEATURE);
+                    addFeature(biome, TIN_FEATURE);
+                    addFeature(biome, OSMIUM_FEATURE);
+                    //Add salt
+                    addFeature(biome, SALT_FEATURE);
+                }
+            });
         });
     }
 

--- a/src/main/java/mekanism/common/world/GenHandler.java
+++ b/src/main/java/mekanism/common/world/GenHandler.java
@@ -40,29 +40,26 @@ public class GenHandler {
     private static ConfiguredFeature<?, ?> SALT_RETROGEN_FEATURE;
 
     public static void setupWorldGeneration() {
-        //noinspection deprecation
-        DeferredWorkQueue.runLater(() -> {
-            COPPER_FEATURE = getOreFeature(MekanismBlocks.COPPER_ORE, MekanismConfig.world.copper, Feature.ORE);
-            TIN_FEATURE = getOreFeature(MekanismBlocks.TIN_ORE, MekanismConfig.world.tin, Feature.ORE);
-            OSMIUM_FEATURE = getOreFeature(MekanismBlocks.OSMIUM_ORE, MekanismConfig.world.osmium, Feature.ORE);
-            SALT_FEATURE = getSaltFeature(MekanismBlocks.SALT_BLOCK, MekanismConfig.world.salt, Placement.COUNT_TOP_SOLID);
-            //Retrogen features
-            if (MekanismConfig.world.enableRegeneration.get()) {
-                COPPER_RETROGEN_FEATURE = getOreFeature(MekanismBlocks.COPPER_ORE, MekanismConfig.world.copper, MekanismFeatures.ORE_RETROGEN.getFeature());
-                TIN_RETROGEN_FEATURE = getOreFeature(MekanismBlocks.TIN_ORE, MekanismConfig.world.tin, MekanismFeatures.ORE_RETROGEN.getFeature());
-                OSMIUM_RETROGEN_FEATURE = getOreFeature(MekanismBlocks.OSMIUM_ORE, MekanismConfig.world.osmium, MekanismFeatures.ORE_RETROGEN.getFeature());
-                SALT_RETROGEN_FEATURE = getSaltFeature(MekanismBlocks.SALT_BLOCK, MekanismConfig.world.salt, MekanismPlacements.TOP_SOLID_RETROGEN.getPlacement());
+        COPPER_FEATURE = getOreFeature(MekanismBlocks.COPPER_ORE, MekanismConfig.world.copper, Feature.ORE);
+        TIN_FEATURE = getOreFeature(MekanismBlocks.TIN_ORE, MekanismConfig.world.tin, Feature.ORE);
+        OSMIUM_FEATURE = getOreFeature(MekanismBlocks.OSMIUM_ORE, MekanismConfig.world.osmium, Feature.ORE);
+        SALT_FEATURE = getSaltFeature(MekanismBlocks.SALT_BLOCK, MekanismConfig.world.salt, Placement.COUNT_TOP_SOLID);
+        //Retrogen features
+        if (MekanismConfig.world.enableRegeneration.get()) {
+            COPPER_RETROGEN_FEATURE = getOreFeature(MekanismBlocks.COPPER_ORE, MekanismConfig.world.copper, MekanismFeatures.ORE_RETROGEN.getFeature());
+            TIN_RETROGEN_FEATURE = getOreFeature(MekanismBlocks.TIN_ORE, MekanismConfig.world.tin, MekanismFeatures.ORE_RETROGEN.getFeature());
+            OSMIUM_RETROGEN_FEATURE = getOreFeature(MekanismBlocks.OSMIUM_ORE, MekanismConfig.world.osmium, MekanismFeatures.ORE_RETROGEN.getFeature());
+            SALT_RETROGEN_FEATURE = getSaltFeature(MekanismBlocks.SALT_BLOCK, MekanismConfig.world.salt, MekanismPlacements.TOP_SOLID_RETROGEN.getPlacement());
+        }
+        ForgeRegistries.BIOMES.forEach(biome -> {
+            if (isValidBiome(biome)) {
+                //Add ores
+                addFeature(biome, COPPER_FEATURE);
+                addFeature(biome, TIN_FEATURE);
+                addFeature(biome, OSMIUM_FEATURE);
+                //Add salt
+                addFeature(biome, SALT_FEATURE);
             }
-            ForgeRegistries.BIOMES.forEach(biome -> {
-                if (isValidBiome(biome)) {
-                    //Add ores
-                    addFeature(biome, COPPER_FEATURE);
-                    addFeature(biome, TIN_FEATURE);
-                    addFeature(biome, OSMIUM_FEATURE);
-                    //Add salt
-                    addFeature(biome, SALT_FEATURE);
-                }
-            });
         });
     }
 


### PR DESCRIPTION
## Changes proposed in this pull request:
Wrap world generator feature additions, baby mob spawn egg dispenser behaviour, and parrot imitation sounds inside a deferred work queue to force them to run on the main thread.

Don't worry about Forge's deprecated annotation on DeferredWorkQueue. They added it before writing a replacement for some weird reason, it's still the correct way to handle this at this moment.