### PR TITLE
Make Flamethrower flames be always faster then the player causing them

### DIFF
--- a/src/main/java/mekanism/client/render/RenderTickHandler.java
+++ b/src/main/java/mekanism/client/render/RenderTickHandler.java
@@ -213,7 +213,7 @@ public class RenderTickHandler {
                 for (UUID uuid : Mekanism.playerState.getActiveJetpacks()) {
                     PlayerEntity p = world.getPlayerByUuid(uuid);
                     if (p != null) {
-                        Pos3D playerPos = new Pos3D(p).translate(0, 1.7, 0);
+                        Pos3D playerPos = new Pos3D(p).translate(0, p.getEyeHeight(), 0);
                         Vector3d playerMotion = p.getMotion();
                         float random = (world.rand.nextFloat() - 0.5F) * 0.1F;
                         Pos3D vLeft = new Pos3D(-0.43, -0.55, -0.54).rotatePitch(p.isCrouching() ? 20 : 0).rotateYaw(p.renderYawOffset);
@@ -232,7 +232,7 @@ public class RenderTickHandler {
                         if (p != null && p.isInWater()) {
                             Pos3D vec = new Pos3D(0.4, 0.4, 0.4).multiply(p.getLook(1)).translate(0, -0.2, 0);
                             Pos3D motion = vec.scale(0.2).translate(p.getMotion());
-                            Pos3D v = new Pos3D(p).translate(0, 1.7, 0).translate(vec);
+                            Pos3D v = new Pos3D(p).translate(0, p.getEyeHeight(), 0).translate(vec);
                             world.addParticle((BasicParticleType) MekanismParticleTypes.SCUBA_BUBBLE.getParticleType(), v.x, v.y, v.z, motion.x, motion.y + 0.2, motion.z);
                         }
                     }
@@ -243,13 +243,13 @@ public class RenderTickHandler {
                             if (!currentItem.isEmpty() && currentItem.getItem() instanceof ItemFlamethrower && ChemicalUtil.hasGas(currentItem)) {
                                 Pos3D flameVec;
                                 if (player == p && minecraft.gameSettings.thirdPersonView == 0) {
-                                    flameVec = new Pos3D(1, 1, 1).multiply(p.getLook(1)).rotateYaw(5).translate(0, 1.6, 0);
+                                    flameVec = new Pos3D(1, 1, 1).multiply(p.getLook(1)).rotateYaw(5).translate(0, p.getEyeHeight() - 0.1, 0);
                                 } else {
                                     double flameXCoord = -0.2;
                                     double flameYCoord = 1;
                                     double flameZCoord = 1.2;
                                     if (p.isCrouching()) {
-                                        flameYCoord -= 0.55;
+                                        flameYCoord -= 0.65;
                                         flameZCoord -= 0.15;
                                     }
                                     flameVec = new Pos3D(flameXCoord, flameYCoord, flameZCoord).rotateYaw(p.renderYawOffset);

--- a/src/main/java/mekanism/common/entity/EntityFlame.java
+++ b/src/main/java/mekanism/common/entity/EntityFlame.java
@@ -235,12 +235,12 @@ public class EntityFlame extends DamagingProjectileEntity implements IEntityAddi
     }
 
     @Override
-	public void readAdditional(@Nonnull CompoundNBT nbtTags) {
+    public void readAdditional(@Nonnull CompoundNBT nbtTags) {
         NBTUtils.setEnumIfPresent(nbtTags, NBTConstants.MODE, FlamethrowerMode::byIndexStatic, mode -> this.mode = mode);
     }
 
     @Override
-	public void writeAdditional(@Nonnull CompoundNBT nbtTags) {
+    public void writeAdditional(@Nonnull CompoundNBT nbtTags) {
         nbtTags.putInt(NBTConstants.MODE, mode.ordinal());
     }
 

--- a/src/main/java/mekanism/common/entity/EntityFlame.java
+++ b/src/main/java/mekanism/common/entity/EntityFlame.java
@@ -73,12 +73,9 @@ public class EntityFlame extends DamagingProjectileEntity implements IEntityAddi
         Pos3D mergedVec = playerPos.translate(flameVec);
         setPosition(mergedVec.x, mergedVec.y, mergedVec.z);
 
-        Pos3D motion = new Pos3D(0.4, 0.4, 0.4).multiply(lookVec);
-        setMotion(motion);
-
         owner = player;
         mode = ((ItemFlamethrower) player.inventory.getCurrentItem().getItem()).getMode(player.inventory.getCurrentItem());
-        func_234612_a_(player, player.rotationPitch, player.rotationYaw, 0.0F, 0.8F, 1.0F);
+        func_234612_a_(player, player.rotationPitch, player.rotationYaw, 0.0F, 0.5F, 1.0F);
     }
 
     @Override

--- a/src/main/java/mekanism/common/entity/EntityFlame.java
+++ b/src/main/java/mekanism/common/entity/EntityFlame.java
@@ -19,7 +19,7 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.item.ItemEntity;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.entity.projectile.DamagingProjectileEntity;
+import net.minecraft.entity.projectile.ProjectileEntity;
 import net.minecraft.entity.projectile.ProjectileHelper;
 import net.minecraft.inventory.Inventory;
 import net.minecraft.item.BlockItem;
@@ -48,9 +48,7 @@ import net.minecraftforge.common.util.Constants.WorldEvents;
 import net.minecraftforge.fml.common.registry.IEntityAdditionalSpawnData;
 import net.minecraftforge.fml.network.NetworkHooks;
 
-// ProjectileEntity would fit better then DamagingProjectileEntity, but seeing as there seem to be problems with ATs in 1.16
-// and its constructor isn't accessible that can't be used.
-public class EntityFlame extends DamagingProjectileEntity implements IEntityAdditionalSpawnData {
+public class EntityFlame extends ProjectileEntity implements IEntityAdditionalSpawnData {
 
     public static final int LIFESPAN = 80;
     public static final int DAMAGE = 10;
@@ -258,29 +256,5 @@ public class EntityFlame extends DamagingProjectileEntity implements IEntityAddi
     @Override
     public void readSpawnData(PacketBuffer dataStream) {
         mode = dataStream.readEnumValue(FlamethrowerMode.class);
-    }
-
-    /**
-     * Called when the entity is attacked.
-     * 
-     * Copied from Entity, wouldn't be needed with ProjectileEntity.
-     */
-    @Override
-    public boolean attackEntityFrom(DamageSource source, float amount) {
-        if (this.isInvulnerableTo(source)) {
-            return false;
-        } else {
-            this.markVelocityChanged();
-            return false;
-        }
-    }
-
-    /**
-     * Returns true if other Entities should be prevented from moving through this Entity.
-     * 
-     * Copied from Entity, wouldn't be needed with ProjectileEntity.
-     */
-    public boolean canBeCollidedWith() {
-        return false;
     }
 }

--- a/src/main/java/mekanism/common/entity/EntityFlame.java
+++ b/src/main/java/mekanism/common/entity/EntityFlame.java
@@ -51,9 +51,9 @@ import net.minecraftforge.fml.network.NetworkHooks;
 public class EntityFlame extends ProjectileEntity implements IEntityAdditionalSpawnData {
 
     public static final int LIFESPAN = 80;
-    public static final int DAMAGE = 10;
+    private static final int DAMAGE = 10;
 
-    public FlamethrowerMode mode = FlamethrowerMode.COMBAT;
+    private FlamethrowerMode mode = FlamethrowerMode.COMBAT;
 
     public EntityFlame(EntityType<EntityFlame> type, World world) {
         super(type, world);
@@ -61,7 +61,7 @@ public class EntityFlame extends ProjectileEntity implements IEntityAdditionalSp
 
     public EntityFlame(PlayerEntity player) {
         this(MekanismEntityTypes.FLAME.getEntityType(), player.world);
-        Pos3D playerPos = new Pos3D(player).translate(0, 1.6, 0);
+        Pos3D playerPos = new Pos3D(player.getPosX(), player.getPosYEye() - 0.1, player.getPosZ());
         Pos3D flameVec = new Pos3D(1, 1, 1);
 
         Vector3d lookVec = player.getLookVec();
@@ -137,10 +137,9 @@ public class EntityFlame extends ProjectileEntity implements IEntityAdditionalSp
     }
 
     @Override
-    protected void func_230299_a_(BlockRayTraceResult blockRayTrace) {
+    protected void func_230299_a_(@Nonnull BlockRayTraceResult blockRayTrace) {
+        super.func_230299_a_(blockRayTrace);
         BlockPos hitPos = blockRayTrace.getPos();
-        BlockState hitState = world.getBlockState(hitPos);
-        hitState.onProjectileCollision(world, hitState, blockRayTrace, this);
         Direction hitSide = blockRayTrace.getFace();
         boolean hitFluid = !world.getFluidState(hitPos).isEmpty();
         if (!world.isRemote && MekanismConfig.general.aestheticWorldDamage.get() && !hitFluid) {
@@ -150,6 +149,7 @@ public class EntityFlame extends ProjectileEntity implements IEntityAdditionalSp
                 Entity owner = func_234616_v_();
                 PlayerEntity shooter = owner instanceof PlayerEntity ? (PlayerEntity) owner : null;
                 BlockPos sidePos = hitPos.offset(hitSide);
+                BlockState hitState = world.getBlockState(hitPos);
                 if (AbstractFireBlock.func_241465_a_(world, sidePos)) {
                     world.setBlockState(sidePos, AbstractFireBlock.func_235326_a_(world, sidePos));
                 } else if (CampfireBlock.func_241470_h_(hitState)) {

--- a/src/main/java/mekanism/common/entity/EntityFlame.java
+++ b/src/main/java/mekanism/common/entity/EntityFlame.java
@@ -74,7 +74,8 @@ public class EntityFlame extends Entity implements IEntityAdditionalSpawnData {
 
         prevRotationPitch = rotationPitch = player.rotationPitch;
         prevRotationYaw = rotationYaw = player.rotationYaw;
-        setMotion(motion.add(player.getMotion().x * 1.5, player.func_233570_aj_() ? 0 : player.getMotion().y * 0.75, player.getMotion().z * 1.5));
+        Vector3d playerMotion = player.getMotion();
+        setMotion(motion.add(playerMotion.x * 2, player.func_233570_aj_() ? 0 : playerMotion.y, playerMotion.z * 2));
 
         owner = player;
         mode = ((ItemFlamethrower) player.inventory.getCurrentItem().getItem()).getMode(player.inventory.getCurrentItem());

--- a/src/main/java/mekanism/common/entity/EntityFlame.java
+++ b/src/main/java/mekanism/common/entity/EntityFlame.java
@@ -74,7 +74,7 @@ public class EntityFlame extends Entity implements IEntityAdditionalSpawnData {
 
         prevRotationPitch = rotationPitch = player.rotationPitch;
         prevRotationYaw = rotationYaw = player.rotationYaw;
-        setMotion(motion.add(player.getMotion().x * 1.5, player.onGround ? 0 : player.getMotion().y * 0.75, player.getMotion().z * 1.5));
+        setMotion(motion.add(player.getMotion().x * 1.5, player.func_233570_aj_() ? 0 : player.getMotion().y * 0.75, player.getMotion().z * 1.5));
 
         owner = player;
         mode = ((ItemFlamethrower) player.inventory.getCurrentItem().getItem()).getMode(player.inventory.getCurrentItem());
@@ -145,7 +145,6 @@ public class EntityFlame extends Entity implements IEntityAdditionalSpawnData {
                 } else if (mode == FlamethrowerMode.INFERNO) {
                     BlockState hitState = world.getBlockState(hitPos);
                     BlockPos sidePos = hitPos.offset(hitSide);
-                    BlockState sideState = world.getBlockState(sidePos);
                     PlayerEntity shooter = owner instanceof PlayerEntity ? (PlayerEntity) owner : null;
                     if (AbstractFireBlock.func_241465_a_(world, sidePos)) {
                         world.setBlockState(sidePos, AbstractFireBlock.func_235326_a_(world, sidePos));

--- a/src/main/java/mekanism/common/entity/EntityFlame.java
+++ b/src/main/java/mekanism/common/entity/EntityFlame.java
@@ -53,8 +53,7 @@ public class EntityFlame extends ProjectileEntity implements IEntityAdditionalSp
     public static final int LIFESPAN = 80;
     public static final int DAMAGE = 10;
 
-    public Entity owner = null;
-    public ItemFlamethrower.FlamethrowerMode mode = ItemFlamethrower.FlamethrowerMode.COMBAT;
+    public FlamethrowerMode mode = FlamethrowerMode.COMBAT;
 
     public EntityFlame(EntityType<EntityFlame> type, World world) {
         super(type, world);
@@ -70,14 +69,13 @@ public class EntityFlame extends ProjectileEntity implements IEntityAdditionalSp
 
         Pos3D mergedVec = playerPos.translate(flameVec);
         setPosition(mergedVec.x, mergedVec.y, mergedVec.z);
-
-        owner = player;
+        setShooter(player);
         mode = ((ItemFlamethrower) player.inventory.getCurrentItem().getItem()).getMode(player.inventory.getCurrentItem());
-        func_234612_a_(player, player.rotationPitch, player.rotationYaw, 0.0F, 0.5F, 1.0F);
+        func_234612_a_(player, player.rotationPitch, player.rotationYaw, 0, 0.5F, 1);
     }
 
     @Override
-    public void tick() {
+    public void baseTick() {
         if (!isAlive()) {
             return;
         }
@@ -113,53 +111,62 @@ public class EntityFlame extends ProjectileEntity implements IEntityAdditionalSp
         }
         EntityRayTraceResult entityResult = ProjectileHelper.rayTraceEntities(world, this, localVec, motionVec,
               getBoundingBox().expand(getMotion()).grow(1.0D, 1.0D, 1.0D), EntityPredicates.NOT_SPECTATING);
-        if (entityResult != null) {
-            Entity entity = entityResult.getEntity();
-            if (entity instanceof PlayerEntity) {
-                PlayerEntity player = (PlayerEntity) entity.getEntity();
-                if (player.abilities.disableDamage || owner instanceof PlayerEntity && !((PlayerEntity) owner).canAttackPlayer(player)) {
-                    return;
-                }
+        onImpact(entityResult == null ? blockRayTrace : entityResult);
+    }
+
+    @Override
+    protected void onEntityHit(EntityRayTraceResult entityResult) {
+        Entity entity = entityResult.getEntity();
+        if (entity instanceof PlayerEntity) {
+            PlayerEntity player = (PlayerEntity) entity.getEntity();
+            Entity owner = func_234616_v_();
+            if (player.abilities.disableDamage || owner instanceof PlayerEntity && !((PlayerEntity) owner).canAttackPlayer(player)) {
+                return;
             }
-            if (!entity.getEntity().func_230279_az_()) {
-                if (entity.getEntity() instanceof ItemEntity && mode == FlamethrowerMode.HEAT) {
-                    if (entity.getEntity().ticksExisted > 100 && !smeltItem((ItemEntity) entity.getEntity())) {
-                        burn(entity.getEntity());
-                    }
-                } else {
+        }
+        if (!entity.getEntity().func_230279_az_()) {
+            if (entity.getEntity() instanceof ItemEntity && mode == FlamethrowerMode.HEAT) {
+                if (entity.getEntity().ticksExisted > 100 && !smeltItem((ItemEntity) entity.getEntity())) {
                     burn(entity.getEntity());
                 }
+            } else {
+                burn(entity.getEntity());
             }
-            remove();
-        } else if (blockRayTrace.getType() != Type.MISS) {
-            BlockPos hitPos = blockRayTrace.getPos();
-            Direction hitSide = blockRayTrace.getFace();
-            boolean hitFluid = !world.getFluidState(hitPos).isEmpty();
-            if (!world.isRemote && MekanismConfig.general.aestheticWorldDamage.get() && !hitFluid) {
-                if (mode == FlamethrowerMode.HEAT) {
-                    smeltBlock(hitPos);
-                } else if (mode == FlamethrowerMode.INFERNO) {
-                    BlockState hitState = world.getBlockState(hitPos);
-                    BlockPos sidePos = hitPos.offset(hitSide);
-                    PlayerEntity shooter = owner instanceof PlayerEntity ? (PlayerEntity) owner : null;
-                    if (AbstractFireBlock.func_241465_a_(world, sidePos)) {
-                        world.setBlockState(sidePos, AbstractFireBlock.func_235326_a_(world, sidePos));
-                    } else if (CampfireBlock.func_241470_h_(hitState)) {
-                        world.setBlockState(hitPos, hitState.with(BlockStateProperties.LIT, true));
-                    } else if (hitState.isFlammable(world, hitPos, hitSide)) {
-                        hitState.catchFire(world, hitPos, hitSide, shooter);
-                        if (hitState.getBlock() instanceof TNTBlock) {
-                            world.removeBlock(hitPos, false);
-                        }
+        }
+        remove();
+    }
+
+    @Override
+    protected void func_230299_a_(BlockRayTraceResult blockRayTrace) {
+        BlockPos hitPos = blockRayTrace.getPos();
+        BlockState hitState = world.getBlockState(hitPos);
+        hitState.onProjectileCollision(world, hitState, blockRayTrace, this);
+        Direction hitSide = blockRayTrace.getFace();
+        boolean hitFluid = !world.getFluidState(hitPos).isEmpty();
+        if (!world.isRemote && MekanismConfig.general.aestheticWorldDamage.get() && !hitFluid) {
+            if (mode == FlamethrowerMode.HEAT) {
+                smeltBlock(hitPos);
+            } else if (mode == FlamethrowerMode.INFERNO) {
+                Entity owner = func_234616_v_();
+                PlayerEntity shooter = owner instanceof PlayerEntity ? (PlayerEntity) owner : null;
+                BlockPos sidePos = hitPos.offset(hitSide);
+                if (AbstractFireBlock.func_241465_a_(world, sidePos)) {
+                    world.setBlockState(sidePos, AbstractFireBlock.func_235326_a_(world, sidePos));
+                } else if (CampfireBlock.func_241470_h_(hitState)) {
+                    world.setBlockState(hitPos, hitState.with(BlockStateProperties.LIT, true));
+                } else if (hitState.isFlammable(world, hitPos, hitSide)) {
+                    hitState.catchFire(world, hitPos, hitSide, shooter);
+                    if (hitState.getBlock() instanceof TNTBlock) {
+                        world.removeBlock(hitPos, false);
                     }
                 }
             }
-            if (hitFluid) {
-                spawnParticlesAt(func_233580_cy_());
-                playSound(SoundEvents.BLOCK_FIRE_EXTINGUISH, 1.0F, 1.0F);
-            }
-            remove();
         }
+        if (hitFluid) {
+            spawnParticlesAt(func_233580_cy_());
+            playSound(SoundEvents.BLOCK_FIRE_EXTINGUISH, 1.0F, 1.0F);
+        }
+        remove();
     }
 
     private boolean smeltItem(ItemEntity item) {
@@ -211,14 +218,7 @@ public class EntityFlame extends ProjectileEntity implements IEntityAdditionalSp
 
     private void burn(Entity entity) {
         entity.setFire(20);
-        entity.attackEntityFrom(getFlamethrowerDamage(), DAMAGE);
-    }
-
-    private DamageSource getFlamethrowerDamage() {
-        if (owner == null) {
-            return DamageSource.causeThrownDamage(this, this);
-        }
-        return DamageSource.causeThrownDamage(this, owner);
+        entity.attackEntityFrom(DamageSource.causeThrownDamage(this, func_234616_v_()), DAMAGE);
     }
 
     private void spawnParticlesAt(BlockPos pos) {
@@ -234,11 +234,13 @@ public class EntityFlame extends ProjectileEntity implements IEntityAdditionalSp
 
     @Override
     public void readAdditional(@Nonnull CompoundNBT nbtTags) {
+        super.readAdditional(nbtTags);
         NBTUtils.setEnumIfPresent(nbtTags, NBTConstants.MODE, FlamethrowerMode::byIndexStatic, mode -> this.mode = mode);
     }
 
     @Override
     public void writeAdditional(@Nonnull CompoundNBT nbtTags) {
+        super.writeAdditional(nbtTags);
         nbtTags.putInt(NBTConstants.MODE, mode.ordinal());
     }
 

--- a/src/main/java/mekanism/common/entity/EntityFlame.java
+++ b/src/main/java/mekanism/common/entity/EntityFlame.java
@@ -37,7 +37,6 @@ import net.minecraft.util.SoundEvents;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.BlockRayTraceResult;
 import net.minecraft.util.math.EntityRayTraceResult;
-import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.RayTraceContext;
 import net.minecraft.util.math.RayTraceContext.BlockMode;
 import net.minecraft.util.math.RayTraceContext.FluidMode;
@@ -73,17 +72,12 @@ public class EntityFlame extends Entity implements IEntityAdditionalSpawnData {
 
         Pos3D motion = new Pos3D(0.4, 0.4, 0.4).multiply(lookVec);
 
-        setHeading(motion);
-        setMotion(motion);
+        prevRotationPitch = rotationPitch = player.rotationPitch;
+        prevRotationYaw = rotationYaw = player.rotationYaw;
+        setMotion(motion.add(player.getMotion().x * 1.5, player.onGround ? 0 : player.getMotion().y * 0.75, player.getMotion().z * 1.5));
 
         owner = player;
         mode = ((ItemFlamethrower) player.inventory.getCurrentItem().getItem()).getMode(player.inventory.getCurrentItem());
-    }
-
-    public void setHeading(Pos3D motion) {
-        float d = MathHelper.sqrt((motion.x * motion.x) + (motion.z * motion.z));
-        prevRotationYaw = rotationYaw = (float) Math.toDegrees(Math.atan2(motion.x, motion.z));
-        prevRotationPitch = rotationPitch = (float) Math.toDegrees(Math.atan2(motion.y, d));
     }
 
     @Override

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -1,6 +1,8 @@
 protected net.minecraft.client.particle.BubbleParticle <init>(Lnet/minecraft/client/world/ClientWorld;DDDDDD)V #BubbleParticle constructor
 protected net.minecraft.client.particle.FlameParticle <init>(Lnet/minecraft/client/world/ClientWorld;DDDDDD)V #FlameParticle constructor
 
+protected net.minecraft.entity.projectile.ProjectileEntity <init>(Lnet/minecraft/entity/EntityType;Lnet/minecraft/world/World;)V #ProjectileEntity constructor
+
 public net.minecraft.client.renderer.chunk.ChunkRenderCache field_212408_i # world
 
 public net.minecraft.client.renderer.entity.LivingRenderer field_177097_h # layerRenderers

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -1,8 +1,6 @@
 protected net.minecraft.client.particle.BubbleParticle <init>(Lnet/minecraft/client/world/ClientWorld;DDDDDD)V #BubbleParticle constructor
 protected net.minecraft.client.particle.FlameParticle <init>(Lnet/minecraft/client/world/ClientWorld;DDDDDD)V #FlameParticle constructor
 
-protected net.minecraft.entity.projectile.ProjectileEntity <init>(Lnet/minecraft/entity/EntityType;Lnet/minecraft/world/World;)V #ProjectileEntity constructor
-
 public net.minecraft.client.renderer.chunk.ChunkRenderCache field_212408_i # world
 
 public net.minecraft.client.renderer.entity.LivingRenderer field_177097_h # layerRenderers
@@ -23,6 +21,8 @@ public net.minecraft.client.renderer.model.ModelRenderer$PositionTextureVertex
 public net.minecraft.client.renderer.model.ModelRenderer$TexturedQuad
 
 public net.minecraft.entity.LivingEntity field_70752_e # potionsNeedUpdate
+
+protected net.minecraft.entity.projectile.ProjectileEntity <init>(Lnet/minecraft/entity/EntityType;Lnet/minecraft/world/World;)V #ProjectileEntity constructor
 
 protected net.minecraft.inventory.container.Container field_75149_d # listeners
 


### PR DESCRIPTION
## Changes proposed in this pull request:
 - Add player motion to the flame motion.

This PR currently fails to make the flames faster then then player, if the player is very fast, this is caused by how the vanilla method for shooting projectiles works.