### PR TITLE
Make Electrolytic Breathing Unit fill any main hand item that can hold hydrogen

### DIFF
--- a/src/main/java/mekanism/common/content/gear/mekasuit/ModuleMekaSuit.java
+++ b/src/main/java/mekanism/common/content/gear/mekasuit/ModuleMekaSuit.java
@@ -18,11 +18,13 @@ import mekanism.common.config.MekanismConfig;
 import mekanism.common.content.gear.Module;
 import mekanism.common.content.gear.ModuleConfigItem;
 import mekanism.common.content.gear.ModuleConfigItem.EnumData;
+import mekanism.common.content.gear.Modules;
 import mekanism.common.content.gear.mekasuit.ModuleLocomotiveBoostingUnit.SprintBoost;
 import mekanism.common.item.gear.ItemMekaSuitArmor;
 import mekanism.common.lib.radiation.RadiationManager.RadiationScale;
 import mekanism.common.lib.radiation.capability.IRadiationEntity;
 import mekanism.common.registries.MekanismGases;
+import mekanism.common.registries.MekanismItems;
 import mekanism.common.util.CapabilityUtils;
 import mekanism.common.util.MekanismUtils;
 import mekanism.common.util.StorageUtils;
@@ -51,7 +53,7 @@ public abstract class ModuleMekaSuit extends Module {
                 GasStack hydrogenStack = MekanismGases.HYDROGEN.getStack(maxRate * 2);
                 ItemStack chestStack = player.getItemStackFromSlot(EquipmentSlotType.CHEST);
                 Optional<IGasHandler> chestCapability = MekanismUtils.toOptional(chestStack.getCapability(Capabilities.GAS_HANDLER_CAPABILITY));
-                if (chestCapability.isPresent()) {
+                if (checkChestPlate(chestStack) && chestCapability.isPresent()) {
                     hydrogenUsed = maxRate * 2 - chestCapability.get().insertChemical(hydrogenStack, Action.EXECUTE).getAmount();
                     hydrogenStack.shrink(hydrogenUsed);
                 }
@@ -64,6 +66,21 @@ public abstract class ModuleMekaSuit extends Module {
                 long used = Math.max((int) Math.ceil(hydrogenUsed / 2D), oxygenUsed);
                 useEnergy(player, usage.multiply(used));
                 player.setAir(player.getAir() + (int) oxygenUsed);
+            }
+        }
+
+        /**
+         * Checks whether the given chestplate should be filled with hydrogen, if it can store hydrogen.
+         * Does not check whether the chestplate can store hydrogen.
+         * 
+         * @param chestPlate the chestplate to check
+         * @return whether the given chestplate should be filled with hydrogen.
+         */
+        private boolean checkChestPlate(ItemStack chestPlate) {
+            if(chestPlate.getItem() == MekanismItems.MEKASUIT_BODYARMOR.get()) {
+                return Modules.load(chestPlate, Modules.JETPACK_UNIT) != null;
+            } else {
+                return true;
             }
         }
 

--- a/src/main/java/mekanism/common/content/gear/mekasuit/ModuleMekaSuit.java
+++ b/src/main/java/mekanism/common/content/gear/mekasuit/ModuleMekaSuit.java
@@ -48,17 +48,17 @@ public abstract class ModuleMekaSuit extends Module {
                 FloatingLong usage = MekanismConfig.general.FROM_H2.get().multiply(2);
                 long maxRate = Math.min(getMaxRate(), getContainerEnergy().divide(usage).intValue());
                 long hydrogenUsed = 0;
-                GasStack hydrogenStack = new GasStack(MekanismGases.HYDROGEN.get(), maxRate * 2);
+                GasStack hydrogenStack = MekanismGases.HYDROGEN.getStack(maxRate * 2);
                 ItemStack chestStack = player.getItemStackFromSlot(EquipmentSlotType.CHEST);
                 Optional<IGasHandler> chestCapability = MekanismUtils.toOptional(chestStack.getCapability(Capabilities.GAS_HANDLER_CAPABILITY));
                 if (chestCapability.isPresent()) {
                     hydrogenUsed = maxRate * 2 - chestCapability.get().insertChemical(hydrogenStack, Action.EXECUTE).getAmount();
+                    hydrogenStack.shrink(hydrogenUsed);
                 }
-                hydrogenStack.setAmount(maxRate * 2 - hydrogenUsed);
                 ItemStack handStack = player.getItemStackFromSlot(EquipmentSlotType.MAINHAND);
                 Optional<IGasHandler> handCapability = MekanismUtils.toOptional(handStack.getCapability(Capabilities.GAS_HANDLER_CAPABILITY));
                 if (handCapability.isPresent()) {
-                	hydrogenUsed -= handCapability.get().insertChemical(hydrogenStack, Action.EXECUTE).getAmount();
+                    hydrogenUsed = maxRate * 2 - handCapability.get().insertChemical(hydrogenStack, Action.EXECUTE).getAmount();
                 }
                 long oxygenUsed = Math.min(maxRate, player.getMaxAir() - player.getAir());
                 long used = Math.max((int) Math.ceil(hydrogenUsed / 2D), oxygenUsed);


### PR DESCRIPTION
## Changes proposed in this pull request:
 * Fix Electrolytic Breathing Unit not working when standing on a trapdoor in two block deep water
 * Make Electrolytic Breathing Unit fill any chestplate item that can hold hydrogen
 * Allow Electrolytic Breathing Unit to fill the item in the players main hand with hydrogen

This does not fix the issue with sprinting underwater.
This implements mekanism/Mekanism-Feature-Requests#45