### PR TITLE
Fix desync between client and server in MekanismClient

### DIFF
--- a/src/main/java/mekanism/common/tile/component/TileComponentSecurity.java
+++ b/src/main/java/mekanism/common/tile/component/TileComponentSecurity.java
@@ -10,6 +10,7 @@ import mekanism.common.frequency.Frequency;
 import mekanism.common.frequency.FrequencyManager;
 import mekanism.common.inventory.container.MekanismContainer;
 import mekanism.common.inventory.container.sync.SyncableEnum;
+import mekanism.common.network.PacketSecurityUpdate;
 import mekanism.common.security.ISecurityTile.SecurityMode;
 import mekanism.common.security.SecurityFrequency;
 import mekanism.common.tile.base.TileEntityMekanism;
@@ -58,6 +59,7 @@ public class TileComponentSecurity implements ITileComponent {
         manager.addFrequency(freq);
         frequency = (SecurityFrequency) freq;
         tile.markDirty(false);
+        Mekanism.packetHandler.sendToAll(new PacketSecurityUpdate());
     }
 
     public UUID getOwnerUUID() {


### PR DESCRIPTION
## Changes proposed in this pull request:
See #6264

Currently, sync  is being done only at login

https://github.com/mekanism/Mekanism/blob/e2fbde5c89f8b3bdcf9e406932436711974d3652/src/main/java/mekanism/common/CommonPlayerTracker.java#L42-L50

https://github.com/mekanism/Mekanism/blob/e2fbde5c89f8b3bdcf9e406932436711974d3652/src/main/java/mekanism/common/network/PacketSecurityUpdate.java#L59-L80

**I'm not sure if this is the *'best'* way to do this**