### PR TITLE
Fix Charge Distribution Unit trying to charge full items and voiding Energy

### DIFF
--- a/src/main/java/mekanism/common/content/gear/mekasuit/ModuleChargeDistributionUnit.java
+++ b/src/main/java/mekanism/common/content/gear/mekasuit/ModuleChargeDistributionUnit.java
@@ -82,7 +82,8 @@ public class ModuleChargeDistributionUnit extends ModuleMekaSuit {
     private FloatingLong charge(PlayerEntity player, ItemStack stack, FloatingLong amount) {
         IStrictEnergyHandler handler = EnergyCompatUtils.getStrictEnergyHandler(stack);
         if (handler != null) {
-            return handler.insertEnergy(useEnergy(player, amount), Action.EXECUTE);
+        	FloatingLong remaining = handler.insertEnergy(amount, Action.SIMULATE);
+            return handler.insertEnergy(useEnergy(player, amount.subtract(remaining)), Action.EXECUTE).add(remaining);
         }
         return amount;
     }

--- a/src/main/java/mekanism/common/content/gear/mekasuit/ModuleChargeDistributionUnit.java
+++ b/src/main/java/mekanism/common/content/gear/mekasuit/ModuleChargeDistributionUnit.java
@@ -82,7 +82,7 @@ public class ModuleChargeDistributionUnit extends ModuleMekaSuit {
     private FloatingLong charge(PlayerEntity player, ItemStack stack, FloatingLong amount) {
         IStrictEnergyHandler handler = EnergyCompatUtils.getStrictEnergyHandler(stack);
         if (handler != null) {
-        	FloatingLong remaining = handler.insertEnergy(amount, Action.SIMULATE);
+            FloatingLong remaining = handler.insertEnergy(amount, Action.SIMULATE);
             return handler.insertEnergy(useEnergy(player, amount.subtract(remaining)), Action.EXECUTE).add(remaining);
         }
         return amount;


### PR DESCRIPTION
## Changes proposed in this pull request:
 - Fix Charge Distribution Unit trying to charge full items and voiding Energy.
 - I know this could technically still happen if something fills the EnergyHandler between the two insertEnergy calls, but i think thats rare enough that it isn't worth the effort to prevent it.