### PR TITLE
Added config option for disabling extended vein mining for the Meka-Tool

### DIFF
--- a/src/main/java/mekanism/client/gui/element/custom/GuiModuleScreen.java
+++ b/src/main/java/mekanism/client/gui/element/custom/GuiModuleScreen.java
@@ -13,6 +13,7 @@ import mekanism.common.MekanismLang;
 import mekanism.common.content.gear.Module;
 import mekanism.common.content.gear.ModuleConfigItem;
 import mekanism.common.content.gear.ModuleConfigItem.BooleanData;
+import mekanism.common.content.gear.ModuleConfigItem.DisableableModuleConfigItem;
 import mekanism.common.content.gear.ModuleConfigItem.EnumData;
 import mekanism.common.registries.MekanismSounds;
 import mekanism.common.util.MekanismUtils;
@@ -57,6 +58,12 @@ public class GuiModuleScreen extends GuiRelativeElement {
                 ModuleConfigItem<?> configItem = module.getConfigItems().get(i);
                 // Don't show the enabled option if this is enabled by default
                 if (configItem.getData() instanceof BooleanData && (!configItem.getName().equals(Module.ENABLED_KEY) || !module.getData().isNoDisable())) {
+                    if (configItem instanceof DisableableModuleConfigItem && !((DisableableModuleConfigItem) configItem).isConfigEnabled()) {
+                        //Skip options that are force disabled by the config
+                        //TODO: Eventually we may want to make it slightly "faster" in that it allows updating the toggle elements rather than just
+                        // not adding them back when switching to another module and then back again
+                        continue;
+                    }
                     newElements.add(new BooleanToggle((ModuleConfigItem<Boolean>) configItem, 2, startY));
                     startY += 24;
                 } else if (configItem.getData() instanceof EnumData) {

--- a/src/main/java/mekanism/common/config/GearConfig.java
+++ b/src/main/java/mekanism/common/config/GearConfig.java
@@ -98,6 +98,7 @@ public class GearConfig extends BaseMekanismConfig {
     public final CachedFloatingLongValue mekaToolEnergyUsageHoe;
     public final CachedFloatingLongValue mekaToolEnergyUsageShovel;
     public final CachedFloatingLongValue mekaToolEnergyUsageAxe;
+    public final CachedBooleanValue mekaToolExtendedMining;
     //MekaSuit
     public final CachedFloatingLongValue mekaSuitBaseEnergyCapacity;
     public final CachedFloatingLongValue mekaSuitBaseChargeRate;
@@ -265,6 +266,8 @@ public class GearConfig extends BaseMekanismConfig {
               "energyUsageShovel", FloatingLong.createConst(10));
         mekaToolEnergyUsageAxe = CachedFloatingLongValue.define(this, builder, "Cost in Joules of using the Meka-Tool as an axe for stripping logs.",
               "energyUsageAxe", FloatingLong.createConst(10));
+        mekaToolExtendedMining = CachedBooleanValue.wrap(this, builder.comment("Enable the 'Extended Vein Mining' mode for the Meka-Tool. (Allows vein mining everything not just ores/logs)")
+                .define("extendedMining", true));
         builder.pop();
 
         builder.comment("MekaSuit Settings").push(MEKASUIT_CATEGORY);

--- a/src/main/java/mekanism/common/content/gear/ModuleConfigItem.java
+++ b/src/main/java/mekanism/common/content/gear/ModuleConfigItem.java
@@ -1,5 +1,6 @@
 package mekanism.common.content.gear;
 
+import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 import mekanism.api.math.MathUtils;
 import mekanism.api.text.IHasTextComponent;
@@ -78,6 +79,25 @@ public class ModuleConfigItem<TYPE> {
         void read(String name, CompoundNBT tag);
 
         void write(String name, CompoundNBT tag);
+    }
+
+    public static class DisableableModuleConfigItem extends ModuleConfigItem<Boolean> {
+
+        private final BooleanSupplier isConfigEnabled;
+
+        public DisableableModuleConfigItem(Module module, String name, ILangEntry description, boolean def, BooleanSupplier isConfigEnabled) {
+            super(module, name, description, new BooleanData(), def);
+            this.isConfigEnabled = isConfigEnabled;
+        }
+
+        @Override
+        public Boolean get() {
+            return isConfigEnabled() && super.get();
+        }
+
+        public boolean isConfigEnabled() {
+            return isConfigEnabled.getAsBoolean();
+        }
     }
 
     public static class BooleanData implements ConfigData<Boolean> {

--- a/src/main/java/mekanism/common/content/gear/mekatool/ModuleVeinMiningUnit.java
+++ b/src/main/java/mekanism/common/content/gear/mekatool/ModuleVeinMiningUnit.java
@@ -10,7 +10,7 @@ import mekanism.common.Mekanism;
 import mekanism.common.MekanismLang;
 import mekanism.common.config.MekanismConfig;
 import mekanism.common.content.gear.ModuleConfigItem;
-import mekanism.common.content.gear.ModuleConfigItem.BooleanData;
+import mekanism.common.content.gear.ModuleConfigItem.DisableableModuleConfigItem;
 import mekanism.common.content.gear.ModuleConfigItem.EnumData;
 import mekanism.common.network.PacketLightningRender;
 import mekanism.common.network.PacketLightningRender.LightningPreset;
@@ -31,17 +31,12 @@ public class ModuleVeinMiningUnit extends ModuleMekaTool {
     @Override
     public void init() {
         super.init();
-
-        //Only show extended vein mining option if enabled in config
-        if (MekanismConfig.gear.mekaToolExtendedMining.getAsBoolean()) {
-            addConfigItem(extendedMode = new ModuleConfigItem<>(this, "extended_mode", MekanismLang.MODULE_EXTENDED_MODE, new BooleanData(), false));
-        }
-
+        addConfigItem(extendedMode = new DisableableModuleConfigItem(this, "extended_mode", MekanismLang.MODULE_EXTENDED_MODE, false, MekanismConfig.gear.mekaToolExtendedMining));
         addConfigItem(excavationRange = new ModuleConfigItem<>(this, "excavation_range", MekanismLang.MODULE_EXCAVATION_RANGE, new EnumData<>(ExcavationRange.class, getInstalledCount() + 1), ExcavationRange.LOW));
     }
 
     public boolean isExtended() {
-        return MekanismConfig.gear.mekaToolExtendedMining.getAsBoolean() && extendedMode.get();
+        return extendedMode.get();
     }
 
     public int getExcavationRange() {
@@ -85,7 +80,6 @@ public class ModuleVeinMiningUnit extends ModuleMekaTool {
         if (!isEnabled()) {
             return;
         }
-
         //Only add hud string for extended vein mining if enabled in config
         if (MekanismConfig.gear.mekaToolExtendedMining.getAsBoolean()) {
             list.add(MekanismLang.MODULE_EXTENDED_ENABLED.translateColored(EnumColor.DARK_GRAY,

--- a/src/main/java/mekanism/common/content/gear/mekatool/ModuleVeinMiningUnit.java
+++ b/src/main/java/mekanism/common/content/gear/mekatool/ModuleVeinMiningUnit.java
@@ -31,12 +31,17 @@ public class ModuleVeinMiningUnit extends ModuleMekaTool {
     @Override
     public void init() {
         super.init();
-        addConfigItem(extendedMode = new ModuleConfigItem<>(this, "extended_mode", MekanismLang.MODULE_EXTENDED_MODE, new BooleanData(), false));
+
+        //Only show extended vein mining option if enabled in config
+        if (MekanismConfig.gear.mekaToolExtendedMining.getAsBoolean()) {
+            addConfigItem(extendedMode = new ModuleConfigItem<>(this, "extended_mode", MekanismLang.MODULE_EXTENDED_MODE, new BooleanData(), false));
+        }
+
         addConfigItem(excavationRange = new ModuleConfigItem<>(this, "excavation_range", MekanismLang.MODULE_EXCAVATION_RANGE, new EnumData<>(ExcavationRange.class, getInstalledCount() + 1), ExcavationRange.LOW));
     }
 
     public boolean isExtended() {
-        return extendedMode.get();
+        return MekanismConfig.gear.mekaToolExtendedMining.getAsBoolean() && extendedMode.get();
     }
 
     public int getExcavationRange() {
@@ -80,9 +85,13 @@ public class ModuleVeinMiningUnit extends ModuleMekaTool {
         if (!isEnabled()) {
             return;
         }
-        list.add(MekanismLang.MODULE_EXTENDED_ENABLED.translateColored(EnumColor.DARK_GRAY,
-              isExtended() ? EnumColor.BRIGHT_GREEN : EnumColor.DARK_RED,
-              isExtended() ? MekanismLang.MODULE_ENABLED_LOWER : MekanismLang.MODULE_DISABLED_LOWER));
+
+        //Only add hud string for extended vein mining if enabled in config
+        if (MekanismConfig.gear.mekaToolExtendedMining.getAsBoolean()) {
+            list.add(MekanismLang.MODULE_EXTENDED_ENABLED.translateColored(EnumColor.DARK_GRAY,
+                    isExtended() ? EnumColor.BRIGHT_GREEN : EnumColor.DARK_RED,
+                    isExtended() ? MekanismLang.MODULE_ENABLED_LOWER : MekanismLang.MODULE_DISABLED_LOWER));
+        }
     }
 
     public enum ExcavationRange implements IHasTextComponent {


### PR DESCRIPTION
Added config option for disabling extended vein mining for the Meka-Tool, this also removes HUD and Module Tweaker UI for extended vein mining when disabled.

Think this is the way to best integrate it with the existing code.
