### PR TITLE
Added back 1.12 recipes for Applied Energistics 2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -235,6 +235,9 @@ minecraft {
         data {
             workingDirectory project.file("run")
             environment 'target', 'fmluserdevdata'
+            // This fixes Mixin application problems from other mods because their refMaps are SRG-based,
+            // but we're in a MCP env
+            property "mixin.env.disableRefMap", "true"
 
             args '--all', '--output', file('src/datagen/generated/'),
                     '--mod', 'mekanism',
@@ -287,6 +290,10 @@ repositories {
         url 'https://www.cursemaven.com'
     }
     maven {
+        name 'Modmaven'
+        url 'https://modmaven.k-4u.nl'
+    }
+    maven {
         name 'HWYLA'
         url "https://maven.tehnut.info"
     }
@@ -322,6 +329,7 @@ dependencies {
     //compileOnly fg.deobf("curse.maven:flux-networks:${flux_networks_id}")
 
     //Dependencies for data generators for mod compat reference
+    datagenmainImplementation fg.deobf("appeng:appliedenergistics2:${ae2_version}")
     datagenmainCompileOnly fg.deobf("curse.maven:biomes-o-plenty-api:${biomesoplenty_api_id}")
     datagenmainRuntimeOnly fg.deobf("curse.maven:biomes-o-plenty:${biomesoplenty_id}")
     //datagenmainCompile fg.deobf("curse.maven:i-like-wood:${ilikewood_id}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,6 +30,7 @@ top_version=1.16-3.0.4-beta-7
 hwyla_version=1.10.11-B78_1.16.2
 
 #Mod dependencies for recipes (only used by our data generators)
+ae2_version=8.1.0-alpha.3
 biomesoplenty_api_id=3063662
 biomesoplenty_id=3063659
 

--- a/src/datagen/generated/mekanism/data/mekanism/recipes/compat/appliedenergistics2/certus_crystal_purification.json
+++ b/src/datagen/generated/mekanism/data/mekanism/recipes/compat/appliedenergistics2/certus_crystal_purification.json
@@ -1,0 +1,24 @@
+{
+  "type": "mekanism:enriching",
+  "conditions": [
+    {
+      "modid": "appliedenergistics2",
+      "type": "forge:mod_loaded"
+    }
+  ],
+  "input": [
+    {
+      "ingredient": {
+        "item": "appliedenergistics2:certus_quartz_crystal"
+      }
+    },
+    {
+      "ingredient": {
+        "item": "appliedenergistics2:certus_quartz_dust"
+      }
+    }
+  ],
+  "output": {
+    "item": "appliedenergistics2:purified_certus_quartz_crystal"
+  }
+}

--- a/src/datagen/generated/mekanism/data/mekanism/recipes/compat/appliedenergistics2/certus_crystal_to_dust.json
+++ b/src/datagen/generated/mekanism/data/mekanism/recipes/compat/appliedenergistics2/certus_crystal_to_dust.json
@@ -1,0 +1,24 @@
+{
+  "type": "mekanism:crushing",
+  "conditions": [
+    {
+      "modid": "appliedenergistics2",
+      "type": "forge:mod_loaded"
+    }
+  ],
+  "input": [
+    {
+      "ingredient": {
+        "item": "appliedenergistics2:certus_quartz_crystal"
+      }
+    },
+    {
+      "ingredient": {
+        "item": "appliedenergistics2:charged_certus_quartz_crystal"
+      }
+    }
+  ],
+  "output": {
+    "item": "appliedenergistics2:certus_quartz_dust"
+  }
+}

--- a/src/datagen/generated/mekanism/data/mekanism/recipes/compat/appliedenergistics2/certus_ore_to_crystal.json
+++ b/src/datagen/generated/mekanism/data/mekanism/recipes/compat/appliedenergistics2/certus_ore_to_crystal.json
@@ -1,0 +1,18 @@
+{
+  "type": "mekanism:enriching",
+  "conditions": [
+    {
+      "modid": "appliedenergistics2",
+      "type": "forge:mod_loaded"
+    }
+  ],
+  "input": {
+    "ingredient": {
+      "item": "appliedenergistics2:quartz_ore"
+    }
+  },
+  "output": {
+    "item": "appliedenergistics2:certus_quartz_crystal",
+    "count": 4
+  }
+}

--- a/src/datagen/generated/mekanism/data/mekanism/recipes/compat/appliedenergistics2/certus_seed_to_purified_crystal.json
+++ b/src/datagen/generated/mekanism/data/mekanism/recipes/compat/appliedenergistics2/certus_seed_to_purified_crystal.json
@@ -1,0 +1,17 @@
+{
+  "type": "mekanism:enriching",
+  "conditions": [
+    {
+      "modid": "appliedenergistics2",
+      "type": "forge:mod_loaded"
+    }
+  ],
+  "input": {
+    "ingredient": {
+      "item": "appliedenergistics2:certus_crystal_seed"
+    }
+  },
+  "output": {
+    "item": "appliedenergistics2:purified_certus_quartz_crystal"
+  }
+}

--- a/src/datagen/generated/mekanism/data/mekanism/recipes/compat/appliedenergistics2/charged_certus_ore_to_crystal.json
+++ b/src/datagen/generated/mekanism/data/mekanism/recipes/compat/appliedenergistics2/charged_certus_ore_to_crystal.json
@@ -1,0 +1,18 @@
+{
+  "type": "mekanism:enriching",
+  "conditions": [
+    {
+      "modid": "appliedenergistics2",
+      "type": "forge:mod_loaded"
+    }
+  ],
+  "input": {
+    "ingredient": {
+      "item": "appliedenergistics2:charged_quartz_ore"
+    }
+  },
+  "output": {
+    "item": "appliedenergistics2:charged_certus_quartz_crystal",
+    "count": 4
+  }
+}

--- a/src/datagen/generated/mekanism/data/mekanism/recipes/compat/appliedenergistics2/fluix_crystal_purification.json
+++ b/src/datagen/generated/mekanism/data/mekanism/recipes/compat/appliedenergistics2/fluix_crystal_purification.json
@@ -1,0 +1,24 @@
+{
+  "type": "mekanism:enriching",
+  "conditions": [
+    {
+      "modid": "appliedenergistics2",
+      "type": "forge:mod_loaded"
+    }
+  ],
+  "input": [
+    {
+      "ingredient": {
+        "item": "appliedenergistics2:fluix_crystal"
+      }
+    },
+    {
+      "ingredient": {
+        "item": "appliedenergistics2:fluix_dust"
+      }
+    }
+  ],
+  "output": {
+    "item": "appliedenergistics2:purified_fluix_crystal"
+  }
+}

--- a/src/datagen/generated/mekanism/data/mekanism/recipes/compat/appliedenergistics2/fluix_crystal_to_dust.json
+++ b/src/datagen/generated/mekanism/data/mekanism/recipes/compat/appliedenergistics2/fluix_crystal_to_dust.json
@@ -1,0 +1,17 @@
+{
+  "type": "mekanism:crushing",
+  "conditions": [
+    {
+      "modid": "appliedenergistics2",
+      "type": "forge:mod_loaded"
+    }
+  ],
+  "input": {
+    "ingredient": {
+      "item": "appliedenergistics2:fluix_crystal"
+    }
+  },
+  "output": {
+    "item": "appliedenergistics2:fluix_dust"
+  }
+}

--- a/src/datagen/generated/mekanism/data/mekanism/recipes/compat/appliedenergistics2/fluix_seed_to_purified_crystal.json
+++ b/src/datagen/generated/mekanism/data/mekanism/recipes/compat/appliedenergistics2/fluix_seed_to_purified_crystal.json
@@ -1,0 +1,17 @@
+{
+  "type": "mekanism:enriching",
+  "conditions": [
+    {
+      "modid": "appliedenergistics2",
+      "type": "forge:mod_loaded"
+    }
+  ],
+  "input": {
+    "ingredient": {
+      "item": "appliedenergistics2:fluix_crystal_seed"
+    }
+  },
+  "output": {
+    "item": "appliedenergistics2:purified_fluix_crystal"
+  }
+}

--- a/src/datagen/generated/mekanism/data/mekanism/recipes/compat/appliedenergistics2/nether_seed_to_purified_crystal.json
+++ b/src/datagen/generated/mekanism/data/mekanism/recipes/compat/appliedenergistics2/nether_seed_to_purified_crystal.json
@@ -1,0 +1,17 @@
+{
+  "type": "mekanism:enriching",
+  "conditions": [
+    {
+      "modid": "appliedenergistics2",
+      "type": "forge:mod_loaded"
+    }
+  ],
+  "input": {
+    "ingredient": {
+      "item": "appliedenergistics2:nether_quartz_seed"
+    }
+  },
+  "output": {
+    "item": "appliedenergistics2:purified_nether_quartz_crystal"
+  }
+}

--- a/src/datagen/main/java/mekanism/common/recipe/compat/AE2RecipeProvider.java
+++ b/src/datagen/main/java/mekanism/common/recipe/compat/AE2RecipeProvider.java
@@ -1,0 +1,109 @@
+package mekanism.common.recipe.compat;
+
+import appeng.api.IAppEngApi;
+import appeng.api.definitions.IBlocks;
+import appeng.api.definitions.IItems;
+import appeng.api.definitions.IMaterials;
+import appeng.core.Api;
+import mekanism.api.datagen.recipe.builder.ItemStackToItemStackRecipeBuilder;
+import mekanism.api.recipes.inputs.ItemStackIngredient;
+import mekanism.common.Mekanism;
+import net.minecraft.data.IFinishedRecipe;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.function.Consumer;
+
+@ParametersAreNonnullByDefault
+public class AE2RecipeProvider extends CompatRecipeProvider {
+
+    public AE2RecipeProvider() {
+        super("appliedenergistics2");
+    }
+
+    @Override
+    protected void registerRecipes(Consumer<IFinishedRecipe> consumer, String basePath) {
+        // We cannot use the public API here since data generators do not run the common setup phase,
+        // which would normally expose the API to addons after AE has initialized and registered all of its blocks.
+        IAppEngApi api = Api.instance();
+        if (api == null) {
+            throw new IllegalStateException("AE2 was not initialized");
+        }
+
+        IItems items = api.definitions().items();
+        IMaterials materials = api.definitions().materials();
+        IBlocks blocks = api.definitions().blocks();
+
+        // Certus Crystal -> Certus Dust
+        ItemStackToItemStackRecipeBuilder.crushing(
+                ItemStackIngredient.createMulti(
+                        ItemStackIngredient.from(materials.certusQuartzCrystal()),
+                        ItemStackIngredient.from(materials.certusQuartzCrystalCharged())
+                ),
+                materials.certusQuartzDust().stack(1)
+        ).addCondition(modLoaded)
+                .build(consumer, Mekanism.rl(basePath + "certus_crystal_to_dust"));
+
+        // Fluix Crystal -> Fluix Dust
+        ItemStackToItemStackRecipeBuilder.crushing(
+                ItemStackIngredient.from(materials.fluixCrystal()),
+                materials.fluixDust().stack(1)
+        ).addCondition(modLoaded)
+                .build(consumer, Mekanism.rl(basePath + "fluix_crystal_to_dust"));
+
+        // Certus Ore -> Certus Crystal
+        ItemStackToItemStackRecipeBuilder.enriching(
+                ItemStackIngredient.from(blocks.quartzOre()),
+                materials.certusQuartzCrystal().stack(4)
+        ).addCondition(modLoaded)
+                .build(consumer, Mekanism.rl(basePath + "certus_ore_to_crystal"));
+
+        // Charged Certus Ore -> Charged Certus Crystal
+        ItemStackToItemStackRecipeBuilder.enriching(
+                ItemStackIngredient.from(blocks.quartzOreCharged()),
+                materials.certusQuartzCrystalCharged().stack(4)
+        ).addCondition(modLoaded)
+                .build(consumer, Mekanism.rl(basePath + "charged_certus_ore_to_crystal"));
+
+        // Certus Crystal & Certus Dust -> Purified Certus Crystal
+        ItemStackToItemStackRecipeBuilder.enriching(
+                ItemStackIngredient.createMulti(
+                        ItemStackIngredient.from(materials.certusQuartzCrystal()),
+                        ItemStackIngredient.from(materials.certusQuartzDust())
+                ),
+                materials.purifiedCertusQuartzCrystal().stack(1)
+        ).addCondition(modLoaded)
+                .build(consumer, Mekanism.rl(basePath + "certus_crystal_purification"));
+
+        // Fluix Crystal & Fluix Dust -> Purified Fluix Crystal
+        ItemStackToItemStackRecipeBuilder.enriching(
+                ItemStackIngredient.createMulti(
+                        ItemStackIngredient.from(materials.fluixCrystal()),
+                        ItemStackIngredient.from(materials.fluixDust())
+                ),
+                materials.purifiedFluixCrystal().stack(1)
+        ).addCondition(modLoaded)
+                .build(consumer, Mekanism.rl(basePath + "fluix_crystal_purification"));
+
+        // Certus Crystal Seed -> Purified Certus Crystal
+        ItemStackToItemStackRecipeBuilder.enriching(
+                ItemStackIngredient.from(items.certusCrystalSeed()),
+                materials.purifiedCertusQuartzCrystal().stack(1)
+        ).addCondition(modLoaded)
+                .build(consumer, Mekanism.rl(basePath + "certus_seed_to_purified_crystal"));
+
+        // Nether Crystal Seed -> Purified Nether Crystal
+        ItemStackToItemStackRecipeBuilder.enriching(
+                ItemStackIngredient.from(items.netherQuartzSeed()),
+                materials.purifiedNetherQuartzCrystal().stack(1)
+        ).addCondition(modLoaded)
+                .build(consumer, Mekanism.rl(basePath + "nether_seed_to_purified_crystal"));
+
+        // Fluix Crystal Seed -> Purified Fluix Crystal
+        ItemStackToItemStackRecipeBuilder.enriching(
+                ItemStackIngredient.from(items.fluixCrystalSeed()),
+                materials.purifiedFluixCrystal().stack(1)
+        ).addCondition(modLoaded)
+                .build(consumer, Mekanism.rl(basePath + "fluix_seed_to_purified_crystal"));
+    }
+
+}

--- a/src/datagen/main/java/mekanism/common/recipe/impl/MekanismRecipeProvider.java
+++ b/src/datagen/main/java/mekanism/common/recipe/impl/MekanismRecipeProvider.java
@@ -18,6 +18,7 @@ import mekanism.common.recipe.ISubRecipeProvider;
 import mekanism.common.recipe.builder.ExtendedShapedRecipeBuilder;
 import mekanism.common.recipe.builder.ExtendedShapelessRecipeBuilder;
 import mekanism.common.recipe.builder.MekDataShapedRecipeBuilder;
+import mekanism.common.recipe.compat.AE2RecipeProvider;
 import mekanism.common.recipe.compat.BiomesOPlentyRecipeProvider;
 import mekanism.common.recipe.pattern.Pattern;
 import mekanism.common.recipe.pattern.RecipePattern;
@@ -102,6 +103,7 @@ public class MekanismRecipeProvider extends BaseRecipeProvider {
               new TransmitterRecipeProvider(),
               new UpgradeRecipeProvider(),
               //Mod Compat Recipe providers
+              new AE2RecipeProvider(),
               new BiomesOPlentyRecipeProvider()
               //new ILikeWoodRecipeProvider()//TODO - ILikeWood
         );


### PR DESCRIPTION
Fixes #6479

For the record: Not a fan of the recipes that directly convert crystals and dusts into their purified variants.
The recipes that do this for seeds I find less offensive (although the energy requirement might be tweaked if your recipes support it), since it's similar to the good 'ol AE2Stuff crystal grower.

One implementation note: AE2 now exposes the API only in common startup since it's not thread-safe to do so in the Mod constructor. Since this is datagen, common setup never runs, so the public-facing API is never made available. That's the reasoning for grabbing the API instance from the internal class here, which is slightly less stable.
We are however not going to change the item IDs in 1.16.1 anymore anyway.