### PR TITLE
Add some Processing Integration for AE2 Sky Stone

### DIFF
--- a/src/datagen/generated/mekanism/data/mekanism/recipes/compat/appliedenergistics2/sky_stone_dust_to_sky_stone.json
+++ b/src/datagen/generated/mekanism/data/mekanism/recipes/compat/appliedenergistics2/sky_stone_dust_to_sky_stone.json
@@ -1,0 +1,17 @@
+{
+  "type": "mekanism:enriching",
+  "conditions": [
+    {
+      "modid": "appliedenergistics2",
+      "type": "forge:mod_loaded"
+    }
+  ],
+  "input": {
+    "ingredient": {
+      "item": "appliedenergistics2:sky_dust"
+    }
+  },
+  "output": {
+    "item": "appliedenergistics2:sky_stone_block"
+  }
+}

--- a/src/datagen/generated/mekanism/data/mekanism/recipes/compat/appliedenergistics2/sky_stone_to_dust.json
+++ b/src/datagen/generated/mekanism/data/mekanism/recipes/compat/appliedenergistics2/sky_stone_to_dust.json
@@ -1,0 +1,17 @@
+{
+  "type": "mekanism:crushing",
+  "conditions": [
+    {
+      "modid": "appliedenergistics2",
+      "type": "forge:mod_loaded"
+    }
+  ],
+  "input": {
+    "ingredient": {
+      "item": "appliedenergistics2:sky_stone_block"
+    }
+  },
+  "output": {
+    "item": "appliedenergistics2:sky_dust"
+  }
+}

--- a/src/datagen/generated/mekanism/data/mekanism/recipes/compat/appliedenergistics2/smooth_sky_stone_to_sky_stone.json
+++ b/src/datagen/generated/mekanism/data/mekanism/recipes/compat/appliedenergistics2/smooth_sky_stone_to_sky_stone.json
@@ -1,0 +1,17 @@
+{
+  "type": "mekanism:enriching",
+  "conditions": [
+    {
+      "modid": "appliedenergistics2",
+      "type": "forge:mod_loaded"
+    }
+  ],
+  "input": {
+    "ingredient": {
+      "item": "appliedenergistics2:smooth_sky_stone_block"
+    }
+  },
+  "output": {
+    "item": "appliedenergistics2:sky_stone_block"
+  }
+}

--- a/src/datagen/main/java/mekanism/common/recipe/compat/AE2RecipeProvider.java
+++ b/src/datagen/main/java/mekanism/common/recipe/compat/AE2RecipeProvider.java
@@ -103,5 +103,26 @@ public class AE2RecipeProvider extends CompatRecipeProvider {
               materials.purifiedFluixCrystal().stack(1)
         ).addCondition(modLoaded)
               .build(consumer, Mekanism.rl(basePath + "fluix_seed_to_purified_crystal"));
+
+        //Sky Stone -> Sky Stone Dust
+        ItemStackToItemStackRecipeBuilder.crushing(
+              ItemStackIngredient.from(blocks.skyStoneBlock()),
+              materials.skyDust().stack(1)
+        ).addCondition(modLoaded)
+              .build(consumer, Mekanism.rl(basePath + "sky_stone_to_dust"));
+
+        //Smooth Sky Stone -> Sky Stone
+        ItemStackToItemStackRecipeBuilder.enriching(
+              ItemStackIngredient.from(blocks.smoothSkyStoneBlock()),
+              blocks.skyStoneBlock().stack(1)
+        ).addCondition(modLoaded)
+              .build(consumer, Mekanism.rl(basePath + "smooth_sky_stone_to_sky_stone"));
+
+        //Sky Stone Dust -> Sky Stone
+        ItemStackToItemStackRecipeBuilder.enriching(
+                ItemStackIngredient.from(materials.skyDust()),
+                blocks.skyStoneBlock().stack(1)
+          ).addCondition(modLoaded)
+                .build(consumer, Mekanism.rl(basePath + "sky_stone_dust_to_sky_stone"));
     }
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
 * Add an Crusher recipe to convert Sky Stone to Sky Stone Dust
 * Add an Enrichment Chamber recipe to convert Sky Stone Dust to Sky Stone
 * Add an Enrichment Chamber recipe to convert Smooth Sky Stone to Sky Stone

Atleast two of there recipes were so common in the 1.12.2 modpacks i played that i thought they were part of mekanism itself, as it seems like there weren't, this pr is correcting that.
Note that these recipes are mostly only useful in modpacks, as AE2 itself has no use for sky stone dust, and no way besides the grindstone to get it.
If the modpack only nature of two of these recipes makes them not fitting what mekanism should be feel free to close this pr.