### PR TITLE
Implement NBTUtils#setResourceLocationIfPresent() the same way as in 1.16, fixes #6644

### DIFF
--- a/src/main/java/mekanism/common/block/BlockMekanism.java
+++ b/src/main/java/mekanism/common/block/BlockMekanism.java
@@ -168,8 +168,14 @@ public abstract class BlockMekanism extends Block {
             ISecurityItem securityItem = (ISecurityItem) item;
             tile.getSecurity().setMode(securityItem.getSecurity(stack));
             UUID ownerUUID = securityItem.getOwnerUUID(stack);
-            tile.getSecurity().setOwnerUUID(ownerUUID == null ? placer.getUniqueID() : ownerUUID);
-            Mekanism.packetHandler.sendToAll(new PacketSecurityUpdate(placer.getUniqueID(), null));
+            if (ownerUUID != null) {
+                tile.getSecurity().setOwnerUUID(ownerUUID);
+            } else if (placer != null) {
+                tile.getSecurity().setOwnerUUID(placer.getUniqueID());
+            }
+            if (!world.isRemote && placer != null) {
+                Mekanism.packetHandler.sendToAll(new PacketSecurityUpdate(placer.getUniqueID(), null));
+            }
         }
         if (tile.supportsUpgrades()) {
             //The read method validates that data is stored

--- a/src/main/java/mekanism/common/block/basic/BlockSecurityDesk.java
+++ b/src/main/java/mekanism/common/block/basic/BlockSecurityDesk.java
@@ -31,7 +31,7 @@ public class BlockSecurityDesk extends BlockTileModel<TileEntitySecurityDesk, Bl
 
     @Override
     public void setTileData(World world, BlockPos pos, BlockState state, LivingEntity placer, ItemStack stack, TileEntityMekanism tile) {
-        if (tile instanceof TileEntitySecurityDesk) {
+        if (tile instanceof TileEntitySecurityDesk && placer != null) {
             ((TileEntitySecurityDesk) tile).ownerUUID = placer.getUniqueID();
         }
     }

--- a/src/main/java/mekanism/common/util/NBTUtils.java
+++ b/src/main/java/mekanism/common/util/NBTUtils.java
@@ -167,9 +167,9 @@ public class NBTUtils {
 
     public static void setResourceLocationIfPresent(CompoundNBT nbt, String key, Consumer<ResourceLocation> setter) {
         if (nbt.contains(key, NBT.TAG_STRING)) {
-            String value = nbt.getString(key);
-            if (ResourceLocation.isResouceNameValid(value)) {
-                setter.accept(new ResourceLocation(value));
+            ResourceLocation value = ResourceLocation.tryCreate(nbt.getString(key));
+            if (value != null) {
+                setter.accept(value);
             }
         }
     }


### PR DESCRIPTION
## Changes proposed in this pull request:
As mentioned in #6644 the current implementation of `NBTUtils#setResourceLocationIfPresent()` crashes a dedicated server because `ResourceLocation#isResourceNameValid() / ResourceLocation#func_217855()` is client-only, this PR fixes this by implementing it the same way it is done in 1.16.

Also fixes block placing trying to send a packet to all players on the client and not handling the placer being null.
