### PR TITLE
Gradle cleanup

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -6,4 +6,4 @@ extraction:
     index:
       java_version: 8
       gradle:
-        version: "5.6.4"
+        version: 5.6.4

--- a/build.gradle
+++ b/build.gradle
@@ -59,23 +59,23 @@ sourceSets {
             //But exclude the cache of the generated data from what gets built
             exclude '.cache'
         }
-        compileClasspath += sourceSets.api.output
-        runtimeClasspath += sourceSets.api.output
+        compileClasspath += api.output
+        runtimeClasspath += api.output
     }
-    additions { setupSourceSet((SourceSet) sourceSets.additions, 'additions') }
-    generators { setupSourceSet((SourceSet) sourceSets.generators, 'generators') }
-    defense { setupSourceSet((SourceSet) sourceSets.defense, 'defense') }
-    tools { setupSourceSet((SourceSet) sourceSets.tools, 'tools') }
+    additions { setupSourceSet(additions, 'additions') }
+    generators { setupSourceSet(generators, 'generators') }
+    defense { setupSourceSet(defense, 'defense') }
+    tools { setupSourceSet(tools, 'tools') }
     test {
-        compileClasspath += sourceSets.api.output + sourceSets.main.output + sourceSets.additions.output + sourceSets.generators.output + sourceSets.defense.output + sourceSets.tools.output
-        runtimeClasspath += sourceSets.api.output + sourceSets.main.output + sourceSets.additions.output + sourceSets.generators.output + sourceSets.defense.output + sourceSets.tools.output
+        compileClasspath += api.output + main.output + additions.output + generators.output + defense.output + tools.output
+        runtimeClasspath += api.output + main.output + additions.output + generators.output + defense.output + tools.output
     }
     //Data gen modules for the different modules
-    datagenmain { setupDataGenSourceSet((SourceSet) sourceSets.datagenmain, null, 'main') }
-    datagenadditions { setupDataGenSourceSet((SourceSet) sourceSets.datagenadditions, (SourceSet) sourceSets.additions, 'additions') }
-    datagengenerators { setupDataGenSourceSet((SourceSet) sourceSets.datagengenerators, (SourceSet) sourceSets.generators, 'generators') }
-    datagendefense { setupDataGenSourceSet((SourceSet) sourceSets.datagendefense, (SourceSet) sourceSets.defense, 'defense') }
-    datagentools { setupDataGenSourceSet((SourceSet) sourceSets.datagentools, (SourceSet) sourceSets.tools, 'tools') }
+    datagenmain { setupDataGenSourceSet(datagenmain, null, 'main') }
+    datagenadditions { setupDataGenSourceSet(datagenadditions, additions, 'additions') }
+    datagengenerators { setupDataGenSourceSet(datagengenerators, generators, 'generators') }
+    datagendefense { setupDataGenSourceSet(datagendefense, defense, 'defense') }
+    datagentools { setupDataGenSourceSet(datagentools, tools, 'tools') }
 }
 
 //This method sets up an additional sourceSet in src/$name and adds a reference to the corresponding

--- a/build.gradle
+++ b/build.gradle
@@ -151,17 +151,26 @@ ext {
 replaceResourcesInfo.each { output, sourceSet ->
     return tasks.create("${output}ReplaceResources", Copy) {
         outputs.upToDateWhen { false }
-        from(sourceSet.resources) {
-            include "META-INF/mods.toml"
-            expand version_properties
+        def modsToml = {
+            from(sourceSet.resources) {
+                include "META-INF/mods.toml"
+                expand version_properties
+            }
         }
         //Copy it into the build dir
-        into "$buildDir/resources/${output}/"
+        copy {
+            with modsToml
+            into "$buildDir/resources/${output}/"
+        }
         //If IntelliJ's output dir exists, copy it there as well
         if (new File("$rootDir/out/production/Mekanism.${output}/").exists()) {
-            into "$rootDir/out/production/Mekanism.${output}/"
-            //TODO: Figure this out, copying it does seem to properly put it in the correct
-            // directory, but it seems that MOD_CLASSES is being built wrong so it doesn't matter
+            //Note: This copies it into the correct place, but it still doesn't have the IntelliJ
+            // run work by default because of incorrect MOD_CLASSES getting generated.
+            // probably related to us setting inheritOutputDirs
+            copy {
+                with modsToml
+                into "$rootDir/out/production/Mekanism.${output}/"
+            }
         }
         //Note: If eclipse has its own non gradle based runClient as well and has issues due to
         // the missing mods.toml file, add a check for its path and copy into the correct spot here

--- a/build.gradle
+++ b/build.gradle
@@ -151,17 +151,15 @@ ext {
 replaceResourcesInfo.each { output, sourceSet ->
     return tasks.create("${output}ReplaceResources", Copy) {
         outputs.upToDateWhen { false }
-        def modsToml = {
+        def modsToml = copySpec {
             from(sourceSet.resources) {
                 include "META-INF/mods.toml"
                 expand version_properties
             }
         }
         //Copy it into the build dir
-        copy {
-            with modsToml
-            into "$buildDir/resources/${output}/"
-        }
+        with modsToml
+        into "$buildDir/resources/${output}/"
         //If IntelliJ's output dir exists, copy it there as well
         if (new File("$rootDir/out/production/Mekanism.${output}/").exists()) {
             //Note: This copies it into the correct place, but it still doesn't have the IntelliJ
@@ -631,63 +629,66 @@ task optimizePng {
 def MAVEN_PASSWORD_PROPERTY_NAME = 'mekanismMavenPassword'
 def MAVEN_URL_PROPERTY_NAME = 'mekanismMavenUrl'
 
-publishing {
-    publications {
-        maven(MavenPublication) {
-            from components.java
+def mavenPublicationsClosure = {
+    maven(MavenPublication) {
+        from components.java
+        groupId = project.group
+        version = project.version
+        artifactId = project.archivesBaseName
+        artifacts = [apiJar, jar, generatorsJar, additionsJar, toolsJar, allJar]
+        pom {
             groupId = project.group
             version = project.version
-            artifactId = project.archivesBaseName
-            artifacts = [apiJar, jar, generatorsJar, additionsJar, toolsJar, allJar]
-            pom {
-                groupId = project.group
-                version = project.version
-                if (System.getenv("MAVEN_ARTIFACT") != null) {
-                    artifactId = System.getenv("MAVEN_ARTIFACT")
-                } else {
-                    artifactId = project.archivesBaseName
+            if (System.getenv("MAVEN_ARTIFACT") != null) {
+                artifactId = System.getenv("MAVEN_ARTIFACT")
+            } else {
+                artifactId = project.archivesBaseName
+            }
+            name = "Mekanism"
+            packaging 'jar'
+            description 'Mekanism is a Minecraft add-on featuring high-tech machinery that can be used to create powerful tools, armor, and weapons.'
+            url = 'http://aidancbrady.com/mekanism/'
+            scm {
+                url = 'https://github.com/mekanism/Mekanism.git'
+            }
+            issueManagement {
+                system = 'github'
+                url = 'https://github.com/mekanism/Mekanism/issues'
+            }
+            licenses {
+                license {
+                    name = 'MIT'
+                    distribution = 'repo'
                 }
-                name = "Mekanism"
-                packaging 'jar'
-                description 'Mekanism is a Minecraft add-on featuring high-tech machinery that can be used to create powerful tools, armor, and weapons.'
-                url = 'http://aidancbrady.com/mekanism/'
-                scm {
-                    url = 'https://github.com/mekanism/Mekanism.git'
-                }
-                issueManagement {
-                    system = 'github'
-                    url = 'https://github.com/mekanism/Mekanism/issues'
-                }
-                licenses {
-                    license {
-                        name = 'MIT'
-                        distribution = 'repo'
-                    }
-                }
-                withXml {
-                    NodeList dependencies = asNode().dependencies
-                    NodeList allDeps = dependencies.'*'
+            }
+            withXml {
+                NodeList dependencies = asNode().dependencies
+                NodeList allDeps = dependencies.'*'
 
-                    // Remove forge deps
-                    allDeps.findAll() { Node el ->
-                        el.artifactId.text() == 'forge' && el.groupId.text() == 'net.minecraftforge'
-                    }.forEach() { Node el ->
-                        el.parent().remove(el)
+                // Remove forge deps
+                allDeps.findAll() { Node el ->
+                    el.artifactId.text() == 'forge' && el.groupId.text() == 'net.minecraftforge'
+                }.forEach() { Node el ->
+                    el.parent().remove(el)
+                }
+                //remove ForgeGradle's mapped suffix from versions & set as optional so anyone else doesn't inherit them
+                allDeps.findAll() { Node el ->
+                    el.version.text().contains('_mapped_')
+                }.each { Node el ->
+                    NodeList version = el.version
+                    version.each {
+                        it.setValue(it.text().substring(0, it.text().indexOf('_mapped_')))
                     }
-                    //remove ForgeGradle's mapped suffix from versions & set as optional so anyone else doesn't inherit them
-                    allDeps.findAll() { Node el ->
-                        el.version.text().contains('_mapped_')
-                    }.each { Node el ->
-                        NodeList version = el.version
-                        version.each {
-                            it.setValue(it.text().substring(0, it.text().indexOf('_mapped_')))
-                        }
-                        el.appendNode('optional', true)
-                    }
+                    el.appendNode('optional', true)
                 }
             }
         }
     }
+}
+mavenPublicationsClosure.setDelegate(project)
+
+publishing {
+    publications(mavenPublicationsClosure)
     repositories {
         maven {
             if (project.findProperty(MAVEN_URL_PROPERTY_NAME) != null) {

--- a/build.gradle
+++ b/build.gradle
@@ -570,66 +570,63 @@ task optimizePng {
 def MAVEN_PASSWORD_PROPERTY_NAME = 'mekanismMavenPassword'
 def MAVEN_URL_PROPERTY_NAME = 'mekanismMavenUrl'
 
-def mavenPublicationsClosure = {
-    maven(MavenPublication) {
-        from components.java
-        groupId = project.group
-        version = project.version
-        artifactId = project.archivesBaseName
-        artifacts = [apiJar, jar, generatorsJar, additionsJar, toolsJar, allJar]
-        pom {
+publishing {
+    publications {
+        maven(MavenPublication) {
+            from components.java
             groupId = project.group
             version = project.version
-            if (System.getenv("MAVEN_ARTIFACT") != null) {
-                artifactId = System.getenv("MAVEN_ARTIFACT")
-            } else {
-                artifactId = project.archivesBaseName
-            }
-            name = "Mekanism"
-            packaging 'jar'
-            description 'Mekanism is a Minecraft add-on featuring high-tech machinery that can be used to create powerful tools, armor, and weapons.'
-            url = 'http://aidancbrady.com/mekanism/'
-            scm {
-                url = 'https://github.com/mekanism/Mekanism.git'
-            }
-            issueManagement {
-                system = 'github'
-                url = 'https://github.com/mekanism/Mekanism/issues'
-            }
-            licenses {
-                license {
-                    name = 'MIT'
-                    distribution = 'repo'
+            artifactId = project.archivesBaseName
+            artifacts = [apiJar, jar, generatorsJar, additionsJar, toolsJar, allJar]
+            pom {
+                groupId = project.group
+                version = project.version
+                if (System.getenv("MAVEN_ARTIFACT") != null) {
+                    artifactId = System.getenv("MAVEN_ARTIFACT")
+                } else {
+                    artifactId = project.archivesBaseName
                 }
-            }
-            withXml {
-                NodeList dependencies = asNode().dependencies
-                NodeList allDeps = dependencies.'*'
-
-                // Remove forge deps
-                allDeps.findAll() { Node el ->
-                    el.artifactId.text() == 'forge' && el.groupId.text() == 'net.minecraftforge'
-                }.forEach() { Node el ->
-                    el.parent().remove(el)
+                name = "Mekanism"
+                packaging 'jar'
+                description 'Mekanism is a Minecraft add-on featuring high-tech machinery that can be used to create powerful tools, armor, and weapons.'
+                url = 'http://aidancbrady.com/mekanism/'
+                scm {
+                    url = 'https://github.com/mekanism/Mekanism.git'
                 }
-                //remove ForgeGradle's mapped suffix from versions & set as optional so anyone else doesn't inherit them
-                allDeps.findAll() { Node el ->
-                    el.version.text().contains('_mapped_')
-                }.each { Node el ->
-                    NodeList version = el.version
-                    version.each {
-                        it.setValue(it.text().substring(0, it.text().indexOf('_mapped_')))
+                issueManagement {
+                    system = 'github'
+                    url = 'https://github.com/mekanism/Mekanism/issues'
+                }
+                licenses {
+                    license {
+                        name = 'MIT'
+                        distribution = 'repo'
                     }
-                    el.appendNode('optional', true)
+                }
+                withXml {
+                    NodeList dependencies = asNode().dependencies
+                    NodeList allDeps = dependencies.'*'
+
+                    // Remove forge deps
+                    allDeps.findAll() { Node el ->
+                        el.artifactId.text() == 'forge' && el.groupId.text() == 'net.minecraftforge'
+                    }.forEach() { Node el ->
+                        el.parent().remove(el)
+                    }
+                    //remove ForgeGradle's mapped suffix from versions & set as optional so anyone else doesn't inherit them
+                    allDeps.findAll() { Node el ->
+                        el.version.text().contains('_mapped_')
+                    }.each { Node el ->
+                        NodeList version = el.version
+                        version.each {
+                            it.setValue(it.text().substring(0, it.text().indexOf('_mapped_')))
+                        }
+                        el.appendNode('optional', true)
+                    }
                 }
             }
         }
     }
-}
-mavenPublicationsClosure.setDelegate(project)
-
-publishing {
-    publications(mavenPublicationsClosure)
     repositories {
         maven {
             if (project.findProperty(MAVEN_URL_PROPERTY_NAME) != null) {

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
 }
 
 plugins {
-    id 'org.ajoberstar.grgit' version '4.0.2'
+    id 'org.ajoberstar.grgit' version '4.1.0'
     id "com.matthewprenger.cursegradle" version '1.4.0'
     id 'java'
     id 'idea'
@@ -61,23 +61,23 @@ sourceSets {
         compileClasspath += sourceSets.api.output
         runtimeClasspath += sourceSets.api.output
     }
-    additions { setupSourceSet(sourceSets.additions, 'additions') }
-    generators { setupSourceSet(sourceSets.generators, 'generators') }
-    defense { setupSourceSet(sourceSets.defense, 'defense') }
-    tools { setupSourceSet(sourceSets.tools, 'tools') }
+    additions { setupSourceSet((SourceSet) sourceSets.additions, 'additions') }
+    generators { setupSourceSet((SourceSet) sourceSets.generators, 'generators') }
+    defense { setupSourceSet((SourceSet) sourceSets.defense, 'defense') }
+    tools { setupSourceSet((SourceSet) sourceSets.tools, 'tools') }
     test {
         compileClasspath += sourceSets.api.output + sourceSets.main.output + sourceSets.additions.output + sourceSets.generators.output + sourceSets.defense.output + sourceSets.tools.output
         runtimeClasspath += sourceSets.api.output + sourceSets.main.output + sourceSets.additions.output + sourceSets.generators.output + sourceSets.defense.output + sourceSets.tools.output
     }
     //Data gen modules for the different modules
-    datagenmain { setupDataGenSourceSet(sourceSets.datagenmain, null, 'main') }
-    datagenadditions { setupDataGenSourceSet(sourceSets.datagenadditions, sourceSets.additions, 'additions') }
-    datagengenerators { setupDataGenSourceSet(sourceSets.datagengenerators, sourceSets.generators, 'generators') }
-    datagendefense { setupDataGenSourceSet(sourceSets.datagendefense, sourceSets.defense, 'defense') }
-    datagentools { setupDataGenSourceSet(sourceSets.datagentools, sourceSets.tools, 'tools') }
+    datagenmain { setupDataGenSourceSet((SourceSet) sourceSets.datagenmain, null, 'main') }
+    datagenadditions { setupDataGenSourceSet((SourceSet) sourceSets.datagenadditions, (SourceSet) sourceSets.additions, 'additions') }
+    datagengenerators { setupDataGenSourceSet((SourceSet) sourceSets.datagengenerators, (SourceSet) sourceSets.generators, 'generators') }
+    datagendefense { setupDataGenSourceSet((SourceSet) sourceSets.datagendefense, (SourceSet) sourceSets.defense, 'defense') }
+    datagentools { setupDataGenSourceSet((SourceSet) sourceSets.datagentools, (SourceSet) sourceSets.tools, 'tools') }
 }
 
-//This method sets up an additional sourceset in src/$name and adds a reference to the corresponding
+//This method sets up an additional sourceSet in src/$name and adds a reference to the corresponding
 // data gen's resource directory excluding the cache. It also adds the api and main mekanism module
 // to the dependencies of the source set we are setting up
 def setupSourceSet(SourceSet sourceSet, String name) {
@@ -173,7 +173,7 @@ minecraft {
 
     runs {
         client {
-            workingDirectory project.file("run")
+            workingDirectory file("run")
 
             //The below if statements are to add args to your gradle.properties file in user home
             // (DO NOT add them directly to the gradle.properties file for this project)
@@ -182,63 +182,43 @@ minecraft {
             // explaining what information to set the value to/format it expects
             // One thing to note is because of the caching that goes on, after changing these
             // variables, you need to refresh the project and rerun genIntellijRuns/genEclipseRuns
-            if (project.hasProperty('mc_uuid')) {
+            if (hasProperty('mc_uuid')) {
                 //Your uuid without any dashes in the middle
-                args '--uuid', project.getProperty('mc_uuid')
+                args '--uuid', getProperty('mc_uuid')
             }
-            if (project.hasProperty('mc_username')) {
+            if (hasProperty('mc_username')) {
                 //Your username/display name, this is the name that shows up in chat
                 // Note: This is not your email, even if you have a Mojang account
-                args '--username', project.getProperty('mc_username')
+                args '--username', getProperty('mc_username')
             }
-            if (project.hasProperty('mc_accessToken')) {
+            if (hasProperty('mc_accessToken')) {
                 //Your access token, you can find it in your '.minecraft/launcher_profiles.json' file
-                args '--accessToken', project.getProperty('mc_accessToken')
+                args '--accessToken', getProperty('mc_accessToken')
             }
 
             mods {
-                mekanism {
-                    sources(sourceSets.main, sourceSets.api)
-                }
-                mekanismadditions {
-                    source(sourceSets.additions)
-                }
-                mekanismgenerators {
-                    source(sourceSets.generators)
-                }
-                mekanismdefense {
-                    source(sourceSets.defense)
-                }
-                mekanismtools {
-                    source(sourceSets.tools)
-                }
+                mekanism.sources((SourceSet[]) [sourceSets.main, sourceSets.api])
+                mekanismadditions.source((SourceSet) sourceSets.additions)
+                mekanismdefense.source((SourceSet) sourceSets.defense)
+                mekanismgenerators.source((SourceSet) sourceSets.generators)
+                mekanismtools.source((SourceSet) sourceSets.tools)
             }
         }
 
         server {
-            workingDirectory project.file("run")
+            workingDirectory file("run")
 
             mods {
-                mekanism {
-                    sources(sourceSets.main, sourceSets.api)
-                }
-                mekanismadditions {
-                    source(sourceSets.additions)
-                }
-                mekanismgenerators {
-                    source(sourceSets.generators)
-                }
-                mekanismdefense {
-                    source(sourceSets.defense)
-                }
-                mekanismtools {
-                    source(sourceSets.tools)
-                }
+                mekanism.sources((SourceSet[]) [sourceSets.main, sourceSets.api])
+                mekanismadditions.source((SourceSet) sourceSets.additions)
+                mekanismdefense.source((SourceSet) sourceSets.defense)
+                mekanismgenerators.source((SourceSet) sourceSets.generators)
+                mekanismtools.source((SourceSet) sourceSets.tools)
             }
         }
 
         data {
-            workingDirectory project.file("run")
+            workingDirectory file("run")
             environment 'target', 'fmluserdevdata'
             //This fixes Mixin application problems from other mods because their refMaps are SRG-based,
             // but we're in a MCP env
@@ -246,32 +226,22 @@ minecraft {
 
             args '--all', '--output', file('src/datagen/generated/'),
                     '--mod', 'mekanism',
-                    '--existing', sourceSets.main.resources.srcDirs[0],
+                    '--existing', file('src/main/resources/'),
                     '--mod', 'mekanismadditions',
-                    '--existing', sourceSets.additions.resources.srcDirs[0],
-                    '--mod', 'mekanismgenerators',
-                    '--existing', sourceSets.generators.resources.srcDirs[0],
+                    '--existing', file('src/additions/resources/'),
                     '--mod', 'mekanismdefense',
-                    '--existing', sourceSets.defense.resources.srcDirs[0],
+                    '--existing', file('src/defense/resources/'),
+                    '--mod', 'mekanismgenerators',
+                    '--existing', file('src/generators/resources/'),
                     '--mod', 'mekanismtools',
-                    '--existing', sourceSets.tools.resources.srcDirs[0]
+                    '--existing', file('src/tools/resources/')
 
             mods {
-                mekanism {
-                    sources(sourceSets.main, sourceSets.api, sourceSets.datagenmain)
-                }
-                mekanismadditions {
-                    sources(sourceSets.additions, sourceSets.datagenadditions)
-                }
-                mekanismgenerators {
-                    sources(sourceSets.generators, sourceSets.datagengenerators)
-                }
-                mekanismdefense {
-                    sources(sourceSets.defense, sourceSets.datagendefense)
-                }
-                mekanismtools {
-                    sources(sourceSets.tools, sourceSets.datagentools)
-                }
+                mekanism.sources((SourceSet[]) [sourceSets.main, sourceSets.api, sourceSets.datagenmain])
+                mekanismadditions.sources((SourceSet[]) [sourceSets.additions, sourceSets.datagenadditions])
+                mekanismdefense.sources((SourceSet[]) [sourceSets.defense, sourceSets.datagendefense])
+                mekanismgenerators.sources((SourceSet[]) [sourceSets.generators, sourceSets.datagengenerators])
+                mekanismtools.sources((SourceSet[]) [sourceSets.tools, sourceSets.datagentools])
             }
         }
     }
@@ -315,7 +285,7 @@ repositories {
     }
     maven {
         name 'Modmaven'
-        url 'https://modmaven.k-4u.nl'
+        url 'https://modmaven.dev/'
         content {
             includeGroup 'appeng'
         }
@@ -458,15 +428,15 @@ jar {
 //TODO: Sources Jars?
 
 task apiJar(type: Jar) {
-    classifier "api"
+    archiveClassifier.set("api")
     from sourceSets.api.output
 }
 
 task additionsJar(type: Jar) {
     //Mark that it shouldn't run before the replace resources gets run
     shouldRunAfter(additionsReplaceResources)
-    archiveName = "MekanismAdditions-${project.version}.jar"
-    classifier = "additions"
+    archiveFileName.set("MekanismAdditions-${project.version}.jar")
+    archiveClassifier.set("additions")
     from sourceSets.additions.output
     manifest.attributes(getManifestAttributes("MekanismAdditions"))
     afterEvaluate {
@@ -477,8 +447,8 @@ task additionsJar(type: Jar) {
 task defenseJar(type: Jar) {
     //Mark that it shouldn't run before the replace resources gets run
     shouldRunAfter(defenseReplaceResources)
-    archiveName = "MekanismDefense-${project.version}.jar"
-    classifier = "defense"
+    archiveFileName.set("MekanismDefense-${project.version}.jar")
+    archiveClassifier.set("defense")
     from sourceSets.defense.output
     manifest.attributes(getManifestAttributes("MekanismDefense"))
     afterEvaluate {
@@ -489,8 +459,8 @@ task defenseJar(type: Jar) {
 task generatorsJar(type: Jar) {
     //Mark that it shouldn't run before the replace resources gets run
     shouldRunAfter(generatorsReplaceResources)
-    archiveName = "MekanismGenerators-${project.version}.jar"
-    classifier = "generators"
+    archiveFileName.set("MekanismGenerators-${project.version}.jar")
+    archiveClassifier.set("generators")
     from sourceSets.generators.output
     manifest.attributes(getManifestAttributes("MekanismGenerators"))
     afterEvaluate {
@@ -501,8 +471,8 @@ task generatorsJar(type: Jar) {
 task toolsJar(type: Jar) {
     //Mark that it shouldn't run before the replace resources gets run
     shouldRunAfter(toolsReplaceResources)
-    archiveName = "MekanismTools-${project.version}.jar"
-    classifier = "tools"
+    archiveFileName.set("MekanismTools-${project.version}.jar")
+    archiveClassifier.set("tools")
     from sourceSets.tools.output
     manifest.attributes(getManifestAttributes("MekanismTools"))
     afterEvaluate {
@@ -519,7 +489,7 @@ task allJar(type: Jar) {
     afterEvaluate {
         finalizedBy reobfAllJar
     }
-    classifier "all"
+    archiveClassifier.set("all")
     manifest.attributes(getManifestAttributes("MekanismAll"))
     doFirst {
         //Generate folders, merge the access transformers and mods.toml files
@@ -686,7 +656,7 @@ publishing {
                     }.forEach() { Node el ->
                         el.parent().remove(el)
                     }
-                    //remove forgegradle's mapped suffix from versions & set as optional so anyone else doesn't inherit them
+                    //remove ForgeGradle's mapped suffix from versions & set as optional so anyone else doesn't inherit them
                     allDeps.findAll() { Node el ->
                         el.version.text().contains('_mapped_')
                     }.each { Node el ->

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 import groovy.json.JsonOutput
 import groovy.json.JsonSlurper
+import mekanism.tasks.MergeJars
 
 buildscript {
     repositories {
@@ -455,9 +456,7 @@ task additionsJar(type: Jar) {
     archiveClassifier.set("additions")
     from sourceSets.additions.output
     manifest.attributes(getManifestAttributes("MekanismAdditions"))
-    afterEvaluate {
-        finalizedBy reobfAdditionsJar
-    }
+    afterEvaluate { finalizedBy reobfAdditionsJar }
 }
 
 task defenseJar(type: Jar) {
@@ -467,9 +466,7 @@ task defenseJar(type: Jar) {
     archiveClassifier.set("defense")
     from sourceSets.defense.output
     manifest.attributes(getManifestAttributes("MekanismDefense"))
-    afterEvaluate {
-        finalizedBy reobfDefenseJar
-    }
+    afterEvaluate { finalizedBy reobfDefenseJar }
 }
 
 task generatorsJar(type: Jar) {
@@ -479,9 +476,7 @@ task generatorsJar(type: Jar) {
     archiveClassifier.set("generators")
     from sourceSets.generators.output
     manifest.attributes(getManifestAttributes("MekanismGenerators"))
-    afterEvaluate {
-        finalizedBy reobfGeneratorsJar
-    }
+    afterEvaluate { finalizedBy reobfGeneratorsJar }
 }
 
 task toolsJar(type: Jar) {
@@ -491,83 +486,29 @@ task toolsJar(type: Jar) {
     archiveClassifier.set("tools")
     from sourceSets.tools.output
     manifest.attributes(getManifestAttributes("MekanismTools"))
-    afterEvaluate {
-        finalizedBy reobfToolsJar
-    }
+    afterEvaluate { finalizedBy reobfToolsJar }
 }
 
-//TODO: Fix the fact that the all jar does not properly merge overlapping tags (cardboard_blacklist, and piglin_loved)
 task allJar(type: Jar) {
     //Make sure the other tasks run first
     shouldRunAfter(apiJar, jar, additionsJar, defenseJar, generatorsJar, toolsJar,
             processResources, processAdditionsResources, processDefenseResources,
             processGeneratorsResources, processToolsResources)
-    afterEvaluate {
-        finalizedBy reobfAllJar
-    }
+    afterEvaluate { finalizedBy reobfAllJar }
     archiveClassifier.set("all")
     manifest.attributes(getManifestAttributes("MekanismAll"))
-    doFirst {
-        //Generate folders, merge the access transformers and mods.toml files
-        mkdir("$buildDir/generated/META-INF")
-        (new File("$buildDir/generated/META-INF/accesstransformer.cfg")).text = mergeATs(sourceSets.main,
-                sourceSets.additions, sourceSets.defense, sourceSets.generators, sourceSets.tools)
-        (new File("$buildDir/generated/META-INF/mods.toml")).text = mergeModsTOML(sourceSets.main,
-                sourceSets.additions, sourceSets.defense, sourceSets.generators, sourceSets.tools)
-    }
+    //Start by generating the merged data
+    doFirst(MergeJars.merge(project, sourceSets.main, sourceSets.additions, sourceSets.defense, sourceSets.generators, sourceSets.tools))
+    //Then copy all the files except for ones we are going to include from the merged
     from(sourceSets.api.output)
-    from(sourceSets.main.output) {
-        exclude 'META-INF/mods.toml', 'META-INF/accesstransformer.cfg'
-    }
-    Closure excluded = {
-        exclude 'META-INF/mods.toml', 'META-INF/accesstransformer.cfg', 'logo.png', 'pack.mcmeta'
-    }
+    from(sourceSets.main.output, MergeJars.excludedMain())
+    Closure excluded = MergeJars.excludedGeneral()
     from(sourceSets.additions.output, excluded)
     from(sourceSets.defense.output, excluded)
     from(sourceSets.generators.output, excluded)
     from(sourceSets.tools.output, excluded)
-    //Copy over the generated files
-    from("$buildDir/generated") {
-        include 'META-INF/mods.toml'
-        expand version_properties
-    }
-    from("$buildDir/generated") {
-        include 'META-INF/accesstransformer.cfg'
-    }
-}
-
-static String mergeATs(SourceSet... sourceSets) {
-    String text = ""
-    for (SourceSet sourceSet : sourceSets) {
-        sourceSet.resources.matching {
-            include 'META-INF/accesstransformer.cfg'
-        }.each {
-            File file -> text = text.isEmpty() ? file.getText() : text + "\n" + file.getText()
-        }
-    }
-    return text
-}
-
-static String mergeModsTOML(SourceSet... sourceSets) {
-    String text = ""
-    for (SourceSet sourceSet : sourceSets) {
-        sourceSet.resources.matching {
-            include 'META-INF/mods.toml'
-        }.each {
-            File file ->
-                if (text.isEmpty()) {
-                    //Nothing added yet, take it all
-                    text = file.getText()
-                } else {
-                    //Otherwise add all but the first four lines (which are duplicated between the files)
-                    String[] lines = file.getText().split("\n")
-                    for (int i = 4; i < lines.length; i++) {
-                        text = text + "\n" + lines[i]
-                    }
-                }
-        }
-    }
-    return text
+    //And finally copy over the generated files
+    MergeJars.getGeneratedClosures(version_properties).each { closure -> from("$buildDir/generated", closure) }
 }
 
 artifacts {

--- a/build.gradle
+++ b/build.gradle
@@ -155,7 +155,16 @@ replaceResourcesInfo.each { output, sourceSet ->
             include "META-INF/mods.toml"
             expand version_properties
         }
+        //Copy it into the build dir
         into "$buildDir/resources/${output}/"
+        //If IntelliJ's output dir exists, copy it there as well
+        if (new File("$rootDir/out/production/Mekanism.${output}/").exists()) {
+            into "$rootDir/out/production/Mekanism.${output}/"
+            //TODO: Figure this out, copying it does seem to properly put it in the correct
+            // directory, but it seems that MOD_CLASSES is being built wrong so it doesn't matter
+        }
+        //Note: If eclipse has its own non gradle based runClient as well and has issues due to
+        // the missing mods.toml file, add a check for its path and copy into the correct spot here
     }
 }
 

--- a/buildSrc/.gitignore
+++ b/buildSrc/.gitignore
@@ -1,0 +1,2 @@
+/.gradle/
+/build/

--- a/buildSrc/src/main/groovy/mekanism/tasks/MergeJars.groovy
+++ b/buildSrc/src/main/groovy/mekanism/tasks/MergeJars.groovy
@@ -1,0 +1,122 @@
+package mekanism.tasks
+
+import groovy.json.JsonOutput
+import groovy.json.JsonSlurper
+import org.gradle.api.Project
+import org.gradle.api.tasks.SourceSet
+
+class MergeJars {
+
+    static Closure excludedMain() {
+        return { exclude 'META-INF/mods.toml', 'META-INF/accesstransformer.cfg' }
+    }
+
+    static Closure excludedGeneral() {
+        return { exclude 'META-INF/mods.toml', 'META-INF/accesstransformer.cfg', 'logo.png', 'pack.mcmeta' }
+    }
+
+    static Closure merge(Project project, SourceSet... sourceSets) {
+        return {
+            //Generate folders, merge the access transformers and mods.toml files
+            project.mkdir("$project.buildDir/generated/META-INF")
+            (new File("$project.buildDir/generated/META-INF/accesstransformer.cfg")).text = mergeATs(sourceSets)
+            (new File("$project.buildDir/generated/META-INF/mods.toml")).text = mergeModsTOML(sourceSets)
+            //Delete the data directory so that we don't accidentally leak bad old data into it
+            project.file("$project.buildDir/generated/data").deleteDir()
+            //And then recreate the directory so we can put stuff in it
+            project.mkdir("$project.buildDir/generated/data")
+            mergeTags(project, sourceSets)
+        }
+    }
+
+    static List<Closure> getGeneratedClosures(def version_properties) {
+        List<Closure> generated = new ArrayList<>()
+        generated.add({
+            include 'META-INF/mods.toml'
+            expand version_properties
+        })
+        generated.add({
+            include 'META-INF/accesstransformer.cfg'
+            include 'data/**'
+        })
+        return generated
+    }
+
+    private static String mergeATs(SourceSet... sourceSets) {
+        String text = ""
+        for (SourceSet sourceSet : sourceSets) {
+            sourceSet.resources.matching {
+                include 'META-INF/accesstransformer.cfg'
+            }.each {
+                file -> text = text.isEmpty() ? file.getText() : text + "\n" + file.getText()
+            }
+        }
+        return text
+    }
+
+    private static String mergeModsTOML(SourceSet... sourceSets) {
+        String text = ""
+        for (SourceSet sourceSet : sourceSets) {
+            sourceSet.resources.matching {
+                include 'META-INF/mods.toml'
+            }.each { file ->
+                if (text.isEmpty()) {
+                    //Nothing added yet, take it all
+                    text = file.getText()
+                } else {
+                    //Otherwise add all but the first four lines (which are duplicated between the files)
+                    String[] lines = file.getText().split("\n")
+                    for (int i = 4; i < lines.length; i++) {
+                        text = text + "\n" + lines[i]
+                    }
+                }
+            }
+        }
+        return text
+    }
+
+    private static void mergeTags(Project project, SourceSet... sourceSets) {
+        Closure tagFilter = { include '**/data/*/tags/**/*.json' }
+        Map<String, List<String>> reverseTags = new HashMap<>()
+        for (SourceSet sourceSet : sourceSets) {
+            sourceSet.resources.srcDirs.each { srcDir ->
+                int srcDirPathLength = srcDir.getPath().length()
+                project.fileTree(srcDir).matching(tagFilter).each { file ->
+                    //Add the sourceSet to the reverse lookup
+                    String path = file.getPath()
+                    String tag = path.substring(srcDirPathLength)
+                    if (!reverseTags.containsKey(tag)) {
+                        reverseTags.put(tag, new ArrayList<>())
+                    }
+                    reverseTags.get(tag).add(path)
+                }
+            }
+        }
+        //Go through the reverse tag index and if there are multiple sourceSets that contain the same tag
+        // properly merge that tag
+        reverseTags.each { tag, tagPaths ->
+            if (tagPaths.size() > 1) {
+                mergeTag(project, tag, tagPaths)
+            }
+        }
+    }
+
+    private static void mergeTag(Project project, String tag, List<String> tagPaths) {
+        println(tag + " appeared " + tagPaths.size() + " times")
+        Object outputTagAsJson = null
+        tagPaths.each {path ->
+            Object tagAsJson = new JsonSlurper().parse(project.file(path))
+            if (outputTagAsJson == null) {
+                outputTagAsJson = tagAsJson
+            } else {
+                outputTagAsJson.values += tagAsJson.values
+            }
+        }
+        if (outputTagAsJson != null) {
+            File outputFile = new File("$project.buildDir/generated" + tag)
+            //Make all parent directories needed
+            outputFile.getParentFile().mkdirs()
+            outputFile.text = JsonOutput.toJson(outputTagAsJson)
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.jvmargs=-Xmx3G
 minecraft_version=1.16.3
 mappings_version=20200916-1.16.2
 loader_version=34
-forge_version=34.1.25
+forge_version=34.1.32
 mod_version=10.0.15
 #This determines the minimum version of forge required to use Mekanism
 # Only bump it whenever we need access to a feature in forge that is not available in earlier versions

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,12 +28,12 @@ jei_version=7.6.0.49
 ctm_version=1.1.1.5
 top_version=1.16-3.0.4-beta-7
 hwyla_version=1.10.11-B78_1.16.2
-flux_networks_id=3092138
+flux_networks_id=3093064
 
 #Mod dependencies for recipes (only used by our data generators)
 ae2_version=8.1.0-alpha.3
-biomesoplenty_api_id=3072958
-biomesoplenty_id=3072955
+biomesoplenty_api_id=3079186
+biomesoplenty_id=3079183
 ilikewood_id=3068985
 
 #Outdated mod dependencies

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.jvmargs=-Xmx3G
 minecraft_version=1.16.3
 mappings_version=20200916-1.16.2
 loader_version=34
-forge_version=34.1.32
+forge_version=34.1.33
 mod_version=10.0.15
 #This determines the minimum version of forge required to use Mekanism
 # Only bump it whenever we need access to a feature in forge that is not available in earlier versions
@@ -31,9 +31,9 @@ hwyla_version=1.10.11-B78_1.16.2
 flux_networks_id=3093064
 
 #Mod dependencies for recipes (only used by our data generators)
-ae2_version=8.1.0-alpha.3
-biomesoplenty_api_id=3079186
-biomesoplenty_id=3079183
+ae2_version=8.1.0-beta.2
+biomesoplenty_api_id=3095155
+biomesoplenty_id=3095152
 ilikewood_id=3068985
 
 #Outdated mod dependencies


### PR DESCRIPTION
## Changes proposed in this pull request:
- Cleaned up deprecated Gradle calls
- Rewrote gradle calls slightly to remove the majority of IntelliJ warnings on the build.gradle file. The one change I am not too sure about is moving the maven publication to a closure and setting the project for it
- Copy the modified mods.toml file to the intellij build folder in addition to the gradle build folder. This only somewhat helps as the intellij runconfigs have the wrong paths for MOD_CLASSES by default, but now if they get manually fixed it can actually run now. (I didn't bother experimenting with manually specifying the values as I am fine with continuing to just use the gradlle intellij runconfigs
- Moved a lot of the all jar merge logic into a separate file and add support for merging tags that are added by multiple modules. In theory I think this fixes all the remaining merge issues the all jar had.