### PR TITLE
Added ComputerCraft integration to main multiblocks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -329,6 +329,8 @@ repositories {
             includeGroup 'mcp.mobius.waila'
         }
     }
+
+    maven { url 'https://squiddev.cc/maven/' }
 }
 
 test {
@@ -359,6 +361,7 @@ dependencies {
     //Mods we have dependencies on but don't bother loading into the dev environment
     //compileOnly fg.deobf("curse.maven:projecte-226410:${projecte_api_id}")
     compileOnly fg.deobf("curse.maven:flux-networks-248020:${flux_networks_id}")
+    compileOnly fg.deobf("org.squiddev:cc-tweaked-${minecraft_version}:${cct_version}")
 
     //Dependencies for data generators for mod compat reference
     datagenmainImplementation fg.deobf("appeng:appliedenergistics2:${ae2_version}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,6 +30,7 @@ ctm_version=1.1.1.5
 top_version=1.16-3.0.6-8
 hwyla_version=1.10.11-B78_1.16.2
 flux_networks_id=3111237
+cct_version=1.94.0
 
 #Mod dependencies for recipes (only used by our data generators)
 ae2_version=8.2.0-alpha.2

--- a/src/main/java/mekanism/common/Mekanism.java
+++ b/src/main/java/mekanism/common/Mekanism.java
@@ -1,6 +1,7 @@
 package mekanism.common;
 
 import com.mojang.authlib.GameProfile;
+import dan200.computercraft.api.ComputerCraftAPI;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import java.util.ArrayList;
 import java.util.List;
@@ -49,6 +50,7 @@ import mekanism.common.content.transporter.PathfinderCache;
 import mekanism.common.content.transporter.TransporterManager;
 import mekanism.common.entity.EntityRobit;
 import mekanism.common.integration.MekanismHooks;
+import mekanism.common.integration.computercraft.MekanismPeripheralProvider;
 import mekanism.common.inventory.container.sync.dynamic.SyncMapper;
 import mekanism.common.item.block.machine.ItemBlockFluidTank.FluidTankItemDispenseBehavior;
 import mekanism.common.lib.Version;
@@ -335,6 +337,10 @@ public class Mekanism {
 
         //Fake player info
         logger.info("Fake player readout: UUID = {}, name = {}", gameProfile.getId(), gameProfile.getName());
+
+        // Register CC peripheral provider
+        if(hooks.CCLoaded)
+            ComputerCraftAPI.registerPeripheralProvider(new MekanismPeripheralProvider());
 
         //Completion notification
         logger.info("Loading complete.");

--- a/src/main/java/mekanism/common/integration/MekanismHooks.java
+++ b/src/main/java/mekanism/common/integration/MekanismHooks.java
@@ -18,6 +18,7 @@ public final class MekanismHooks {
     public static final String CRAFTTWEAKER_MOD_ID = "crafttweaker";
     public static final String PROJECTE_MOD_ID = "projecte";
     public static final String FLUX_NETWORKS_MOD_ID = "fluxnetworks";
+    public static final String COMPUTER_CRAFT_MOD_ID = "computercraft";
 
     public boolean JEILoaded = false;
     public boolean CraftTweakerLoaded = false;
@@ -25,6 +26,7 @@ public final class MekanismHooks {
     public boolean FluxNetworksLoaded = false;
     public boolean ProjectELoaded = false;
     public boolean TOPLoaded = false;
+    public boolean CCLoaded = false;
 
     public void hookCommonSetup() {
         ModList modList = ModList.get();
@@ -34,6 +36,7 @@ public final class MekanismHooks {
         ProjectELoaded = modList.isLoaded(PROJECTE_MOD_ID);
         TOPLoaded = modList.isLoaded(TOP_MOD_ID);
         FluxNetworksLoaded = modList.isLoaded(FLUX_NETWORKS_MOD_ID);
+        CCLoaded = modList.isLoaded(COMPUTER_CRAFT_MOD_ID);
     }
 
     public void sendIMCMessages(InterModEnqueueEvent event) {

--- a/src/main/java/mekanism/common/integration/computercraft/MekanismPeripheralProvider.java
+++ b/src/main/java/mekanism/common/integration/computercraft/MekanismPeripheralProvider.java
@@ -1,0 +1,44 @@
+package mekanism.common.integration.computercraft;
+
+import dan200.computercraft.api.peripheral.IPeripheral;
+import dan200.computercraft.api.peripheral.IPeripheralProvider;
+import mekanism.common.content.boiler.BoilerMultiblockData;
+import mekanism.common.content.evaporation.EvaporationMultiblockData;
+import mekanism.common.content.matrix.MatrixMultiblockData;
+import mekanism.common.content.sps.SPSMultiblockData;
+import mekanism.common.content.tank.TankMultiblockData;
+import mekanism.common.integration.computercraft.peripherals.*;
+import mekanism.common.lib.multiblock.MultiblockData;
+import mekanism.common.tile.prefab.TileEntityMultiblock;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.Direction;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.LazyOptional;
+import org.jetbrains.annotations.NotNull;
+
+public class MekanismPeripheralProvider implements IPeripheralProvider {
+    @Override
+    public @NotNull LazyOptional<IPeripheral> getPeripheral(@NotNull World world, @NotNull BlockPos blockPos, @NotNull Direction direction) {
+        TileEntity t = world.getTileEntity(blockPos);
+
+        if(t instanceof TileEntityMultiblock){
+            TileEntityMultiblock<?> multiblock = (TileEntityMultiblock<?>) t;
+            MultiblockData data = multiblock.getMultiblock();
+
+            if(data instanceof MatrixMultiblockData){
+                return LazyOptional.of(() -> new InductionMatrixPeripheral((MatrixMultiblockData) data));
+            } else if(data instanceof EvaporationMultiblockData){
+                return LazyOptional.of(() -> new ThermalEvaporationPeripheral((EvaporationMultiblockData) data));
+            } else if(data instanceof TankMultiblockData){
+                return LazyOptional.of(() -> new DynamicTankPeripheral((TankMultiblockData) data));
+            } else if(data instanceof BoilerMultiblockData){
+                return LazyOptional.of(() -> new BoilerPeripheral((BoilerMultiblockData) data));
+            } else if(data instanceof SPSMultiblockData){
+                return LazyOptional.of(() -> new SPSPeripheral((SPSMultiblockData) data));
+            }
+        }
+
+        return LazyOptional.empty();
+    }
+}

--- a/src/main/java/mekanism/common/integration/computercraft/peripherals/BoilerPeripheral.java
+++ b/src/main/java/mekanism/common/integration/computercraft/peripherals/BoilerPeripheral.java
@@ -1,0 +1,96 @@
+package mekanism.common.integration.computercraft.peripherals;
+
+import dan200.computercraft.api.lua.LuaFunction;
+import dan200.computercraft.api.peripheral.IPeripheral;
+import mekanism.common.config.MekanismConfig;
+import mekanism.common.content.boiler.BoilerMultiblockData;
+import mekanism.common.content.tank.TankMultiblockData;
+import mekanism.common.util.HeatUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class BoilerPeripheral implements IPeripheral {
+    private BoilerMultiblockData boiler;
+
+    public BoilerPeripheral(BoilerMultiblockData boiler) {
+        this.boiler = boiler;
+    }
+
+    public BoilerMultiblockData getBoiler() {
+        return boiler;
+    }
+
+    @LuaFunction
+    public long getHeatedCoolantCapacity(){
+        return boiler.superheatedCoolantTank.getCapacity();
+    }
+
+    @LuaFunction
+    public long getHeatedCoolantAmount(){
+        return boiler.superheatedCoolantTank.getStored();
+    }
+
+    @LuaFunction
+    public long getCoolantCapacity(){
+        return boiler.cooledCoolantTank.getCapacity();
+    }
+
+    @LuaFunction
+    public long getCoolantAmount(){
+        return boiler.cooledCoolantTank.getStored();
+    }
+
+    @LuaFunction
+    public long getWaterCapacity(){
+        return boiler.waterTank.getCapacity();
+    }
+
+    @LuaFunction
+    public int getWaterAmount(){
+        return boiler.waterTank.getFluidAmount();
+    }
+
+    @LuaFunction
+    public long getSteamCapacity(){
+        return boiler.steamTank.getCapacity();
+    }
+
+    @LuaFunction
+    public long getSteamAmount(){
+        return boiler.steamTank.getStored();
+    }
+
+    @LuaFunction
+    public double getTemperature(){
+        return boiler.getTotalTemperature();
+    }
+
+    @LuaFunction
+    public double getBoilRate(){
+        return boiler.lastBoilRate;
+    }
+
+    @LuaFunction
+    public double getMaxBoil(){
+        return boiler.lastMaxBoil;
+    }
+
+    @LuaFunction
+    public double getBoilCapacity(){
+        return (MekanismConfig.general.superheatingHeatTransfer.get() * boiler.superheatingElements / HeatUtils.getWaterThermalEnthalpy()) * HeatUtils.getSteamEnergyEfficiency();
+    }
+
+    @NotNull
+    @Override
+    public String getType() {
+        return "boiler";
+    }
+
+    @Override
+    public boolean equals(@Nullable IPeripheral iPeripheral) {
+        if(iPeripheral instanceof BoilerPeripheral){
+            BoilerPeripheral boilerPeripheral = (BoilerPeripheral) iPeripheral;
+            return boilerPeripheral.getBoiler().equals(this.boiler);
+        } else return false;
+    }
+}

--- a/src/main/java/mekanism/common/integration/computercraft/peripherals/DynamicTankPeripheral.java
+++ b/src/main/java/mekanism/common/integration/computercraft/peripherals/DynamicTankPeripheral.java
@@ -1,0 +1,55 @@
+package mekanism.common.integration.computercraft.peripherals;
+
+import dan200.computercraft.api.lua.LuaFunction;
+import dan200.computercraft.api.peripheral.IPeripheral;
+import mekanism.common.content.tank.TankMultiblockData;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class DynamicTankPeripheral implements IPeripheral {
+    private TankMultiblockData tank;
+
+    public DynamicTankPeripheral(TankMultiblockData tank) {
+        this.tank = tank;
+    }
+
+    public TankMultiblockData getTank() {
+        return tank;
+    }
+
+    @LuaFunction
+    public int getCapacity() {
+        return tank.getTankCapacity();
+    }
+
+    @LuaFunction
+    public long getAmount() {
+        switch (tank.mergedTank.getCurrentType()) {
+            case FLUID:
+                return tank.getFluidTank().getFluidAmount();
+            case GAS:
+                return tank.getGasTank().getStored();
+            case INFUSION:
+                return tank.getInfusionTank().getStored();
+            case PIGMENT:
+                return tank.getPigmentTank().getStored();
+            case SLURRY:
+                return tank.getSlurryTank().getStored();
+        }
+        return 0;
+    }
+
+    @NotNull
+    @Override
+    public String getType() {
+        return "dynamic_tank";
+    }
+
+    @Override
+    public boolean equals(@Nullable IPeripheral iPeripheral) {
+        if(iPeripheral instanceof DynamicTankPeripheral){
+            DynamicTankPeripheral tankPeripheral = (DynamicTankPeripheral) iPeripheral;
+            return tankPeripheral.getTank().equals(this.tank);
+        } else return false;
+    }
+}

--- a/src/main/java/mekanism/common/integration/computercraft/peripherals/InductionMatrixPeripheral.java
+++ b/src/main/java/mekanism/common/integration/computercraft/peripherals/InductionMatrixPeripheral.java
@@ -1,0 +1,65 @@
+package mekanism.common.integration.computercraft.peripherals;
+
+import dan200.computercraft.api.lua.LuaFunction;
+import dan200.computercraft.api.peripheral.IPeripheral;
+import mekanism.common.config.MekanismConfig;
+import mekanism.common.content.matrix.MatrixMultiblockData;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class InductionMatrixPeripheral implements IPeripheral {
+    private MatrixMultiblockData matrix;
+
+    public InductionMatrixPeripheral(MatrixMultiblockData matrix) {
+        this.matrix = matrix;
+
+    }
+
+    public MatrixMultiblockData getMatrix() {
+        return matrix;
+    }
+
+    @LuaFunction
+    public final Long getStoredEnergy(){
+        return matrix.getEnergy().multiply(MekanismConfig.general.TO_FORGE.get()).longValue();
+    }
+
+    @LuaFunction
+    public final Long getMaxEnergy(){
+        return matrix.getEnergyContainer().getMaxEnergy().multiply(MekanismConfig.general.TO_FORGE.get()).longValue();
+    }
+
+    @LuaFunction
+    public final Long getInputRate(){
+        return matrix.getLastInput().multiply(MekanismConfig.general.TO_FORGE.get()).longValue();
+    }
+
+    @LuaFunction
+    public final Long getOutputRate(){
+        return matrix.getLastOutput().multiply(MekanismConfig.general.TO_FORGE.get()).longValue();
+    }
+
+    @LuaFunction
+    public final Long getTransferCap(){
+        return matrix.getTransferCap().multiply(MekanismConfig.general.TO_FORGE.get()).longValue();
+    }
+
+    @LuaFunction
+    public final Long getStorageCap(){
+        return matrix.getStorageCap().multiply(MekanismConfig.general.TO_FORGE.get()).longValue();
+    }
+
+    @NotNull
+    @Override
+    public String getType() {
+        return "induction_matrix";
+    }
+
+    @Override
+    public boolean equals(@Nullable IPeripheral iPeripheral) {
+        if(iPeripheral instanceof InductionMatrixPeripheral){
+            InductionMatrixPeripheral inductionMatrixPeripheral = (InductionMatrixPeripheral) iPeripheral;
+            return inductionMatrixPeripheral.getMatrix().equals(matrix);
+        } else return false;
+    }
+}

--- a/src/main/java/mekanism/common/integration/computercraft/peripherals/SPSPeripheral.java
+++ b/src/main/java/mekanism/common/integration/computercraft/peripherals/SPSPeripheral.java
@@ -1,0 +1,59 @@
+package mekanism.common.integration.computercraft.peripherals;
+
+import dan200.computercraft.api.lua.LuaFunction;
+import dan200.computercraft.api.peripheral.IPeripheral;
+import mekanism.common.content.sps.SPSMultiblockData;
+import mekanism.common.content.tank.TankMultiblockData;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class SPSPeripheral implements IPeripheral {
+    private SPSMultiblockData sps;
+
+    public SPSPeripheral(SPSMultiblockData sps) {
+        this.sps = sps;
+    }
+
+    public SPSMultiblockData getSPS() {
+        return sps;
+    }
+
+    @LuaFunction
+    public long getInputCapacity() {
+        return sps.inputTank.getCapacity();
+    }
+
+    @LuaFunction
+    public long getOutputCapacity() {
+        return sps.outputTank.getCapacity();
+    }
+
+    @LuaFunction
+    public long getInputAmount() {
+        return sps.inputTank.getStored();
+    }
+
+    @LuaFunction
+    public long getOutputAmount() {
+        return sps.outputTank.getStored();
+    }
+
+    @LuaFunction
+    public double getProgress(){
+        return sps.progress;
+    }
+
+    @NotNull
+    @Override
+    public String getType() {
+        return "sps";
+    }
+
+    @Override
+    public boolean equals(@Nullable IPeripheral iPeripheral) {
+        if(iPeripheral instanceof SPSPeripheral){
+            SPSPeripheral spsPeripheral = (SPSPeripheral) iPeripheral;
+            return spsPeripheral.getSPS().equals(sps);
+        } else return false;
+    }
+}

--- a/src/main/java/mekanism/common/integration/computercraft/peripherals/ThermalEvaporationPeripheral.java
+++ b/src/main/java/mekanism/common/integration/computercraft/peripherals/ThermalEvaporationPeripheral.java
@@ -1,0 +1,63 @@
+package mekanism.common.integration.computercraft.peripherals;
+
+import dan200.computercraft.api.lua.LuaFunction;
+import dan200.computercraft.api.peripheral.IPeripheral;
+import mekanism.common.content.evaporation.EvaporationMultiblockData;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class ThermalEvaporationPeripheral implements IPeripheral {
+    private EvaporationMultiblockData thermalEvaporation;
+
+    public ThermalEvaporationPeripheral(EvaporationMultiblockData thermalEvaporation) {
+        this.thermalEvaporation = thermalEvaporation;
+    }
+
+    public EvaporationMultiblockData getThermalEvaporation() {
+        return thermalEvaporation;
+    }
+
+    @LuaFunction
+    public double getTemperature(){
+        return thermalEvaporation.getTemp();
+    }
+
+    @LuaFunction
+    public int getInputCapacity() {
+        return thermalEvaporation.inputTank.getCapacity();
+    }
+
+    @LuaFunction
+    public int getOutputCapacity() {
+        return thermalEvaporation.outputTank.getCapacity();
+    }
+
+    @LuaFunction
+    public int getInputAmount() {
+        return thermalEvaporation.inputTank.getFluidAmount();
+    }
+
+    @LuaFunction
+    public int getOutputAmount() {
+        return thermalEvaporation.outputTank.getFluidAmount();
+    }
+
+    @LuaFunction
+    public double getProductionRate() {
+        return thermalEvaporation.lastGain;
+    }
+
+    @NotNull
+    @Override
+    public String getType() {
+        return "thermal_evaporation";
+    }
+
+    @Override
+    public boolean equals(@Nullable IPeripheral iPeripheral) {
+        if(iPeripheral instanceof ThermalEvaporationPeripheral){
+            ThermalEvaporationPeripheral thermalEvaporationPeripheral = (ThermalEvaporationPeripheral) iPeripheral;
+            return thermalEvaporationPeripheral.getThermalEvaporation().equals(thermalEvaporation);
+        } else return false;
+    }
+}


### PR DESCRIPTION
Was frustrated when I couldn't make an induction matrix power display since normal Forge Energy API runs on ints and advanced cell in induction matrix is larger than int. So, I decided to add computercraft integration on my own, it's not much, supports only 5 multiblocks from main module, but at least that's a start. #6445 