### PR TITLE
Add Configuration Card support for Quantum Entangloporter

### DIFF
--- a/src/main/java/mekanism/common/lib/frequency/IFrequencyHandler.java
+++ b/src/main/java/mekanism/common/lib/frequency/IFrequencyHandler.java
@@ -16,6 +16,10 @@ public interface IFrequencyHandler extends ISecurityTile {
         getFrequencyComponent().setFrequencyFromData(type, data);
     }
 
+    default void unsetFrequency(FrequencyType<?> type) {
+        getFrequencyComponent().unsetFrequency(type);
+    }
+
     default void removeFrequency(FrequencyType<?> type, FrequencyIdentity data) {
         getFrequencyComponent().removeFrequencyFromData(type, data);
     }

--- a/src/main/java/mekanism/common/lib/frequency/TileComponentFrequency.java
+++ b/src/main/java/mekanism/common/lib/frequency/TileComponentFrequency.java
@@ -59,6 +59,12 @@ public class TileComponentFrequency implements ITileComponent {
         heldFrequencies.put(type, freq);
     }
 
+    public <FREQ extends Frequency> void unsetFrequency(FrequencyType<FREQ> type) {
+        deactivate(type);
+        heldFrequencies.remove(type);
+        setNeedsNotify(type);
+    }
+
     public <FREQ extends Frequency> List<FREQ> getPublicCache(FrequencyType<FREQ> type) {
         return (List<FREQ>) publicCache.computeIfAbsent(type, t -> new ArrayList<>());
     }

--- a/src/main/java/mekanism/common/tile/TileEntityQuantumEntangloporter.java
+++ b/src/main/java/mekanism/common/tile/TileEntityQuantumEntangloporter.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import mekanism.api.IConfigCardAccess.ISpecialConfigData;
 import mekanism.api.NBTConstants;
 import mekanism.api.RelativeSide;
 import mekanism.api.chemical.gas.Gas;
@@ -36,6 +37,7 @@ import mekanism.common.capabilities.holder.heat.IHeatCapacitorHolder;
 import mekanism.common.capabilities.holder.heat.QuantumEntangloporterHeatCapacitorHolder;
 import mekanism.common.capabilities.holder.slot.IInventorySlotHolder;
 import mekanism.common.capabilities.holder.slot.QuantumEntangloporterInventorySlotHolder;
+import mekanism.common.capabilities.resolver.BasicCapabilityResolver;
 import mekanism.common.content.entangloporter.InventoryFrequency;
 import mekanism.common.inventory.container.MekanismContainer;
 import mekanism.common.inventory.container.sync.SyncableDouble;
@@ -70,11 +72,12 @@ import mekanism.common.util.CapabilityUtils;
 import mekanism.common.util.ItemDataUtils;
 import mekanism.common.util.WorldUtils;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Direction;
 import net.minecraft.util.math.ChunkPos;
 
-public class TileEntityQuantumEntangloporter extends TileEntityMekanism implements ISideConfiguration, IFrequencyHandler, ISustainedData, IChunkLoader {
+public class TileEntityQuantumEntangloporter extends TileEntityMekanism implements ISideConfiguration, IFrequencyHandler, ISustainedData, IChunkLoader, ISpecialConfigData {
 
     public final TileComponentEjector ejectorComponent;
     public final TileComponentConfig configComponent;
@@ -111,6 +114,9 @@ public class TileEntityQuantumEntangloporter extends TileEntityMekanism implemen
 
         chunkLoaderComponent = new TileComponentChunkLoader<>(this);
         frequencyComponent.track(FrequencyType.INVENTORY, true, true, true);
+
+        addCapabilityResolver(BasicCapabilityResolver.constant(Capabilities.CONFIG_CARD_CAPABILITY, this));
+        addCapabilityResolver(BasicCapabilityResolver.constant(Capabilities.SPECIAL_CONFIG_DATA_CAPABILITY, this));
     }
 
     private <T> void setupConfig(TransmissionType type, ProxySlotInfoCreator<T> proxyCreator, Supplier<List<T>> supplier) {
@@ -288,5 +294,29 @@ public class TileEntityQuantumEntangloporter extends TileEntityMekanism implemen
         super.addContainerTrackers(container);
         container.track(SyncableDouble.create(this::getLastTransferLoss, value -> lastTransferLoss = value));
         container.track(SyncableDouble.create(this::getLastEnvironmentLoss, value -> lastEnvironmentLoss = value));
+    }
+
+    @Override
+    public CompoundNBT getConfigurationData(CompoundNBT nbtTags) {
+        InventoryFrequency freq = getFreq();
+        if (freq != null) {
+            nbtTags.put(NBTConstants.FREQUENCY, freq.serializeIdentity());
+        }
+        return nbtTags;
+    }
+
+    @Override
+    public void setConfigurationData(CompoundNBT nbtTags) {
+        FrequencyIdentity freq = FrequencyIdentity.load(FrequencyType.INVENTORY, nbtTags.getCompound(NBTConstants.FREQUENCY));
+        if (freq != null) {
+            setFrequency(FrequencyType.INVENTORY, freq);
+        } else {
+            unsetFrequency(FrequencyType.INVENTORY);
+        }
+    }
+
+    @Override
+    public String getDataType() {
+        return getBlockType().getTranslationKey();
     }
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add Configuration Card support for Quantum Entangloporter
- Add method to unset frequency for the above to work correctly when copying from a QE that does not have a frequency set

Hello, this is my first PR to Mekanism.
Let me know if the implementation is not desired (e.g. if Frequency shouldn't be copied or only copied if present and no "unset") or if there's some problems I missed due to low experience with code base.
I'm unsue if the `deactivate(type)` and `setNeedsNotify(type)` are required since the mek cables properly disconnect and reconnect without them, but were added to match with `setFrequencyFromData` just incase.