### PR TITLE
Increase Refined Obsidian harvest level to match netherite

### DIFF
--- a/src/tools/java/mekanism/tools/common/material/impl/RefinedObsidianMaterialDefaults.java
+++ b/src/tools/java/mekanism/tools/common/material/impl/RefinedObsidianMaterialDefaults.java
@@ -32,7 +32,7 @@ public class RefinedObsidianMaterialDefaults extends BaseMekanismMaterial {
 
     @Override
     public int getPaxelHarvestLevel() {
-        return 3;
+        return 4;
     }
 
     @Override
@@ -62,7 +62,7 @@ public class RefinedObsidianMaterialDefaults extends BaseMekanismMaterial {
 
     @Override
     public int getHarvestLevel() {
-        return 3;
+        return 4;
     }
 
     @Override


### PR DESCRIPTION
## Changes proposed in this pull request:
Increase Refined Obsidian harvest level to match netherite
Even though Refined Obsidian is faster and does more damage than netherite, it has a lower harvest level.