### PR TITLE
Change Resistive Heater efficiency from 60% to 100%

### DIFF
--- a/src/main/java/mekanism/common/config/GeneralConfig.java
+++ b/src/main/java/mekanism/common/config/GeneralConfig.java
@@ -133,7 +133,7 @@ public class GeneralConfig extends BaseMekanismConfig {
         heatPerFuelTick = CachedDoubleValue.wrap(this, builder.comment("Amount of heat produced per fuel tick of a fuel's burn time in the Fuelwood Heater.")
               .define("heatPerFuelTick", 400D));
         resistiveHeaterEfficiency = CachedDoubleValue.wrap(this, builder.comment("How much heat energy is created from one Joule of regular energy in the Resistive Heater.")
-              .defineInRange("resistiveHeaterEfficiency", 0.6, 0, 1));
+              .defineInRange("resistiveHeaterEfficiency", 1.0, 0, 1));
         superheatingHeatTransfer = CachedDoubleValue.wrap(this, builder.comment("Amount of heat each Boiler heating element produces.")
               .define("superheatingHeatTransfer", 16_000_000D));
         tempUnit = CachedEnumValue.wrap(this, builder.comment("Displayed temperature unit in Mekanism GUIs.")


### PR DESCRIPTION
## Changes proposed in this pull request:
Changing the Resistive Heater efficiency from 60% to 100%

In real life, resistive heaters are 100% efficient at converting electric energy to heat energy, and I saw in the Mekanism configuration that the default is 60%. Since this mod is to some extent realistic, I thought that this might be a welcome change.