### PR TITLE
Update Forge Maven

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     repositories {
         maven {
             name "forge"
-            url "https://files.minecraftforge.net/maven"
+            url "https://maven.minecraftforge.net/"
         }
     }
     dependencies {
@@ -282,7 +282,7 @@ minecraft {
 repositories {
     maven {
         name 'ForgeFS'
-        url 'https://files.minecraftforge.net/maven'
+        url 'https://maven.minecraftforge.net/'
         content {
             includeGroupByRegex 'net\\.minecraftforge.*'
             includeGroup 'de.oceanlabs.mcp'


### PR DESCRIPTION
Minecraft forge maven URI has changed. I follow steps given by forge-bot on the Forge Discord:
How to fix your gradle build
Forge has recently updated maven endpoints, which has caused a bug in Gradle because the old one now redirects. To fix this, follow the steps below.
1. Update all endpoints in your build.gradle
You should change all references of https://files.minecraftforge.net/maven in your build.gradle to the newer endpoint at https://maven.minecraftforge.net/.
2. Update your ForgeGradle version
The maven endpoint used in ForgeGradle is hardcoded. A fix has been pushed for FG 3 and 4, while FG 1 and 2 are unsupported. Please run gradlew --refresh-dependencies in a terminal inside the project to force Gradle to use the latest ForgeGradle version.

Source: https://discord.com/channels/313125603924639766/796838585797050428/835278480761421845

Note : The step 2 update local cache. So there no impact on the repo itself