### PR TITLE
Implement Fill Held toggle for Electrolytic Breathing Unit (reupload)

### DIFF
--- a/src/datagen/generated/mekanism/.cache/cache
+++ b/src/datagen/generated/mekanism/.cache/cache
@@ -23,8 +23,8 @@ d5bd6c407c9250a90e22e1f2c8805738b3830abf assets/mekanism/blockstates/lithium.jso
 c1be0ed56a542f711719367cf1e508f10063c695 assets/mekanism/blockstates/sulfuric_acid.json
 f5e3eb6799a15d0b72969547614dfc51dac53419 assets/mekanism/blockstates/tin_ore.json
 246c1904e7699b01a3a20f2a2b79b35b5d99aec9 assets/mekanism/blockstates/uranium_ore.json
-3007c55b61d0f98bfde05ef9563812c53723f77e assets/mekanism/lang/en_ud.json
-9db124f3360fc6b8399e39a6a24dcb9b4cd82a2d assets/mekanism/lang/en_us.json
+c54db2c07a4c96924eb1794b98eabfde09309f60 assets/mekanism/lang/en_ud.json
+1b9839f0d14bc1d1ad9db7997f5359dd4864997e assets/mekanism/lang/en_us.json
 beea3be5a8af802be66d456a7a648678bede0f02 assets/mekanism/models/block/brine.json
 beea3be5a8af802be66d456a7a648678bede0f02 assets/mekanism/models/block/chlorine.json
 beea3be5a8af802be66d456a7a648678bede0f02 assets/mekanism/models/block/ethene.json

--- a/src/datagen/generated/mekanism/assets/mekanism/lang/en_ud.json
+++ b/src/datagen/generated/mekanism/assets/mekanism/lang/en_ud.json
@@ -1046,6 +1046,7 @@
   "miner.mekanism.well": "\u00A1\uA781\uA781\u01DD\u028D s\u1D09 \uA781\uA781\u2C6F",
   "module.mekanism.attack_amplification_unit": "\u0287\u1D09u\u2229 uo\u1D09\u0287\u0250\u0254\u1D09\u025F\u1D09\uA781d\u026F\u2C6F \u029E\u0254\u0250\u0287\u0287\u2C6F",
   "module.mekanism.attack_damage": "\u01DD\u1D77\u0250\u026F\u0250\u15E1 \u029E\u0254\u0250\u0287\u0287\u2C6F",
+  "module.mekanism.breathing.held": "p\uA781\u01DDH \uA781\uA781\u1D09\u2132",
   "module.mekanism.charge_distribution_unit": "\u0287\u1D09u\u2229 uo\u1D09\u0287nq\u1D09\u0279\u0287s\u1D09\u15E1 \u01DD\u1D77\u0279\u0250\u0265\u0186",
   "module.mekanism.charge_inventory": "\u028E\u0279o\u0287u\u01DD\u028CuI \u01DD\u1D77\u0279\u0250\u0265\u0186",
   "module.mekanism.charge_suit": "\u0287\u1D09nS \u01DD\u1D77\u0279\u0250\u0265\u0186",

--- a/src/datagen/generated/mekanism/assets/mekanism/lang/en_us.json
+++ b/src/datagen/generated/mekanism/assets/mekanism/lang/en_us.json
@@ -1046,6 +1046,7 @@
   "miner.mekanism.well": "All is well!",
   "module.mekanism.attack_amplification_unit": "Attack Amplification Unit",
   "module.mekanism.attack_damage": "Attack Damage",
+  "module.mekanism.breathing.held": "Fill Held",
   "module.mekanism.charge_distribution_unit": "Charge Distribution Unit",
   "module.mekanism.charge_inventory": "Charge Inventory",
   "module.mekanism.charge_suit": "Charge Suit",

--- a/src/datagen/main/java/mekanism/client/lang/MekanismLangProvider.java
+++ b/src/datagen/main/java/mekanism/client/lang/MekanismLangProvider.java
@@ -1228,6 +1228,7 @@ public class MekanismLangProvider extends BaseLanguageProvider {
         add(MekanismLang.MODULE_CHARGE_INVENTORY, "Charge Inventory");
         add(MekanismLang.MODULE_SPEED_BOOST, "Speed Boost");
         add(MekanismLang.MODULE_VISION_ENHANCEMENT, "Vision Enhancement");
+        add(MekanismLang.MODULE_BREATHING_HELD, "Fill Held");
         add(MekanismLang.MODULE_PURIFICATION_BENEFICIAL, "Remove Beneficial");
         add(MekanismLang.MODULE_PURIFICATION_NEUTRAL, "Remove Neutral");
         add(MekanismLang.MODULE_PURIFICATION_HARMFUL, "Remove Harmful");

--- a/src/main/java/mekanism/common/MekanismLang.java
+++ b/src/main/java/mekanism/common/MekanismLang.java
@@ -769,6 +769,7 @@ public enum MekanismLang implements ILangEntry {
     MODULE_FARMING_UNIT("module", "farming_unit"),
     MODULE_TELEPORTATION_UNIT("module", "teleportation_unit"),
     MODULE_ELECTROLYTIC_BREATHING_UNIT("module", "electrolytic_breathing_unit"),
+    MODULE_BREATHING_HELD("module", "breathing.held"),
     MODULE_INHALATION_PURIFICATION_UNIT("module", "inhalation_purification_unit"),
     MODULE_VISION_ENHANCEMENT_UNIT("module", "vision_enhancement_unit"),
     MODULE_SOLAR_RECHARGING_UNIT("module", "solar_recharging_unit"),

--- a/src/main/java/mekanism/common/content/gear/mekasuit/ModuleMekaSuit.java
+++ b/src/main/java/mekanism/common/content/gear/mekasuit/ModuleMekaSuit.java
@@ -49,6 +49,14 @@ import net.minecraft.util.text.StringTextComponent;
 public abstract class ModuleMekaSuit extends Module {
 
     public static class ModuleElectrolyticBreathingUnit extends ModuleMekaSuit {
+    	
+    	private ModuleConfigItem<Boolean> fillHeld;
+    	
+    	 @Override
+         public void init() {
+             super.init();
+             addConfigItem(fillHeld = new ModuleConfigItem<>(this, "fill_held", MekanismLang.MODULE_BREATHING_HELD, new BooleanData(), true));
+         }
 
         @Override
         public void tickServer(PlayerEntity player) {
@@ -78,10 +86,12 @@ public abstract class ModuleMekaSuit extends Module {
                     hydrogenUsed = maxRate * 2L - chestCapability.get().insertChemical(hydrogenStack, Action.EXECUTE).getAmount();
                     hydrogenStack.shrink(hydrogenUsed);
                 }
-                ItemStack handStack = player.getItemBySlot(EquipmentSlotType.MAINHAND);
-                Optional<IGasHandler> handCapability = handStack.getCapability(Capabilities.GAS_HANDLER_CAPABILITY).resolve();
-                if (handCapability.isPresent()) {
-                    hydrogenUsed = maxRate * 2L - handCapability.get().insertChemical(hydrogenStack, Action.EXECUTE).getAmount();
+                if (fillHeld.get()) {
+                	ItemStack handStack = player.getItemBySlot(EquipmentSlotType.MAINHAND);
+                	Optional<IGasHandler> handCapability = handStack.getCapability(Capabilities.GAS_HANDLER_CAPABILITY).resolve();
+                	if (handCapability.isPresent()) {
+                		hydrogenUsed = maxRate * 2L - handCapability.get().insertChemical(hydrogenStack, Action.EXECUTE).getAmount();
+                	}
                 }
                 int oxygenUsed = Math.min(maxRate, player.getMaxAirSupply() - player.getAirSupply());
                 long used = Math.max((int) Math.ceil(hydrogenUsed / 2D), oxygenUsed);


### PR DESCRIPTION
## Changes proposed in this pull request:
Adds a toggle to the Electrolytic Breathing Unit that dictates whether it will attempt to fill held items with hydrogen, as described in [this feature request](https://github.com/mekanism/Mekanism-Feature-Requests/issues/230).
Originally created based on [the 1.16.x branch](https://github.com/mekanism/Mekanism/pull/7128), this PR is based on the v10.1 branch.