### PR TITLE
Avoid VisionEnhancement night vision flashing

### DIFF
--- a/src/main/java/mekanism/client/ClientTickHandler.java
+++ b/src/main/java/mekanism/client/ClientTickHandler.java
@@ -243,7 +243,7 @@ public class ClientTickHandler {
             if (isVisionEnhancementOn(minecraft.player)) {
                 visionEnhancement = true;
                 // adds if it doesn't exist, otherwise tops off duration to 200
-                minecraft.player.addPotionEffect(new EffectInstance(Effects.NIGHT_VISION, 200, 0, false, true, false));
+                minecraft.player.addPotionEffect(new EffectInstance(Effects.NIGHT_VISION, 300, 0, false, true, false));
             } else if (visionEnhancement) {
                 visionEnhancement = false;
                 minecraft.player.removePotionEffect(Effects.NIGHT_VISION);

--- a/src/main/java/mekanism/client/ClientTickHandler.java
+++ b/src/main/java/mekanism/client/ClientTickHandler.java
@@ -242,8 +242,8 @@ public class ClientTickHandler {
 
             if (isVisionEnhancementOn(minecraft.player)) {
                 visionEnhancement = true;
-                // adds if it doesn't exist, otherwise tops off duration to 200
-                minecraft.player.addPotionEffect(new EffectInstance(Effects.NIGHT_VISION, 300, 0, false, true, false));
+                // adds if it doesn't exist, otherwise tops off duration to 220. equal or less than 200 will make vision flickers
+                minecraft.player.addPotionEffect(new EffectInstance(Effects.NIGHT_VISION, 220, 0, false, true, false));
             } else if (visionEnhancement) {
                 visionEnhancement = false;
                 minecraft.player.removePotionEffect(Effects.NIGHT_VISION);


### PR DESCRIPTION
Change VisionEnhancement night vision effect to 15s (300 tick) to avoid flashing.
