### PR TITLE
Fix an issue with networks not merging correctly

### DIFF
--- a/src/main/java/mekanism/common/lib/transmitter/TransmitterNetworkRegistry.java
+++ b/src/main/java/mekanism/common/lib/transmitter/TransmitterNetworkRegistry.java
@@ -176,6 +176,7 @@ public class TransmitterNetworkRegistry {
                 if (MekanismAPI.debug) {
                     Mekanism.logger.info("Merging {} networks with {} new transmitters", finder.networksFound.size(), finder.connectedTransmitters.size());
                 }
+                commitChanges();
                 network = finder.createNetworkByMerging();
         }
         network.addNewTransmitters(finder.connectedTransmitters);


### PR DESCRIPTION
It's possible for 2 networks to merge when being scheduled for a change (being in networksToChange set) completely neglecting the change.

We should update networks scheduled for a change before merging them.