### PR TITLE
Set annotation-processor Java version to java 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ MDK.zip
 /.gradle
 *.classpath
 *.project
-/.settings
+.settings
 /eclipse
 *.txt
 *.launch
@@ -22,3 +22,4 @@ MDK.zip
 /bin
 /logs
 /src/datagen/main/resources
+/annotation-processor/bin

--- a/annotation-processor/build.gradle
+++ b/annotation-processor/build.gradle
@@ -4,6 +4,7 @@ plugins {
 
 group 'mekanism.annotation-processor'
 version '1.0'
+java.toolchain.languageVersion = JavaLanguageVersion.of(8)
 
 repositories {
     maven {


### PR DESCRIPTION
## Changes proposed in this pull request:
Currently the annotation processor uses whatever java version gradle prefers, in my case that is Java 16.
However the main project uses Java 8, and thus fails when trying to use the Java 16 compiled binaries from the annotation processor.
This PR fixes this.