### PR TITLE
Fix a variety of issues relating to temperature

### DIFF
--- a/src/api/java/mekanism/api/heat/HeatAPI.java
+++ b/src/api/java/mekanism/api/heat/HeatAPI.java
@@ -1,5 +1,6 @@
 package mekanism.api.heat;
 
+import javax.annotation.Nullable;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IWorldReader;
 
@@ -36,7 +37,7 @@ public class HeatAPI {
      * Gets the atmospheric temperature at a given spot in the specified world based on the biome's temperature modifier at that position. The baseline temperature
      * modifier is taken to be the plains biome, or a biome with a temperature modifier of 0.8.
      *
-     * @param world World.
+     * @param world World; if {@code null} {@link #AMBIENT_TEMP} is returned instead.
      * @param pos   Position in the world.
      *
      * @return Atmospheric temperature at the given position.
@@ -44,7 +45,11 @@ public class HeatAPI {
      * @implNote This method is a helper to call {@link #getAmbientTemp(double)} using the temperature of the biome at the location specified.
      * @see #AMBIENT_TEMP
      */
-    public static double getAmbientTemp(IWorldReader world, BlockPos pos) {
+    public static double getAmbientTemp(@Nullable IWorldReader world, BlockPos pos) {
+        if (world == null) {
+            return AMBIENT_TEMP;
+        }
+        //TODO - 10.1: Do we need to do checks about if the position is loaded (and if the position is in the world?, for example not above max y)
         return getAmbientTemp(world.getBiome(pos).getTemperature(pos));
     }
 
@@ -65,7 +70,6 @@ public class HeatAPI {
         //See implementation note about this range. If any other mods do have valid more extreme temperatures,
         // we may want to consider expanding this range to [-10, 10]
         biomeTemp = Math.max(Math.min(biomeTemp, 5), -5);
-        //TODO: Make use of this and the other getAmbientTemp helper in more places than just evaporation multiblocks
         return AMBIENT_TEMP + 25 * (biomeTemp - 0.8);
     }
 

--- a/src/api/java/mekanism/api/heat/HeatAPI.java
+++ b/src/api/java/mekanism/api/heat/HeatAPI.java
@@ -49,7 +49,6 @@ public class HeatAPI {
         if (world == null) {
             return AMBIENT_TEMP;
         }
-        //TODO - 10.1: Do we need to do checks about if the position is loaded (and if the position is in the world?, for example not above max y)
         return getAmbientTemp(world.getBiome(pos).getTemperature(pos));
     }
 

--- a/src/generators/java/mekanism/generators/common/content/gear/mekasuit/ModuleGeothermalGeneratorUnit.java
+++ b/src/generators/java/mekanism/generators/common/content/gear/mekasuit/ModuleGeothermalGeneratorUnit.java
@@ -45,7 +45,7 @@ public class ModuleGeothermalGeneratorUnit implements ICustomModule<ModuleGeothe
                 }
                 //Divide the temperature by how many positions there are in case there is a difference due to the position in the world
                 // Strictly speaking we should take the height of the position into account for calculating the average as a "weighted"
-                // average, but we don't worry about that as it is highly unlikely the positions will actually have different temperatures
+                // average, but we don't worry about that as it is highly unlikely the positions will actually have different temperatures,
                 // and it would add a bunch of complexity to the calculations to account for it
                 temperature /= positions.size();
                 if (temperature > HeatAPI.AMBIENT_TEMP) {

--- a/src/generators/java/mekanism/generators/common/tile/fission/TileEntityFissionReactorPort.java
+++ b/src/generators/java/mekanism/generators/common/tile/fission/TileEntityFissionReactorPort.java
@@ -9,6 +9,7 @@ import mekanism.api.chemical.gas.GasStack;
 import mekanism.api.chemical.gas.IGasTank;
 import mekanism.api.heat.IHeatHandler;
 import mekanism.common.MekanismLang;
+import mekanism.common.capabilities.heat.CachedAmbientTemperature;
 import mekanism.common.capabilities.holder.chemical.IChemicalTankHolder;
 import mekanism.common.capabilities.holder.fluid.IFluidTankHolder;
 import mekanism.common.capabilities.holder.heat.IHeatCapacitorHolder;
@@ -73,7 +74,7 @@ public class TileEntityFissionReactorPort extends TileEntityFissionReactorCasing
 
     @Nonnull
     @Override
-    protected IHeatCapacitorHolder getInitialHeatCapacitors() {
+    protected IHeatCapacitorHolder getInitialHeatCapacitors(CachedAmbientTemperature ambientTemperature) {
         return side -> getMultiblock().getHeatCapacitors(side);
     }
 

--- a/src/generators/java/mekanism/generators/common/tile/fusion/TileEntityFusionReactorPort.java
+++ b/src/generators/java/mekanism/generators/common/tile/fusion/TileEntityFusionReactorPort.java
@@ -9,6 +9,7 @@ import mekanism.api.chemical.gas.GasStack;
 import mekanism.api.chemical.gas.IGasTank;
 import mekanism.api.heat.IHeatHandler;
 import mekanism.common.capabilities.Capabilities;
+import mekanism.common.capabilities.heat.CachedAmbientTemperature;
 import mekanism.common.capabilities.holder.chemical.IChemicalTankHolder;
 import mekanism.common.capabilities.holder.energy.IEnergyContainerHolder;
 import mekanism.common.capabilities.holder.fluid.IFluidTankHolder;
@@ -59,7 +60,7 @@ public class TileEntityFusionReactorPort extends TileEntityFusionReactorBlock im
 
     @Nonnull
     @Override
-    protected IHeatCapacitorHolder getInitialHeatCapacitors() {
+    protected IHeatCapacitorHolder getInitialHeatCapacitors(CachedAmbientTemperature ambientTemperature) {
         return side -> getMultiblock().getHeatCapacitors(side);
     }
 

--- a/src/main/java/mekanism/client/gui/GuiThermalEvaporationController.java
+++ b/src/main/java/mekanism/client/gui/GuiThermalEvaporationController.java
@@ -35,7 +35,7 @@ public class GuiThermalEvaporationController extends GuiMekanismTile<TileEntityT
         addButton(new GuiInnerScreen(this, 48, 19, 80, 40, () -> {
             EvaporationMultiblockData multiblock = tile.getMultiblock();
             return Arrays.asList(MekanismLang.MULTIBLOCK_FORMED.translate(), MekanismLang.EVAPORATION_HEIGHT.translate(multiblock.height()),
-                  MekanismLang.TEMPERATURE.translate(MekanismUtils.getTemperatureDisplay(multiblock.getTemp(), TemperatureUnit.KELVIN, true)),
+                  MekanismLang.TEMPERATURE.translate(MekanismUtils.getTemperatureDisplay(multiblock.getTemperature(), TemperatureUnit.KELVIN, true)),
                   MekanismLang.FLUID_PRODUCTION.translate(Math.round(multiblock.lastGain * 100D) / 100D));
         }).spacing(1).jeiCategory(tile));
         addButton(new GuiDownArrow(this, 32, 39));
@@ -43,18 +43,18 @@ public class GuiThermalEvaporationController extends GuiMekanismTile<TileEntityT
         addButton(new GuiHorizontalRateBar(this, new IBarInfoHandler() {
             @Override
             public ITextComponent getTooltip() {
-                return MekanismUtils.getTemperatureDisplay(tile.getMultiblock().getTemp(), TemperatureUnit.KELVIN, true);
+                return MekanismUtils.getTemperatureDisplay(tile.getMultiblock().getTemperature(), TemperatureUnit.KELVIN, true);
             }
 
             @Override
             public double getLevel() {
-                return Math.min(1, tile.getMultiblock().getTemp() / EvaporationMultiblockData.MAX_MULTIPLIER_TEMP);
+                return Math.min(1, tile.getMultiblock().getTemperature() / EvaporationMultiblockData.MAX_MULTIPLIER_TEMP);
             }
         }, 48, 63));
         addButton(new GuiFluidGauge(() -> tile.getMultiblock().inputTank, () -> tile.getMultiblock().getFluidTanks(null), GaugeType.STANDARD, this, 6, 13));
         addButton(new GuiFluidGauge(() -> tile.getMultiblock().outputTank, () -> tile.getMultiblock().getFluidTanks(null), GaugeType.STANDARD, this, 152, 13));
         addButton(new GuiHeatTab(this, () -> {
-            ITextComponent environment = MekanismUtils.getTemperatureDisplay(tile.getMultiblock().totalLoss, TemperatureUnit.KELVIN, false);
+            ITextComponent environment = MekanismUtils.getTemperatureDisplay(tile.getMultiblock().lastEnvironmentLoss, TemperatureUnit.KELVIN, false);
             return Collections.singletonList(MekanismLang.DISSIPATED_RATE.translate(environment));
         }));
     }

--- a/src/main/java/mekanism/common/capabilities/heat/CachedAmbientTemperature.java
+++ b/src/main/java/mekanism/common/capabilities/heat/CachedAmbientTemperature.java
@@ -1,0 +1,45 @@
+package mekanism.common.capabilities.heat;
+
+import java.util.Arrays;
+import java.util.function.DoubleSupplier;
+import java.util.function.Supplier;
+import javax.annotation.Nullable;
+import mekanism.api.heat.HeatAPI;
+import mekanism.common.util.EnumUtils;
+import net.minecraft.util.Direction;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+public class CachedAmbientTemperature implements DoubleSupplier {
+
+    private final double[] ambientTemperature = new double[EnumUtils.DIRECTIONS.length + 1];
+    private final Supplier<World> worldSupplier;
+    private final Supplier<BlockPos> positionSupplier;
+
+    public CachedAmbientTemperature(Supplier<World> worldSupplier, Supplier<BlockPos> positionSupplier) {
+        this.worldSupplier = worldSupplier;
+        this.positionSupplier = positionSupplier;
+        Arrays.fill(ambientTemperature, -1);
+    }
+
+    @Override
+    public double getAsDouble() {
+        return getTemperature(null);
+    }
+
+    public double getTemperature(@Nullable Direction side) {
+        int index = side == null ? EnumUtils.DIRECTIONS.length : side.ordinal();
+        double biomeAmbientTemp = ambientTemperature[index];
+        if (biomeAmbientTemp == -1) {
+            World world = worldSupplier.get();
+            if (world != null) {
+                BlockPos pos = positionSupplier.get();
+                if (side != null) {
+                    pos = pos.relative(side);
+                }
+                return ambientTemperature[index] = HeatAPI.getAmbientTemp(world, pos);
+            }
+        }
+        return HeatAPI.AMBIENT_TEMP;
+    }
+}

--- a/src/main/java/mekanism/common/capabilities/heat/CachedAmbientTemperature.java
+++ b/src/main/java/mekanism/common/capabilities/heat/CachedAmbientTemperature.java
@@ -32,14 +32,15 @@ public class CachedAmbientTemperature implements DoubleSupplier {
         double biomeAmbientTemp = ambientTemperature[index];
         if (biomeAmbientTemp == -1) {
             World world = worldSupplier.get();
-            if (world != null) {
-                BlockPos pos = positionSupplier.get();
-                if (side != null) {
-                    pos = pos.relative(side);
-                }
-                return ambientTemperature[index] = HeatAPI.getAmbientTemp(world, pos);
+            if (world == null) {
+                return HeatAPI.AMBIENT_TEMP;
             }
+            BlockPos pos = positionSupplier.get();
+            if (side != null) {
+                pos = pos.relative(side);
+            }
+            return ambientTemperature[index] = HeatAPI.getAmbientTemp(world, pos);
         }
-        return HeatAPI.AMBIENT_TEMP;
+        return biomeAmbientTemp;
     }
 }

--- a/src/main/java/mekanism/common/capabilities/heat/ITileHeatHandler.java
+++ b/src/main/java/mekanism/common/capabilities/heat/ITileHeatHandler.java
@@ -66,13 +66,12 @@ public interface ITileHeatHandler extends IMekanismHeatHandler {
         double adjacentTransfer = 0;
         for (Direction side : EnumUtils.DIRECTIONS) {
             IHeatHandler sink = getAdjacent(side);
-            //we use the same heat capacity for all further calculations
-            double heatCapacity = getTotalHeatCapacity(side);
             if (sink != null) {
                 double invConduction = sink.getTotalInverseConduction() + getTotalInverseConductionCoefficient(side);
                 double tempToTransfer = (getTotalTemperature(side) - sink.getTotalTemperature()) / invConduction;
-                handleHeat(-tempToTransfer * heatCapacity, side);
-                sink.handleHeat(tempToTransfer * heatCapacity);
+                handleHeat(-tempToTransfer * getTotalHeatCapacity(side), side);
+                //Note: Our sinks in mek are "lazy" but they will update the next tick if needed
+                sink.handleHeat(tempToTransfer * sink.getTotalHeatCapacity());
                 if (!(sink instanceof TileEntityTransmitter) || !TransmissionType.HEAT.checkTransmissionType((TileEntityTransmitter) sink)) {
                     adjacentTransfer += tempToTransfer;
                 }

--- a/src/main/java/mekanism/common/capabilities/heat/ITileHeatHandler.java
+++ b/src/main/java/mekanism/common/capabilities/heat/ITileHeatHandler.java
@@ -44,6 +44,10 @@ public interface ITileHeatHandler extends IMekanismHeatHandler {
         return new HeatTransfer(simulateAdjacent(), simulateEnvironment());
     }
 
+    default double getAmbientTemperature(Direction side) {
+        return HeatAPI.AMBIENT_TEMP;
+    }
+
     default double simulateEnvironment() {
         double environmentTransfer = 0;
         for (Direction side : EnumUtils.DIRECTIONS) {
@@ -51,7 +55,7 @@ public interface ITileHeatHandler extends IMekanismHeatHandler {
             //transfer to air otherwise
             double invConduction = HeatAPI.AIR_INVERSE_COEFFICIENT + getTotalInverseInsulation(side) + getTotalInverseConductionCoefficient(side);
             //transfer heat difference based on environment temperature (ambient)
-            double tempToTransfer = (getTotalTemperature(side) - HeatAPI.AMBIENT_TEMP) / invConduction;
+            double tempToTransfer = (getTotalTemperature(side) - getAmbientTemperature(side)) / invConduction;
             handleHeat(-tempToTransfer * heatCapacity, side);
             environmentTransfer += tempToTransfer;
         }
@@ -66,7 +70,7 @@ public interface ITileHeatHandler extends IMekanismHeatHandler {
             double heatCapacity = getTotalHeatCapacity(side);
             if (sink != null) {
                 double invConduction = sink.getTotalInverseConduction() + getTotalInverseConductionCoefficient(side);
-                double tempToTransfer = (getTotalTemperature(side) - HeatAPI.AMBIENT_TEMP) / invConduction;
+                double tempToTransfer = (getTotalTemperature(side) - sink.getTotalTemperature()) / invConduction;
                 handleHeat(-tempToTransfer * heatCapacity, side);
                 sink.handleHeat(tempToTransfer * heatCapacity);
                 if (!(sink instanceof TileEntityTransmitter) || !TransmissionType.HEAT.checkTransmissionType((TileEntityTransmitter) sink)) {

--- a/src/main/java/mekanism/common/capabilities/heat/MultiblockHeatCapacitor.java
+++ b/src/main/java/mekanism/common/capabilities/heat/MultiblockHeatCapacitor.java
@@ -2,6 +2,7 @@ package mekanism.common.capabilities.heat;
 
 import java.util.Objects;
 import java.util.function.DoubleSupplier;
+import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import mcp.MethodsReturnNonnullByDefault;
 import mekanism.api.annotations.FieldsAreNonnullByDefault;
@@ -18,20 +19,20 @@ public class MultiblockHeatCapacitor<MULTIBLOCK extends MultiblockData> extends 
     protected final TileEntityMultiblock<MULTIBLOCK> tile;
 
     public static <MULTIBLOCK extends MultiblockData> MultiblockHeatCapacitor<MULTIBLOCK> create(MULTIBLOCK multiblock, TileEntityMultiblock<MULTIBLOCK> tile,
-          double heatCapacity) {
-        return create(multiblock, tile, heatCapacity, () -> HeatAPI.DEFAULT_INVERSE_CONDUCTION, () -> HeatAPI.DEFAULT_INVERSE_INSULATION);
+          double heatCapacity, @Nullable DoubleSupplier ambientTempSupplier) {
+        return create(multiblock, tile, heatCapacity, () -> HeatAPI.DEFAULT_INVERSE_CONDUCTION, () -> HeatAPI.DEFAULT_INVERSE_INSULATION, ambientTempSupplier);
     }
 
     public static <MULTIBLOCK extends MultiblockData> MultiblockHeatCapacitor<MULTIBLOCK> create(MULTIBLOCK multiblock, TileEntityMultiblock<MULTIBLOCK> tile,
-          double heatCapacity, DoubleSupplier conductionCoefficient, DoubleSupplier insulationCoefficient) {
+          double heatCapacity, DoubleSupplier conductionCoefficient, DoubleSupplier insulationCoefficient, @Nullable DoubleSupplier ambientTempSupplier) {
         Objects.requireNonNull(conductionCoefficient, "Conduction coefficient supplier cannot be null");
         Objects.requireNonNull(insulationCoefficient, "Insulation coefficient supplier cannot be null");
-        return new MultiblockHeatCapacitor<>(multiblock, tile, heatCapacity, conductionCoefficient, insulationCoefficient);
+        return new MultiblockHeatCapacitor<>(multiblock, tile, heatCapacity, conductionCoefficient, insulationCoefficient, ambientTempSupplier);
     }
 
     protected MultiblockHeatCapacitor(MULTIBLOCK multiblock, TileEntityMultiblock<MULTIBLOCK> tile, double heatCapacity, DoubleSupplier conductionCoefficient,
-          DoubleSupplier insulationCoefficient) {
-        super(heatCapacity, conductionCoefficient, insulationCoefficient, null);
+          DoubleSupplier insulationCoefficient, @Nullable DoubleSupplier ambientTempSupplier) {
+        super(heatCapacity, conductionCoefficient, insulationCoefficient, ambientTempSupplier, null);
         this.multiblock = multiblock;
         this.tile = tile;
     }

--- a/src/main/java/mekanism/common/capabilities/heat/VariableHeatCapacitor.java
+++ b/src/main/java/mekanism/common/capabilities/heat/VariableHeatCapacitor.java
@@ -16,13 +16,13 @@ public class VariableHeatCapacitor extends BasicHeatCapacitor {
     private final DoubleSupplier conductionCoefficientSupplier;
     private final DoubleSupplier insulationCoefficientSupplier;
 
-    public static VariableHeatCapacitor create(double heatCapacity, boolean absorbHeat, boolean emitHeat, @Nullable IContentsListener listener) {
-        return new VariableHeatCapacitor(heatCapacity, () -> HeatAPI.DEFAULT_INVERSE_CONDUCTION, () -> HeatAPI.DEFAULT_INVERSE_INSULATION, listener);
+    public static VariableHeatCapacitor create(double heatCapacity, @Nullable DoubleSupplier ambientTempSupplier, @Nullable IContentsListener listener) {
+        return new VariableHeatCapacitor(heatCapacity, () -> HeatAPI.DEFAULT_INVERSE_CONDUCTION, () -> HeatAPI.DEFAULT_INVERSE_INSULATION, ambientTempSupplier, listener);
     }
 
     protected VariableHeatCapacitor(double heatCapacity, DoubleSupplier conductionCoefficient, DoubleSupplier insulationCoefficient,
-          @Nullable IContentsListener listener) {
-        super(heatCapacity, conductionCoefficient.getAsDouble(), insulationCoefficient.getAsDouble(), listener);
+          @Nullable DoubleSupplier ambientTempSupplier, @Nullable IContentsListener listener) {
+        super(heatCapacity, conductionCoefficient.getAsDouble(), insulationCoefficient.getAsDouble(), ambientTempSupplier, listener);
         this.conductionCoefficientSupplier = conductionCoefficient;
         this.insulationCoefficientSupplier = insulationCoefficient;
     }

--- a/src/main/java/mekanism/common/capabilities/heat/VariableHeatCapacitor.java
+++ b/src/main/java/mekanism/common/capabilities/heat/VariableHeatCapacitor.java
@@ -17,7 +17,12 @@ public class VariableHeatCapacitor extends BasicHeatCapacitor {
     private final DoubleSupplier insulationCoefficientSupplier;
 
     public static VariableHeatCapacitor create(double heatCapacity, @Nullable DoubleSupplier ambientTempSupplier, @Nullable IContentsListener listener) {
-        return new VariableHeatCapacitor(heatCapacity, () -> HeatAPI.DEFAULT_INVERSE_CONDUCTION, () -> HeatAPI.DEFAULT_INVERSE_INSULATION, ambientTempSupplier, listener);
+        return create(heatCapacity, () -> HeatAPI.DEFAULT_INVERSE_CONDUCTION, () -> HeatAPI.DEFAULT_INVERSE_INSULATION, ambientTempSupplier, listener);
+    }
+
+    public static VariableHeatCapacitor create(double heatCapacity, DoubleSupplier conductionCoefficient, DoubleSupplier insulationCoefficient,
+          @Nullable DoubleSupplier ambientTempSupplier, @Nullable IContentsListener listener) {
+        return new VariableHeatCapacitor(heatCapacity, conductionCoefficient, insulationCoefficient, ambientTempSupplier, listener);
     }
 
     protected VariableHeatCapacitor(double heatCapacity, DoubleSupplier conductionCoefficient, DoubleSupplier insulationCoefficient,

--- a/src/main/java/mekanism/common/content/entangloporter/InventoryFrequency.java
+++ b/src/main/java/mekanism/common/content/entangloporter/InventoryFrequency.java
@@ -28,6 +28,7 @@ import mekanism.api.energy.IEnergyContainer;
 import mekanism.api.energy.IMekanismStrictEnergyHandler;
 import mekanism.api.fluid.IExtendedFluidTank;
 import mekanism.api.fluid.IMekanismFluidHandler;
+import mekanism.api.heat.HeatAPI;
 import mekanism.api.heat.IHeatCapacitor;
 import mekanism.api.inventory.AutomationType;
 import mekanism.api.inventory.IInventorySlot;
@@ -111,7 +112,8 @@ public class InventoryFrequency extends Frequency implements IMekanismInventory,
         slurryTanks = Collections.singletonList(storedSlurry = ChemicalTankBuilder.SLURRY.create(MekanismConfig.general.entangloporterChemicalBuffer.get(), this));
         inventorySlots = Collections.singletonList(storedItem = EntangloporterInventorySlot.create(this));
         energyContainers = Collections.singletonList(storedEnergy = BasicEnergyContainer.create(MekanismConfig.general.entangloporterEnergyBuffer.get(), this));
-        heatCapacitors = Collections.singletonList(storedHeat = BasicHeatCapacitor.create(1, 1, 1_000, this));
+        heatCapacitors = Collections.singletonList(storedHeat = BasicHeatCapacitor.create(HeatAPI.DEFAULT_HEAT_CAPACITY, HeatAPI.DEFAULT_INVERSE_CONDUCTION,
+              1_000, null, this));
     }
 
     @Override

--- a/src/main/java/mekanism/common/content/network/HeatNetwork.java
+++ b/src/main/java/mekanism/common/content/network/HeatNetwork.java
@@ -48,11 +48,15 @@ public class HeatNetwork extends DynamicNetwork<IHeatHandler, HeatNetwork, Therm
         super.onUpdate();
         double newSumTemp = 0, newHeatLost = 0, newHeatTransferred = 0;
         for (ThermodynamicConductor transmitter : transmitters) {
-            // change this when we re-integrate with multipart
             HeatTransfer transfer = transmitter.simulate();
-            transmitter.updateHeatCapacitors(null);
             newHeatTransferred += transfer.getAdjacentTransfer();
             newHeatLost += transfer.getEnvironmentTransfer();
+        }
+        //After we updated the heat values of all the transmitters, we need to update the temperatures
+        // we do this after instead of when iterating initially so that if heat is transferred from one
+        // conductor to one we already updated then we want it to have the proper total temperaturer
+        for (ThermodynamicConductor transmitter : transmitters) {
+            transmitter.updateHeatCapacitors(null);
             newSumTemp += transmitter.getTotalTemperature();
         }
         heatLost = newHeatLost;

--- a/src/main/java/mekanism/common/content/network/transmitter/ThermodynamicConductor.java
+++ b/src/main/java/mekanism/common/content/network/transmitter/ThermodynamicConductor.java
@@ -13,9 +13,9 @@ import mekanism.api.heat.IHeatHandler;
 import mekanism.api.providers.IBlockProvider;
 import mekanism.common.block.attribute.Attribute;
 import mekanism.common.capabilities.Capabilities;
-import mekanism.common.capabilities.heat.BasicHeatCapacitor;
 import mekanism.common.capabilities.heat.CachedAmbientTemperature;
 import mekanism.common.capabilities.heat.ITileHeatHandler;
+import mekanism.common.capabilities.heat.VariableHeatCapacitor;
 import mekanism.common.content.network.HeatNetwork;
 import mekanism.common.lib.Color;
 import mekanism.common.lib.transmitter.TransmissionType;
@@ -38,7 +38,7 @@ public class ThermodynamicConductor extends Transmitter<IHeatHandler, HeatNetwor
     //Default to negative one, so we know we need to calculate it when needed
     private double clientTemperature = -1;
     private final List<IHeatCapacitor> capacitors;
-    public final BasicHeatCapacitor buffer;
+    public final VariableHeatCapacitor buffer;
 
     public ThermodynamicConductor(IBlockProvider blockProvider, TileEntityTransmitter tile) {
         super(tile, TransmissionType.HEAT);

--- a/src/main/java/mekanism/common/content/network/transmitter/ThermodynamicConductor.java
+++ b/src/main/java/mekanism/common/content/network/transmitter/ThermodynamicConductor.java
@@ -43,7 +43,7 @@ public class ThermodynamicConductor extends Transmitter<IHeatHandler, HeatNetwor
     public ThermodynamicConductor(IBlockProvider blockProvider, TileEntityTransmitter tile) {
         super(tile, TransmissionType.HEAT);
         this.tier = Attribute.getTier(blockProvider, ConductorTier.class);
-        buffer = BasicHeatCapacitor.create(tier.getHeatCapacity(), tier.getInverseConduction(), tier.getInverseConductionInsulation(), ambientTemperature, this);
+        buffer = VariableHeatCapacitor.create(tier.getHeatCapacity(), tier::getInverseConduction, tier::getInverseConductionInsulation, ambientTemperature, this);
         capacitors = Collections.singletonList(buffer);
     }
 

--- a/src/main/java/mekanism/common/lib/multiblock/MultiblockCache.java
+++ b/src/main/java/mekanism/common/lib/multiblock/MultiblockCache.java
@@ -315,7 +315,7 @@ public class MultiblockCache<T extends MultiblockData> implements IMekanismInven
         public static final CacheSubstance<IMekanismHeatHandler, IHeatCapacitor> HEAT = new CacheSubstance<IMekanismHeatHandler, IHeatCapacitor>(NBTConstants.HEAT_CAPACITORS) {
             @Override
             protected void defaultPrefab(MultiblockCache<?> cache) {
-                cache.heatCapacitors.add(BasicHeatCapacitor.create(HeatAPI.DEFAULT_HEAT_CAPACITY, cache));
+                cache.heatCapacitors.add(BasicHeatCapacitor.create(HeatAPI.DEFAULT_HEAT_CAPACITY, null, cache));
             }
 
             @Override

--- a/src/main/java/mekanism/common/lib/multiblock/MultiblockData.java
+++ b/src/main/java/mekanism/common/lib/multiblock/MultiblockData.java
@@ -22,6 +22,7 @@ import mekanism.api.energy.IEnergyContainer;
 import mekanism.api.energy.IMekanismStrictEnergyHandler;
 import mekanism.api.fluid.IExtendedFluidTank;
 import mekanism.api.fluid.IMekanismFluidHandler;
+import mekanism.api.heat.HeatAPI;
 import mekanism.api.heat.IHeatCapacitor;
 import mekanism.api.inventory.IInventorySlot;
 import mekanism.api.inventory.IMekanismInventory;
@@ -131,6 +132,12 @@ public class MultiblockData implements IMekanismInventory, IMekanismFluidHandler
             data.prevActive = data.activeTicks > 0;
         }
         return needsPacket;
+    }
+
+    protected double calculateAverageAmbientTemperature(World world) {
+        //Take a rough average of the biome temperature between the min and max positions of the multiblock
+        double biomeTemp = (world.getBiome(getMinPos()).getTemperature(getMinPos()) + world.getBiome(getMaxPos()).getTemperature(getMaxPos())) / 2;
+        return HeatAPI.getAmbientTemp(biomeTemp);
     }
 
     public boolean setShape(IShape shape) {

--- a/src/main/java/mekanism/common/lib/multiblock/MultiblockData.java
+++ b/src/main/java/mekanism/common/lib/multiblock/MultiblockData.java
@@ -2,6 +2,7 @@ package mekanism.common.lib.multiblock;
 
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -135,9 +136,26 @@ public class MultiblockData implements IMekanismInventory, IMekanismFluidHandler
     }
 
     protected double calculateAverageAmbientTemperature(World world) {
-        //Take a rough average of the biome temperature between the min and max positions of the multiblock
-        double biomeTemp = (world.getBiome(getMinPos()).getTemperature(getMinPos()) + world.getBiome(getMaxPos()).getTemperature(getMaxPos())) / 2;
-        return HeatAPI.getAmbientTemp(biomeTemp);
+        //Take a rough average of the biome temperature by calculating the average of all the corners of the multiblock
+        BlockPos min = getMinPos();
+        BlockPos max = getMaxPos();
+        return HeatAPI.getAmbientTemp(getBiomeTemp(world,
+              min,
+              new BlockPos(max.getX(), min.getY(), min.getZ()),
+              new BlockPos(min.getX(), min.getY(), max.getZ()),
+              new BlockPos(max.getX(), min.getY(), max.getZ()),
+              new BlockPos(min.getX(), max.getY(), min.getZ()),
+              new BlockPos(max.getX(), max.getY(), min.getZ()),
+              new BlockPos(min.getX(), max.getY(), max.getZ()),
+              max
+        ));
+    }
+
+    private static double getBiomeTemp(World world, BlockPos... positions) {
+        if (positions.length == 0) {
+            throw new IllegalArgumentException("No positions given.");
+        }
+        return Arrays.stream(positions).mapToDouble(pos -> world.getBiome(pos).getTemperature(pos)).sum() / positions.length;
     }
 
     public boolean setShape(IShape shape) {

--- a/src/main/java/mekanism/common/tile/TileEntityQuantumEntangloporter.java
+++ b/src/main/java/mekanism/common/tile/TileEntityQuantumEntangloporter.java
@@ -25,6 +25,7 @@ import mekanism.api.heat.HeatAPI.HeatTransfer;
 import mekanism.api.heat.IHeatCapacitor;
 import mekanism.api.heat.IHeatHandler;
 import mekanism.common.capabilities.Capabilities;
+import mekanism.common.capabilities.heat.CachedAmbientTemperature;
 import mekanism.common.capabilities.holder.chemical.IChemicalTankHolder;
 import mekanism.common.capabilities.holder.chemical.QuantumEntangloporterChemicalTankHolder;
 import mekanism.common.capabilities.holder.energy.IEnergyContainerHolder;
@@ -161,7 +162,7 @@ public class TileEntityQuantumEntangloporter extends TileEntityConfigurableMachi
 
     @Nonnull
     @Override
-    protected IHeatCapacitorHolder getInitialHeatCapacitors() {
+    protected IHeatCapacitorHolder getInitialHeatCapacitors(CachedAmbientTemperature ambientTemperature) {
         return new QuantumEntangloporterHeatCapacitorHolder(this);
     }
 

--- a/src/main/java/mekanism/common/tile/machine/TileEntityFuelwoodHeater.java
+++ b/src/main/java/mekanism/common/tile/machine/TileEntityFuelwoodHeater.java
@@ -4,6 +4,7 @@ import javax.annotation.Nonnull;
 import mekanism.api.NBTConstants;
 import mekanism.api.heat.HeatAPI.HeatTransfer;
 import mekanism.common.capabilities.heat.BasicHeatCapacitor;
+import mekanism.common.capabilities.heat.CachedAmbientTemperature;
 import mekanism.common.capabilities.holder.heat.HeatCapacitorHelper;
 import mekanism.common.capabilities.holder.heat.IHeatCapacitorHolder;
 import mekanism.common.capabilities.holder.slot.IInventorySlotHolder;
@@ -49,9 +50,9 @@ public class TileEntityFuelwoodHeater extends TileEntityMekanism {
 
     @Nonnull
     @Override
-    protected IHeatCapacitorHolder getInitialHeatCapacitors() {
+    protected IHeatCapacitorHolder getInitialHeatCapacitors(CachedAmbientTemperature ambientTemperature) {
         HeatCapacitorHelper builder = HeatCapacitorHelper.forSide(this::getDirection);
-        builder.addCapacitor(heatCapacitor = BasicHeatCapacitor.create(100, 5, 10, this));
+        builder.addCapacitor(heatCapacitor = BasicHeatCapacitor.create(100, 5, 10, ambientTemperature, this));
         return builder.build();
     }
 

--- a/src/main/java/mekanism/common/tile/machine/TileEntityResistiveHeater.java
+++ b/src/main/java/mekanism/common/tile/machine/TileEntityResistiveHeater.java
@@ -11,6 +11,7 @@ import mekanism.common.capabilities.Capabilities;
 import mekanism.common.capabilities.energy.MachineEnergyContainer;
 import mekanism.common.capabilities.energy.ResistiveHeaterEnergyContainer;
 import mekanism.common.capabilities.heat.BasicHeatCapacitor;
+import mekanism.common.capabilities.heat.CachedAmbientTemperature;
 import mekanism.common.capabilities.holder.energy.EnergyContainerHelper;
 import mekanism.common.capabilities.holder.energy.IEnergyContainerHolder;
 import mekanism.common.capabilities.holder.heat.HeatCapacitorHelper;
@@ -61,9 +62,9 @@ public class TileEntityResistiveHeater extends TileEntityMekanism {
 
     @Nonnull
     @Override
-    protected IHeatCapacitorHolder getInitialHeatCapacitors() {
+    protected IHeatCapacitorHolder getInitialHeatCapacitors(CachedAmbientTemperature ambientTemperature) {
         HeatCapacitorHelper builder = HeatCapacitorHelper.forSide(this::getDirection);
-        builder.addCapacitor(heatCapacitor = BasicHeatCapacitor.create(100, 5, 100, this));
+        builder.addCapacitor(heatCapacitor = BasicHeatCapacitor.create(100, 5, 100, ambientTemperature, this));
         return builder.build();
     }
 

--- a/src/main/java/mekanism/common/tile/multiblock/TileEntityBoilerCasing.java
+++ b/src/main/java/mekanism/common/tile/multiblock/TileEntityBoilerCasing.java
@@ -3,6 +3,7 @@ package mekanism.common.tile.multiblock;
 import javax.annotation.Nonnull;
 import mekanism.api.providers.IBlockProvider;
 import mekanism.common.Mekanism;
+import mekanism.common.capabilities.heat.CachedAmbientTemperature;
 import mekanism.common.capabilities.holder.heat.IHeatCapacitorHolder;
 import mekanism.common.content.boiler.BoilerMultiblockData;
 import mekanism.common.lib.multiblock.MultiblockManager;
@@ -33,7 +34,7 @@ public class TileEntityBoilerCasing extends TileEntityMultiblock<BoilerMultibloc
 
     @Nonnull
     @Override
-    protected IHeatCapacitorHolder getInitialHeatCapacitors() {
+    protected IHeatCapacitorHolder getInitialHeatCapacitors(CachedAmbientTemperature ambientTemperature) {
         return side -> getMultiblock().getHeatCapacitors(side);
     }
 

--- a/src/main/java/mekanism/common/tile/multiblock/TileEntityThermalEvaporationBlock.java
+++ b/src/main/java/mekanism/common/tile/multiblock/TileEntityThermalEvaporationBlock.java
@@ -25,9 +25,7 @@ public class TileEntityThermalEvaporationBlock extends TileEntityMultiblock<Evap
         if (!isRemote()) {
             EvaporationMultiblockData multiblock = getMultiblock();
             if (multiblock.isFormed()) {
-                if (multiblock.isSolarSpot(neighborPos)) {
-                    multiblock.updateSolars(getLevel());
-                }
+                multiblock.updateSolarSpot(getLevel(), neighborPos);
             }
         }
     }

--- a/src/main/java/mekanism/common/tile/multiblock/TileEntityThermalEvaporationValve.java
+++ b/src/main/java/mekanism/common/tile/multiblock/TileEntityThermalEvaporationValve.java
@@ -2,6 +2,7 @@ package mekanism.common.tile.multiblock;
 
 import javax.annotation.Nonnull;
 import mekanism.api.Action;
+import mekanism.common.capabilities.heat.CachedAmbientTemperature;
 import mekanism.common.capabilities.holder.fluid.IFluidTankHolder;
 import mekanism.common.capabilities.holder.heat.IHeatCapacitorHolder;
 import mekanism.common.capabilities.holder.slot.IInventorySlotHolder;
@@ -24,7 +25,7 @@ public class TileEntityThermalEvaporationValve extends TileEntityThermalEvaporat
 
     @Nonnull
     @Override
-    protected IHeatCapacitorHolder getInitialHeatCapacitors() {
+    protected IHeatCapacitorHolder getInitialHeatCapacitors(CachedAmbientTemperature ambientTemperature) {
         return side -> getMultiblock().getHeatCapacitors(side);
     }
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Make use of the biome's temperature in just about every ambient temperature calculation instead of just in the evaporation plant #6702
- Make the fission reactor's simulate environment method mirror the boiler one as there aren't exactly sides. Potentially these things should be multiplied by six so as to simulate each side?
- Fix an issue in `ITileHeatHandler#simulateAdjacent` where it was calculating temperature differential against the environment instead of against the sinks temperature, and also using an incorrect heat capacity. This needs verification that this change is correct, especially because of the change to how the sink's heat is handled.
- Move the evaporation plant's temp multiplier calculations to after the temperature is actually updated.
- Improve handling of how the evaporation plant updates the solar locations so as to be able to cache the existing array and other solars when updating a specific one
- Rewrote the calculation for how the biome's temperature modifier gets taken into account for calculating the biome's ambient temperature. Previously in the Evaporation Plant this had a small range where lower temperatures were considered "hotter". We should discuss if we want to cap it at five like I am currently doing or if we want to bump the range up to ten.

I am opening this PR as a draft mostly because it still needs quite a bit more testing and review.