### PR TITLE
Add instructions on building and moving over ProjectE files

### DIFF
--- a/docs/Development.md
+++ b/docs/Development.md
@@ -100,3 +100,7 @@ All in one jar.
 ## Building
 
 Mekanism is built in the same way that the vast majority of other mods are. If you are using an IDE such as Eclipse or IntelliJ IDEA, the normal ways of building/launching it work. If you are just trying to build the jars yourself without an IDE and are new to building mods, this can be done by downloading the sources from GitHub and in the root directory running `gradlew build` or `gradlew.bat build`. The built jars will be output into the `build/libs/` folder.
+
+### Dependencies
+
+ProjectE is currently a dependency, but a 1.18.x version is only available through the [ProjectE GitHub](https://github.com/sinkillerj/ProjectE/tree/mc1.18.x). Build that mod from source, then place the build output files `projecte-1.0.0-universal.jar` and `projecte-1.0.0-api.jar` (from ProjectE's `build/libs/` folder) in the `libs/` folder.


### PR DESCRIPTION
## Changes proposed in this pull request:

The build documentation is updated with instructions on building and copying over ProjectE files. At the moment, this is the only part of the build process that must be done manually and not through Gradle.

I would have found it helpful if these instructions were available when I tried to build Mekanism.