### PR TITLE
Fix energy dupe bug while charging stacks of induction cells

### DIFF
--- a/src/main/java/mekanism/common/capabilities/energy/item/ItemStackEnergyHandler.java
+++ b/src/main/java/mekanism/common/capabilities/energy/item/ItemStackEnergyHandler.java
@@ -5,9 +5,11 @@ import java.util.function.Consumer;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import mekanism.api.Action;
 import mekanism.api.NBTConstants;
 import mekanism.api.energy.IEnergyContainer;
 import mekanism.api.energy.IMekanismStrictEnergyHandler;
+import mekanism.api.math.FloatingLong;
 import mekanism.common.capabilities.ItemCapabilityWrapper.ItemCapability;
 import mekanism.common.capabilities.resolver.EnergyCapabilityResolver;
 import mekanism.common.capabilities.resolver.ICapabilityResolver;
@@ -47,6 +49,45 @@ public abstract class ItemStackEnergyHandler extends ItemCapability implements I
     @Override
     public void onContentsChanged() {
         ItemDataUtils.writeContainers(getStack(), NBTConstants.ENERGY_CONTAINERS, getEnergyContainers(null));
+    }
+
+    private int itemsCount() {
+        return this.getStack().getCount();
+    }
+
+    @Override
+    public FloatingLong getEnergy(int container, @Nullable Direction side) {
+        return IMekanismStrictEnergyHandler.super.getEnergy(container, side).multiply(itemsCount());
+    }
+
+    @Override
+    public void setEnergy(int container, FloatingLong energy, @Nullable Direction side) {
+        if (itemsCount() > 0) {
+            IMekanismStrictEnergyHandler.super.setEnergy(container, energy.divide(itemsCount()), side);
+        }
+    }
+
+    @Override
+    public FloatingLong getMaxEnergy(int container, @Nullable Direction side) {
+        return IMekanismStrictEnergyHandler.super.getMaxEnergy(container, side).multiply(itemsCount());
+    }
+
+    @Override
+    public FloatingLong insertEnergy(int container, FloatingLong amount, @Nullable Direction side, Action action) {
+        int count = itemsCount();
+        if (count <= 0) {
+            return amount;
+        }
+        return IMekanismStrictEnergyHandler.super.insertEnergy(container, amount.divide(count), side, action).multiply(count);
+    }
+
+    @Override
+    public FloatingLong extractEnergy(int container, FloatingLong amount, @Nullable Direction side, Action action) {
+        int count = itemsCount();
+        if (count <= 0) {
+            return FloatingLong.ZERO;
+        }
+        return IMekanismStrictEnergyHandler.super.extractEnergy(container, amount.divide(count), side, action).multiply(count);
     }
 
     @Override

--- a/src/main/java/mekanism/common/item/block/ItemBlockInductionCell.java
+++ b/src/main/java/mekanism/common/item/block/ItemBlockInductionCell.java
@@ -2,6 +2,7 @@ package mekanism.common.item.block;
 
 import java.util.List;
 import javax.annotation.Nonnull;
+import mekanism.api.math.FloatingLong;
 import mekanism.api.text.EnumColor;
 import mekanism.common.MekanismLang;
 import mekanism.common.block.attribute.Attribute;
@@ -32,8 +33,9 @@ public class ItemBlockInductionCell extends ItemBlockTooltip<BlockTile<TileEntit
     @Override
     protected void addStats(@Nonnull ItemStack stack, Level world, @Nonnull List<Component> tooltip, @Nonnull TooltipFlag flag) {
         InductionCellTier tier = getTier();
-        tooltip.add(MekanismLang.CAPACITY.translateColored(tier.getBaseTier().getTextColor(), EnumColor.GRAY, EnergyDisplay.of(tier.getMaxEnergy())));
+        FloatingLong capacity = tier.getMaxEnergy().multiply(stack.getCount());
+        tooltip.add(MekanismLang.CAPACITY.translateColored(tier.getBaseTier().getTextColor(), EnumColor.GRAY, EnergyDisplay.of(capacity)));
         tooltip.add(MekanismLang.STORED_ENERGY.translateColored(EnumColor.BRIGHT_GREEN, EnumColor.GRAY, EnergyDisplay.of(StorageUtils.getStoredEnergyFromNBT(stack),
-              tier.getMaxEnergy())));
+                capacity)));
     }
 }

--- a/src/main/java/mekanism/common/util/StorageUtils.java
+++ b/src/main/java/mekanism/common/util/StorageUtils.java
@@ -231,7 +231,7 @@ public class StorageUtils {
     public static FloatingLong getStoredEnergyFromNBT(ItemStack stack) {
         BasicEnergyContainer container = BasicEnergyContainer.create(FloatingLong.MAX_VALUE, null);
         ItemDataUtils.readContainers(stack, NBTConstants.ENERGY_CONTAINERS, Collections.singletonList(container));
-        return container.getEnergy();
+        return container.getEnergy().multiply(stack.getCount());
     }
 
     public static ItemStack getFilledEnergyVariant(ItemStack toFill, FloatingLong capacity) {


### PR DESCRIPTION
## Changes proposed in this pull request:

Currently you can stack induction cells, but charging any stack of mekanism items will charge all items in stack for the cost of one, allowing to dupe huge amounts of energy in very short time - especially when combined with much faster wireless charging mods like flux networks.

Also makes induction cells display sum of data to represent real state of what is inside the slot.