### PR TITLE
Update mek radiation heal command to set to baseline instead of 0

### DIFF
--- a/src/main/java/mekanism/common/command/RadiationCommand.java
+++ b/src/main/java/mekanism/common/command/RadiationCommand.java
@@ -73,7 +73,7 @@ public class RadiationCommand {
                     .executes(ctx -> {
                         CommandSourceStack source = ctx.getSource();
                         source.getPlayerOrException().getCapability(Capabilities.RADIATION_ENTITY).ifPresent(c -> {
-                            c.set(0);
+                            c.set(RadiationManager.BASELINE);
                             source.sendSuccess(MekanismLang.COMMAND_RADIATION_CLEAR.translateColored(EnumColor.GRAY), true);
                         });
                         return 0;
@@ -83,7 +83,7 @@ public class RadiationCommand {
                               for (Entity entity : EntityArgument.getEntities(ctx, "targets")) {
                                   if (entity instanceof LivingEntity) {
                                       entity.getCapability(Capabilities.RADIATION_ENTITY).ifPresent(c -> {
-                                          c.set(0);
+                                          c.set(RadiationManager.BASELINE);
                                           source.sendSuccess(MekanismLang.COMMAND_RADIATION_CLEAR_ENTITY.translateColored(EnumColor.GRAY, EnumColor.INDIGO,
                                                 entity.getDisplayName()), true);
                                       });

--- a/src/main/java/mekanism/common/lib/radiation/capability/DefaultRadiationEntity.java
+++ b/src/main/java/mekanism/common/lib/radiation/capability/DefaultRadiationEntity.java
@@ -26,7 +26,7 @@ import org.jetbrains.annotations.NotNull;
 
 public class DefaultRadiationEntity implements IRadiationEntity {
 
-    private double radiation;
+    private double radiation = RadiationManager.BASELINE;
 
     @Override
     public double getRadiation() {


### PR DESCRIPTION
## Changes proposed in this pull request:
Update mek radiation heal command and DefaultRadiationEntity radiation variable to set to baseline instead of 0