### PR TITLE
Update FusionReactorMultiblockData.java getProductionRate() to return actual production rate

### DIFF
--- a/src/generators/java/mekanism/generators/common/content/fusion/FusionReactorMultiblockData.java
+++ b/src/generators/java/mekanism/generators/common/content/fusion/FusionReactorMultiblockData.java
@@ -444,7 +444,7 @@ public class FusionReactorMultiblockData extends MultiblockData {
 
     @ComputerMethod
     private FloatingLong getProductionRate() {
-        return getPassiveGeneration(false, false);
+        return getPassiveGeneration(false, true);
     }
     //End computer related methods
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
The computer method getProductionRate is set to return the same value as if calling getPassiveGeneration(false). Between these two methods, there is no computer method to show the actual energy being produced by the reactor.  Changing the second argument to true with getProductionRate returns the actual energy being produced.