### PR TITLE
Added 'Cosmetic Armor Reworked' integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -404,6 +404,8 @@ dependencies {
 
     implementation fg.deobf("com.blamejared.crafttweaker:CraftTweaker-forge-${minecraft_version}:${crafttweaker_version}")
     implementation fg.deobf("com.blamejared.jeitweaker:JEITweaker-${minecraft_version}:${jeitweaker_version}")
+    
+    implementation fg.deobf("curse.maven:cosmetic-armor-reworked-237307:${cosmetic_armror_id}")
 
     //Mods we have dependencies on but don't bother loading into the dev environment
     compileOnly fg.deobf("curse.maven:projecte-api-226410:${projecte_api_id}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -41,6 +41,7 @@ oc2_id=3739469
 projecte_api_id=3722832
 top_version=1.18-5.1.0-8
 wildfire_gender_mod_id=3706808
+cosmetic_armror_id=3738144
 
 #Mod dependency min version ranges
 crafttweaker_version_range=[9.1.139,)

--- a/src/main/java/mekanism/client/render/RenderTickHandler.java
+++ b/src/main/java/mekanism/client/render/RenderTickHandler.java
@@ -34,6 +34,8 @@ import mekanism.common.block.attribute.AttributeCustomSelectionBox;
 import mekanism.common.capabilities.Capabilities;
 import mekanism.common.content.gear.IBlastingItem;
 import mekanism.common.content.gear.IModuleContainerItem;
+import mekanism.common.integration.MekanismHooks;
+import mekanism.common.integration.cosmeticarmor.CosmeticArmorIntegration;
 import mekanism.common.item.ItemConfigurator;
 import mekanism.common.item.ItemConfigurator.ConfiguratorMode;
 import mekanism.common.item.gear.ItemFlamethrower;
@@ -163,6 +165,11 @@ public class RenderTickHandler {
     public void renderArm(RenderArmEvent event) {
         AbstractClientPlayer player = event.getPlayer();
         ItemStack chestStack = player.getItemBySlot(EquipmentSlot.CHEST);
+        
+        if (Mekanism.hooks.CosmeticArmorLoaded) {
+            chestStack = CosmeticArmorIntegration.getCosmeticChestItemStack(player, chestStack);
+        }
+        
         if (chestStack.getItem() instanceof ItemMekaSuitArmor armorItem) {
             MekaSuitArmor armor = (MekaSuitArmor) ((ISpecialGear) RenderProperties.get(armorItem)).getGearModel(EquipmentSlot.CHEST);
             PlayerRenderer renderer = (PlayerRenderer) Minecraft.getInstance().getEntityRenderDispatcher().getRenderer(player);

--- a/src/main/java/mekanism/common/integration/MekanismHooks.java
+++ b/src/main/java/mekanism/common/integration/MekanismHooks.java
@@ -28,6 +28,7 @@ public final class MekanismHooks {
     public static final String PROJECTE_MOD_ID = "projecte";
     public static final String TOP_MOD_ID = "theoneprobe";
     public static final String WILDFIRE_GENDER_MOD_ID = "wildfire_gender";
+    public static final String COSMETIC_AMROR_MOD_ID = "cosmeticarmorreworked";
 
     public boolean CCLoaded;
     public boolean CraftTweakerLoaded;
@@ -39,6 +40,7 @@ public final class MekanismHooks {
     public boolean ProjectELoaded;
     public boolean TOPLoaded;
     public boolean WildfireGenderModLoaded;
+    public boolean CosmeticArmorLoaded;
 
     public void hookConstructor(final IEventBus bus) {
         ModList modList = ModList.get();
@@ -59,6 +61,7 @@ public final class MekanismHooks {
         TOPLoaded = modList.isLoaded(TOP_MOD_ID);
         FluxNetworksLoaded = modList.isLoaded(FLUX_NETWORKS_MOD_ID);
         WildfireGenderModLoaded = modList.isLoaded(WILDFIRE_GENDER_MOD_ID);
+        CosmeticArmorLoaded = modList.isLoaded(COSMETIC_AMROR_MOD_ID);
         if (CCLoaded) {
             CCCapabilityHelper.registerCCMathHelper();
         }

--- a/src/main/java/mekanism/common/integration/cosmeticarmor/CosmeticArmorIntegration.java
+++ b/src/main/java/mekanism/common/integration/cosmeticarmor/CosmeticArmorIntegration.java
@@ -1,0 +1,24 @@
+package mekanism.common.integration.cosmeticarmor;
+
+import javax.annotation.Nonnull;
+
+import lain.mods.cos.impl.ModObjects;
+import lain.mods.cos.impl.inventory.InventoryCosArmor;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+
+public class CosmeticArmorIntegration {
+
+    public static final int CHEST_SLOT = 2;
+
+    public static ItemStack getCosmeticChestItemStack(@Nonnull Player player, @Nonnull ItemStack originalEquipment) {
+        InventoryCosArmor invCosArmor = ModObjects.invMan.getCosArmorInventoryClient(player.getUUID());
+
+        if (invCosArmor.isSkinArmor(CHEST_SLOT)) {
+            return ItemStack.EMPTY;
+        } else {
+            ItemStack cosmetic = invCosArmor.getItem(CHEST_SLOT);
+            return cosmetic.isEmpty() ? originalEquipment : cosmetic;
+        }
+    }
+}


### PR DESCRIPTION
## Changes proposed in this pull request:

I want to see my skin, even while meka-suit working.
Cosmetic Armor Reworked mod did what I wanted.

Except for just one thing that worries me.
This pull request is replace itemstack for render hand on 1st person view.
Match with same as seen in 3rd person view.

![CosmeticArmor](https://user-images.githubusercontent.com/44163945/193464702-24b94d18-bffc-4622-b900-717b8314c85f.gif)
