### PR TITLE
Update CodeQL to include a timeout

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   analyze:
     name: Analyze
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     permissions:
       actions: read


### PR DESCRIPTION
This avoid actions being alive for too long for no reason, there has been examples of actions being alive for 2 hours or even 6 hours (By default, GitHub Actions kills workflows after 6 hours if they have not finished by then.)