### PR TITLE
Ensure Mekanism modules are added in a thread-safe manner

### DIFF
--- a/src/additions/java/mekanism/additions/common/MekanismAdditions.java
+++ b/src/additions/java/mekanism/additions/common/MekanismAdditions.java
@@ -51,7 +51,7 @@ public class MekanismAdditions implements IModModule {
     public static VoiceServerManager voiceManager;
 
     public MekanismAdditions() {
-        Mekanism.modulesLoaded.add(instance = this);
+        Mekanism.addModule(instance = this);
         MekanismAdditionsConfig.registerConfigs(ModLoadingContext.get());
         MinecraftForge.EVENT_BUS.addListener(this::serverStarting);
         MinecraftForge.EVENT_BUS.addListener(this::serverStopping);

--- a/src/defense/java/mekanism/defense/common/MekanismDefense.java
+++ b/src/defense/java/mekanism/defense/common/MekanismDefense.java
@@ -38,7 +38,7 @@ public class MekanismDefense implements IModModule {
     private final DefensePacketHandler packetHandler;
 
     public MekanismDefense() {
-        Mekanism.modulesLoaded.add(instance = this);
+        Mekanism.addModule(instance = this);
         MekanismDefenseConfig.registerConfigs(ModLoadingContext.get());
         MinecraftForge.EVENT_BUS.addListener(this::serverStopped);
 

--- a/src/generators/java/mekanism/generators/common/MekanismGenerators.java
+++ b/src/generators/java/mekanism/generators/common/MekanismGenerators.java
@@ -63,7 +63,7 @@ public class MekanismGenerators implements IModModule {
     public static final MultiblockManager<FusionReactorMultiblockData> fusionReactorManager = new MultiblockManager<>("fusionReactor", FusionReactorCache::new, FusionReactorValidator::new);
 
     public MekanismGenerators() {
-        Mekanism.modulesLoaded.add(instance = this);
+        Mekanism.addModule(instance = this);
         MekanismGeneratorsConfig.registerConfigs(ModLoadingContext.get());
         IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
         modEventBus.addListener(this::commonSetup);

--- a/src/main/java/mekanism/common/Mekanism.java
+++ b/src/main/java/mekanism/common/Mekanism.java
@@ -278,6 +278,10 @@ public class Mekanism {
         }
     }
 
+    public static synchronized void addModule(IModModule modModule) {
+        modulesLoaded.add(modModule);
+    }
+
     public static PacketHandler packetHandler() {
         return instance.packetHandler;
     }

--- a/src/tools/java/mekanism/tools/common/MekanismTools.java
+++ b/src/tools/java/mekanism/tools/common/MekanismTools.java
@@ -48,7 +48,7 @@ public class MekanismTools implements IModModule {
     public final Version versionNumber;
 
     public MekanismTools() {
-        Mekanism.modulesLoaded.add(instance = this);
+        Mekanism.addModule(instance = this);
         MekanismToolsConfig.registerConfigs(ModLoadingContext.get());
         //Register the listener for special mob spawning (mobs with Mekanism armor/tools)
         MinecraftForge.EVENT_BUS.addListener(this::onLivingSpecialSpawn);


### PR DESCRIPTION
## Changes proposed in this pull request:

Ensures Mekanism modules are added in a thread-safe manner.

## Background

After Mekanism itself is loaded, modules are loading in parallel. In some occasions, modules access `Mekanism#loadedModules` concurrently in bad timings, which leads to an inevitable crash as plain `ArrayList` is not thread-safe. In my case, this triggers `IndexOutOfBoundException`.

## Inspiration

Approach used in this PR is identical to the one used in 1.19.x. Newer versions of Mekanism introduced a synchronized `addModule` method, which solves the given issue.

https://github.com/mekanism/Mekanism/blob/ee5707f96155c0306f99b768212cb893d43b60e8/src/main/java/mekanism/common/Mekanism.java#L253-L255