### PR TITLE
Fix Nutritional Paste/Canteen giving too much food saturation

### DIFF
--- a/src/main/java/mekanism/common/content/gear/mekasuit/ModuleNutritionalInjectionUnit.java
+++ b/src/main/java/mekanism/common/content/gear/mekasuit/ModuleNutritionalInjectionUnit.java
@@ -41,7 +41,7 @@ public class ModuleNutritionalInjectionUnit implements ICustomModule<ModuleNutri
                 module.useEnergy(player, usage.multiply(toFeed));
                 FluidUtil.getFluidHandler(container).ifPresent(handler ->
                       handler.drain(MekanismFluids.NUTRITIONAL_PASTE.getFluidStack(toFeed * MekanismConfig.general.nutritionalPasteMBPerFood.get()), FluidAction.EXECUTE));
-                player.getFoodData().eat(needed, needed * MekanismConfig.general.nutritionalPasteSaturation.get());
+                player.getFoodData().eat(needed, MekanismConfig.general.nutritionalPasteSaturation.get());
             }
         }
     }

--- a/src/main/java/mekanism/common/item/ItemNutritionalPasteBucket.java
+++ b/src/main/java/mekanism/common/item/ItemNutritionalPasteBucket.java
@@ -64,7 +64,7 @@ public class ItemNutritionalPasteBucket extends BucketItem {
                     serverPlayer.awardStat(Stats.ITEM_USED.get(this));
                 }
                 if (!level.isClientSide) {
-                    player.getFoodData().eat(needed, needed * MekanismConfig.general.nutritionalPasteSaturation.get());
+                    player.getFoodData().eat(needed, MekanismConfig.general.nutritionalPasteSaturation.get());
                 }
                 stack.shrink(1);
                 return stack.isEmpty() ? new ItemStack(Items.BUCKET) : stack;

--- a/src/main/java/mekanism/common/item/gear/ItemCanteen.java
+++ b/src/main/java/mekanism/common/item/gear/ItemCanteen.java
@@ -74,7 +74,7 @@ public class ItemCanteen extends CapabilityItem {
         if (!world.isClientSide && entityLiving instanceof Player player) {
             int needed = Math.min(20 - player.getFoodData().getFoodLevel(), getFluid(stack).getAmount() / MekanismConfig.general.nutritionalPasteMBPerFood.get());
             if (needed > 0) {
-                player.getFoodData().eat(needed, needed * MekanismConfig.general.nutritionalPasteSaturation.get());
+                player.getFoodData().eat(needed, MekanismConfig.general.nutritionalPasteSaturation.get());
                 FluidUtil.getFluidHandler(stack).ifPresent(handler -> handler.drain(needed * MekanismConfig.general.nutritionalPasteMBPerFood.get(),
                       FluidAction.EXECUTE));
                 entityLiving.gameEvent(GameEvent.DRINK);


### PR DESCRIPTION
With Appleskin to show food saturation, I have noticed that the canteen in mek 10.3.8 fills saturation meter wayyyy more than it sounds like it should.

After searching the code I realized the paste's intended saturation ratio is multiplied by the food restored and then given to the `eat` function, but that function expects a ratio and multiplies it by the food amount (this gets done in `FoodData.eat(int, float)`). So nutritional paste is wayyyy more nutritrious than it should.

This simple change should fix that.

*(Please squash the commits, I thought making stuff on github directly would be easier but it just made one commit per file)*