### PR TITLE
Rework how multiblock caches are tracked and persisted

### DIFF
--- a/src/generators/java/mekanism/generators/common/content/fission/FissionReactorMultiblockData.java
+++ b/src/generators/java/mekanism/generators/common/content/fission/FissionReactorMultiblockData.java
@@ -32,7 +32,6 @@ import mekanism.common.inventory.container.sync.dynamic.ContainerSync;
 import mekanism.common.lib.multiblock.IValveHandler;
 import mekanism.common.lib.multiblock.MultiblockCache;
 import mekanism.common.lib.multiblock.MultiblockData;
-import mekanism.common.lib.multiblock.MultiblockManager;
 import mekanism.common.lib.radiation.RadiationManager;
 import mekanism.common.registries.MekanismGases;
 import mekanism.common.tags.MekanismTags;
@@ -306,12 +305,9 @@ public class FissionReactorMultiblockData extends MultiblockData implements IVal
             //Reset the heat to the default of the heat capacitor
             heatCapacitor.setHeat(heatCapacitor.getHeatCapacity() * biomeAmbientTemp);
             //Force sync the update to the cache that corresponds to this multiblock
-            MultiblockManager<FissionReactorMultiblockData>.CacheWrapper cacheWrapper = MekanismGenerators.fissionReactorManager.inventories.get(inventoryID);
-            if (cacheWrapper != null) {
-                MultiblockCache<FissionReactorMultiblockData> cache = cacheWrapper.getCache();
-                if (cache != null) {
-                    cache.sync(this);
-                }
+            MultiblockCache<FissionReactorMultiblockData> cache = MekanismGenerators.fissionReactorManager.getCache(inventoryID);
+            if (cache != null) {
+                cache.sync(this);
             }
         }
     }

--- a/src/main/java/mekanism/common/CommonWorldTickHandler.java
+++ b/src/main/java/mekanism/common/CommonWorldTickHandler.java
@@ -15,6 +15,7 @@ import mekanism.common.content.qio.IQIOCraftingWindowHolder;
 import mekanism.common.content.qio.QIOGlobalItemLookup;
 import mekanism.common.inventory.container.item.PortableQIODashboardContainer;
 import mekanism.common.lib.frequency.FrequencyManager;
+import mekanism.common.lib.multiblock.MultiblockManager;
 import mekanism.common.lib.radiation.RadiationManager;
 import mekanism.common.util.WorldUtils;
 import mekanism.common.world.GenHandler;
@@ -172,6 +173,7 @@ public class CommonWorldTickHandler {
     public void worldLoadEvent(LevelEvent.Load event) {
         if (!event.getLevel().isClientSide()) {
             FrequencyManager.load();
+            MultiblockManager.createOrLoadAll();
             QIOGlobalItemLookup.INSTANCE.createOrLoad();
             RadiationManager.INSTANCE.createOrLoad();
         }

--- a/src/main/java/mekanism/common/lib/MekanismSavedData.java
+++ b/src/main/java/mekanism/common/lib/MekanismSavedData.java
@@ -41,13 +41,10 @@ public abstract class MekanismSavedData extends SavedData {
      * Note: This should only be called from the server side
      */
     public static <DATA extends MekanismSavedData> DATA createSavedData(DimensionDataStorage dataStorage, Supplier<DATA> createFunction, String name) {
-        //TODO: Should we always prepend the modid to the name like we are doing for the multiblock managers?
-        // In general our names are probably unique enough but do we want to ensure they should be truly unique?
-        // This is especially prevalent for things like the radiation_manager
         return dataStorage.computeIfAbsent(tag -> {
             DATA handler = createFunction.get();
             handler.load(tag);
             return handler;
-        }, createFunction, name);
+        }, createFunction, Mekanism.MODID + "_" + name);
     }
 }

--- a/src/main/java/mekanism/common/lib/MekanismSavedData.java
+++ b/src/main/java/mekanism/common/lib/MekanismSavedData.java
@@ -1,0 +1,53 @@
+package mekanism.common.lib;
+
+import java.io.File;
+import java.util.function.Supplier;
+import mekanism.common.Mekanism;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.level.saveddata.SavedData;
+import net.minecraft.world.level.storage.DimensionDataStorage;
+import net.minecraftforge.server.ServerLifecycleHooks;
+import org.jetbrains.annotations.NotNull;
+
+public abstract class MekanismSavedData extends SavedData {
+
+    public abstract void load(@NotNull CompoundTag nbt);
+
+    @Override
+    public void save(@NotNull File file) {
+        if (isDirty()) {
+            //This is loosely based on Refined Storage's RSSavedData's system of saving first to a temp file
+            // to reduce the odds of corruption if the user's computer crashes while the file is being written
+            File tempFile = file.toPath().getParent().resolve(file.getName() + ".tmp").toFile();
+            super.save(tempFile);
+            if (file.exists() && !file.delete()) {
+                Mekanism.logger.error("Failed to delete " + file.getName());
+            }
+            if (!tempFile.renameTo(file)) {
+                Mekanism.logger.error("Failed to rename " + tempFile.getName());
+            }
+        }
+    }
+
+    /**
+     * Note: This should only be called from the server side
+     */
+    public static <DATA extends MekanismSavedData> DATA createSavedData(Supplier<DATA> createFunction, String name) {
+        DimensionDataStorage dataStorage = ServerLifecycleHooks.getCurrentServer().overworld().getDataStorage();
+        return createSavedData(dataStorage, createFunction, name);
+    }
+
+    /**
+     * Note: This should only be called from the server side
+     */
+    public static <DATA extends MekanismSavedData> DATA createSavedData(DimensionDataStorage dataStorage, Supplier<DATA> createFunction, String name) {
+        //TODO: Should we always prepend the modid to the name like we are doing for the multiblock managers?
+        // In general our names are probably unique enough but do we want to ensure they should be truly unique?
+        // This is especially prevalent for things like the radiation_manager
+        return dataStorage.computeIfAbsent(tag -> {
+            DATA handler = createFunction.get();
+            handler.load(tag);
+            return handler;
+        }, createFunction, name);
+    }
+}

--- a/src/main/java/mekanism/common/lib/frequency/FrequencyManager.java
+++ b/src/main/java/mekanism/common/lib/frequency/FrequencyManager.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import mekanism.api.NBTConstants;
+import mekanism.common.lib.MekanismSavedData;
 import mekanism.common.lib.collection.HashList;
 import mekanism.common.lib.frequency.Frequency.FrequencyIdentity;
 import mekanism.common.util.NBTUtils;
@@ -15,9 +16,6 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.level.saveddata.SavedData;
-import net.minecraft.world.level.storage.DimensionDataStorage;
-import net.minecraftforge.server.ServerLifecycleHooks;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -117,12 +115,7 @@ public class FrequencyManager<FREQ extends Frequency> {
         if (dataHandler == null) {
             String name = getName();
             //Always associate the world with the over world as the frequencies are global
-            DimensionDataStorage savedData = ServerLifecycleHooks.getCurrentServer().overworld().getDataStorage();
-            dataHandler = savedData.computeIfAbsent(nbt -> {
-                FrequencyDataHandler handler = new FrequencyDataHandler();
-                handler.load(nbt);
-                return handler;
-            }, FrequencyDataHandler::new, name);
+            dataHandler = MekanismSavedData.createSavedData(FrequencyDataHandler::new, name);
             dataHandler.syncManager();
         }
     }
@@ -174,7 +167,7 @@ public class FrequencyManager<FREQ extends Frequency> {
         return owner + frequencyType.getName() + "FrequencyHandler";
     }
 
-    public class FrequencyDataHandler extends SavedData {
+    public class FrequencyDataHandler extends MekanismSavedData {
 
         public List<FREQ> loadedFrequencies;
         public UUID loadedOwner;
@@ -186,6 +179,7 @@ public class FrequencyManager<FREQ extends Frequency> {
             }
         }
 
+        @Override
         public void load(@NotNull CompoundTag nbtTags) {
             NBTUtils.setUUIDIfPresent(nbtTags, NBTConstants.OWNER_UUID, uuid -> loadedOwner = uuid);
             ListTag list = nbtTags.getList(NBTConstants.FREQUENCY_LIST, Tag.TAG_COMPOUND);

--- a/src/main/java/mekanism/common/lib/multiblock/CuboidStructureValidator.java
+++ b/src/main/java/mekanism/common/lib/multiblock/CuboidStructureValidator.java
@@ -117,13 +117,16 @@ public abstract class CuboidStructureValidator<T extends MultiblockData> impleme
             // then we are not valid over all
             return FormationResult.fail(MekanismLang.MULTIBLOCK_INVALID_FRAME, pos);
         }
-        if (tile instanceof IMultiblock) {
-            @SuppressWarnings("unchecked")
-            IMultiblock<T> multiblockTile = (IMultiblock<T>) tile;
+        if (tile instanceof IMultiblock<?> multiblockTile) {
             UUID uuid = multiblockTile.getCacheID();
-            if (uuid != null && multiblockTile.getManager() == manager && multiblockTile.hasCache()) {
-                manager.updateCache(multiblockTile, multiblockTile.getMultiblock());
-                ctx.idsFound.add(uuid);
+            if (uuid != null && multiblockTile.getManager() == manager) {
+                MultiblockCache<T> cache = manager.getCache(uuid);
+                if (cache == null) {
+                    //If there is no cache matching the id the multiblock has reset the id it has cached as it is stale
+                    multiblockTile.resetCache();
+                } else {
+                    ctx.idsFound.put(uuid, cache);
+                }
             }
         }
         //Make sure the position is immutable before we store it

--- a/src/main/java/mekanism/common/lib/multiblock/IMultiblock.java
+++ b/src/main/java/mekanism/common/lib/multiblock/IMultiblock.java
@@ -1,6 +1,7 @@
 package mekanism.common.lib.multiblock;
 
 import java.util.UUID;
+import org.jetbrains.annotations.Nullable;
 
 public interface IMultiblock<T extends MultiblockData> extends IMultiblockBase {
 
@@ -20,13 +21,10 @@ public interface IMultiblock<T extends MultiblockData> extends IMultiblockBase {
 
     MultiblockManager<T> getManager();
 
+    @Nullable
     UUID getCacheID();
 
-    MultiblockCache<T> getCache();
-
     void resetCache();
-
-    void setCache(MultiblockCache<T> cache);
 
     boolean isMaster();
 
@@ -54,10 +52,6 @@ public interface IMultiblock<T extends MultiblockData> extends IMultiblockBase {
     @Override
     default boolean hasStructure(Structure structure) {
         return getStructure() == structure;
-    }
-
-    default boolean hasCache() {
-        return getCache() != null;
     }
 
     default FormationProtocol<T> createFormationProtocol() {

--- a/src/main/java/mekanism/common/lib/multiblock/MultiblockCache.java
+++ b/src/main/java/mekanism/common/lib/multiblock/MultiblockCache.java
@@ -117,15 +117,9 @@ public class MultiblockCache<T extends MultiblockData> implements IMekanismInven
         // Slurry
         StorageUtils.mergeTanks(getSlurryTanks(null), mergeCache.getSlurryTanks(null), rejectContents.rejectedSlurries);
         // Energy
-        List<IEnergyContainer> cacheContainers = getEnergyContainers(null);
-        for (int i = 0; i < cacheContainers.size(); i++) {
-            StorageUtils.mergeContainers(cacheContainers.get(i), mergeCache.getEnergyContainers(null).get(i));
-        }
+        StorageUtils.mergeEnergyContainers(getEnergyContainers(null), mergeCache.getEnergyContainers(null));
         // Heat
-        List<IHeatCapacitor> cacheCapacitors = getHeatCapacitors(null);
-        for (int i = 0; i < cacheCapacitors.size(); i++) {
-            StorageUtils.mergeContainers(cacheCapacitors.get(i), mergeCache.getHeatCapacitors(null).get(i));
-        }
+        StorageUtils.mergeHeatCapacitors(getHeatCapacitors(null), mergeCache.getHeatCapacitors(null));
     }
 
     @Override

--- a/src/main/java/mekanism/common/lib/multiblock/MultiblockCache.java
+++ b/src/main/java/mekanism/common/lib/multiblock/MultiblockCache.java
@@ -86,15 +86,23 @@ public class MultiblockCache<T extends MultiblockData> implements IMekanismInven
 
     public void load(CompoundTag nbtTags) {
         for (CacheSubstance<?, INBTSerializable<CompoundTag>> type : CacheSubstance.VALUES) {
-            type.prefab(this, nbtTags.getInt(type.getTagKey() + "_stored"));
-            DataHandlerUtils.readContainers(type.getContainerList(this), nbtTags.getList(type.getTagKey(), Tag.TAG_COMPOUND));
+            int stored = nbtTags.getInt(type.getTagKey() + "_stored");
+            if (stored > 0) {
+                type.prefab(this, stored);
+                DataHandlerUtils.readContainers(type.getContainerList(this), nbtTags.getList(type.getTagKey(), Tag.TAG_COMPOUND));
+            }
         }
     }
 
     public void save(CompoundTag nbtTags) {
         for (CacheSubstance<?, INBTSerializable<CompoundTag>> type : CacheSubstance.VALUES) {
-            nbtTags.putInt(type.getTagKey() + "_stored", type.getContainerList(this).size());
-            nbtTags.put(type.getTagKey(), DataHandlerUtils.writeContainers(type.getContainerList(this)));
+            List<INBTSerializable<CompoundTag>> containers = type.getContainerList(this);
+            if (!containers.isEmpty()) {
+                //Note: We can skip putting stored at zero if containers is empty (in addition to skipping actually writing the containers)
+                // because getInt will default to 0 for keys that aren't present
+                nbtTags.putInt(type.getTagKey() + "_stored", containers.size());
+                nbtTags.put(type.getTagKey(), DataHandlerUtils.writeContainers(containers));
+            }
         }
     }
 

--- a/src/main/java/mekanism/common/lib/multiblock/MultiblockManager.java
+++ b/src/main/java/mekanism/common/lib/multiblock/MultiblockManager.java
@@ -1,22 +1,25 @@
 package mekanism.common.lib.multiblock;
 
-import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
-import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Supplier;
-import mekanism.api.Coord4D;
-import mekanism.common.tile.prefab.TileEntityMultiblock;
-import mekanism.common.util.WorldUtils;
-import net.minecraft.world.level.Level;
+import mekanism.api.NBTConstants;
+import mekanism.common.Mekanism;
+import mekanism.common.lib.MekanismSavedData;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.Tag;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class MultiblockManager<T extends MultiblockData> {
 
-    private static final Set<MultiblockManager<?>> managers = new ObjectOpenHashSet<>();
+    private static final Set<MultiblockManager<?>> managers = new HashSet<>();
 
     private final String name;
     private final String nameLower;
@@ -27,7 +30,13 @@ public class MultiblockManager<T extends MultiblockData> {
     /**
      * A map containing references to all multiblock inventory caches.
      */
-    public final Map<UUID, CacheWrapper> inventories = new Object2ObjectOpenHashMap<>();
+    private final Map<UUID, MultiblockCache<T>> caches = new HashMap<>();
+
+    /**
+     * Note: This can and will be null on the client side
+     */
+    @Nullable
+    private MultiblockCacheDataHandler dataHandler;
 
     public MultiblockManager(String name, Supplier<MultiblockCache<T>> cacheSupplier, Supplier<IStructureValidator<T>> validatorSupplier) {
         this.name = name;
@@ -37,8 +46,24 @@ public class MultiblockManager<T extends MultiblockData> {
         managers.add(this);
     }
 
+    /**
+     * Note: It is important that callers also call {@link #trackCache(UUID, MultiblockCache)} after initializing any data the cache might require.
+     */
     public MultiblockCache<T> createCache() {
         return cacheSupplier.get();
+    }
+
+    /**
+     * Adds a cache as tracked and marks the manager as dirty.
+     */
+    public void trackCache(UUID id, MultiblockCache<T> cache) {
+        caches.put(id, cache);
+        markDirty();
+    }
+
+    @Nullable
+    public MultiblockCache<T> getCache(UUID multiblockID) {
+        return caches.get(multiblockID);
     }
 
     public IStructureValidator<T> createValidator() {
@@ -53,11 +78,6 @@ public class MultiblockManager<T extends MultiblockData> {
         return nameLower;
     }
 
-    @Nullable
-    public static UUID getMultiblockID(TileEntityMultiblock<?> tile) {
-        return tile.getMultiblock().inventoryID;
-    }
-
     public boolean isCompatible(BlockEntity tile) {
         if (tile instanceof IMultiblock<?> multiblock) {
             return multiblock.getManager() == this;
@@ -67,43 +87,36 @@ public class MultiblockManager<T extends MultiblockData> {
 
     public static void reset() {
         for (MultiblockManager<?> manager : managers) {
-            manager.inventories.clear();
-        }
-    }
-
-    public void invalidate(IMultiblock<?> multiblock) {
-        CacheWrapper cache = inventories.get(multiblock.getCacheID());
-        if (cache != null) {
-            cache.locations.remove(multiblock.getTileCoord());
-            if (cache.locations.isEmpty()) {
-                inventories.remove(multiblock.getCacheID());
-            }
+            manager.caches.clear();
+            manager.dataHandler = null;
         }
     }
 
     /**
-     * Grabs an inventory from the world's caches, and removes all the world's references to it. NOTE: this is not guaranteed to remove all references if somehow blocks
-     * with this inventory ID exist in unloaded chunks when the inventory is pulled. We should consider whether we should implement a way to mitigate this.
-     *
-     * @param world - world the cache is stored in
-     * @param id    - inventory ID to pull
-     *
-     * @return correct multiblock inventory cache or {@code null} if one could not be found for the given id.
+     * Replaces and invalidates all the caches with the given ids with a new cache with the given id.
      */
-    @Nullable
-    public MultiblockCache<T> pullInventory(Level world, UUID id) {
-        CacheWrapper toReturn = inventories.remove(id);
-        if (toReturn == null) {
-            //If there wasn't an inventory found return that we didn't have one
-            return null;
+    public void replaceCaches(Set<UUID> staleIds, UUID id, MultiblockCache<T> cache) {
+        for (UUID staleId : staleIds) {
+            caches.remove(staleId);
         }
-        for (Coord4D obj : toReturn.locations) {
-            BlockEntity tile = WorldUtils.getTileEntity(world, obj.getPos());
-            if (tile instanceof IMultiblock<?> multiblock) {
-                multiblock.resetCache();
+        trackCache(id, cache);
+    }
+
+    public void handleDirtyMultiblock(T multiblock) {
+        //Validate the multiblock is actually dirty and needs saving
+        if (multiblock.isDirty()) {
+            MultiblockCache<T> cache = getCache(multiblock.inventoryID);
+            //Validate the multiblock's cache exists as if it doesn't we want to ignore it
+            // in theory this method should only be called if the multiblock is valid and formed
+            // but in case something goes wrong, don't let it
+            if (cache != null) {
+                cache.sync(multiblock);
+                //If the multiblock is dirty mark the manager's data handler as dirty to ensure that we save
+                markDirty();
+                // next we can reset the dirty state of the multiblock
+                multiblock.resetDirty();
             }
         }
-        return toReturn.getCache();
     }
 
     /**
@@ -115,47 +128,63 @@ public class MultiblockManager<T extends MultiblockData> {
         return UUID.randomUUID();
     }
 
-    public void updateCache(IMultiblock<T> tile, T multiblock) {
-        inventories.computeIfAbsent(tile.getCacheID(), id -> new CacheWrapper()).update(tile, multiblock);
+    private void markDirty() {
+        if (dataHandler != null) {
+            dataHandler.setDirty();
+        }
     }
 
-    public class CacheWrapper {
-
-        private MultiblockCache<T> cache;
-        private final Set<Coord4D> locations = new ObjectOpenHashSet<>();
-
-        private CacheWrapper() {
+    /**
+     * Note: This should only be called from the server side
+     */
+    public static void createOrLoadAll() {
+        for (MultiblockManager<?> manager : managers) {
+            manager.createOrLoad();
         }
+    }
 
-        public MultiblockCache<T> getCache() {
-            return cache;
+    /**
+     * Note: This should only be called from the server side
+     */
+    private void createOrLoad() {
+        if (dataHandler == null) {
+            //Always associate the world with the overworld as we base it on a manager wide state
+            dataHandler = MekanismSavedData.createSavedData(MultiblockCacheDataHandler::new, Mekanism.MODID + "_" + getNameLower());
         }
+    }
 
-        public void update(IMultiblock<T> tile, T multiblock) {
-            if (multiblock.isFormed()) {
-                if (tile.isMaster()) {
-                    // create a new cache for the tile if it needs one
-                    if (!tile.hasCache()) {
-                        tile.setCache(createCache());
-                        locations.add(tile.getTileCoord());
-                    } else if (cache != tile.getCache()) {
-                        locations.add(tile.getTileCoord());
+    private class MultiblockCacheDataHandler extends MekanismSavedData {
+
+        @Override
+        public void load(@NotNull CompoundTag nbt) {
+            if (nbt.contains(NBTConstants.CACHE, Tag.TAG_LIST)) {
+                ListTag cachesNbt = nbt.getList(NBTConstants.CACHE, Tag.TAG_COMPOUND);
+                for (int i = 0; i < cachesNbt.size(); i++) {
+                    CompoundTag cacheTags = cachesNbt.getCompound(i);
+                    if (cacheTags.hasUUID(NBTConstants.INVENTORY_ID)) {
+                        UUID id = cacheTags.getUUID(NBTConstants.INVENTORY_ID);
+                        MultiblockCache<T> cachedData = cacheSupplier.get();
+                        cachedData.load(cacheTags);
+                        caches.put(id, cachedData);
                     }
-                    // if this is the master tile, sync the cache with the multiblock and then update our reference
-                    tile.getCache().sync(multiblock);
-                    cache = tile.getCache();
                 }
-            } else if (tile.hasCache()) {
-                if (cache != tile.getCache()) {
-                    // if the tile doesn't have a formed multiblock but has a cache, update our reference
-                    cache = tile.getCache();
-                    locations.add(tile.getTileCoord());
-                }
-            } else if (cache != null) {
-                // if the tile doesn't have a cache, but we do, update the tile's reference
-                tile.setCache(cache);
-                locations.add(tile.getTileCoord());
             }
+        }
+
+        @NotNull
+        @Override
+        public CompoundTag save(@NotNull CompoundTag nbt) {
+            ListTag cachesNbt = new ListTag();
+            for (Map.Entry<UUID, MultiblockCache<T>> entry : caches.entrySet()) {
+                CompoundTag cacheTags = new CompoundTag();
+                //Note: We can just store the inventory id in the same compound tag as the rest of the cache data
+                // as none of the caches save anything to this tag
+                cacheTags.putUUID(NBTConstants.INVENTORY_ID, entry.getKey());
+                entry.getValue().save(cacheTags);
+                cachesNbt.add(cacheTags);
+            }
+            nbt.put(NBTConstants.CACHE, cachesNbt);
+            return nbt;
         }
     }
 }

--- a/src/main/java/mekanism/common/lib/multiblock/MultiblockManager.java
+++ b/src/main/java/mekanism/common/lib/multiblock/MultiblockManager.java
@@ -8,7 +8,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.Supplier;
 import mekanism.api.NBTConstants;
-import mekanism.common.Mekanism;
 import mekanism.common.lib.MekanismSavedData;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
@@ -149,7 +148,7 @@ public class MultiblockManager<T extends MultiblockData> {
     private void createOrLoad() {
         if (dataHandler == null) {
             //Always associate the world with the overworld as we base it on a manager wide state
-            dataHandler = MekanismSavedData.createSavedData(MultiblockCacheDataHandler::new, Mekanism.MODID + "_" + getNameLower());
+            dataHandler = MekanismSavedData.createSavedData(MultiblockCacheDataHandler::new, getNameLower());
         }
     }
 

--- a/src/main/java/mekanism/common/util/NBTUtils.java
+++ b/src/main/java/mekanism/common/util/NBTUtils.java
@@ -125,27 +125,15 @@ public class NBTUtils {
         }
     }
 
-    public static boolean hasOldUUID(CompoundTag nbt, String key) {
-        return nbt.contains(key + "Most", Tag.TAG_ANY_NUMERIC) && nbt.contains(key + "Least", Tag.TAG_ANY_NUMERIC);
-    }
-
-    public static UUID getOldUUID(CompoundTag nbt, String key) {
-        return new UUID(nbt.getLong(key + "Most"), nbt.getLong(key + "Least"));
-    }
-
     public static void setUUIDIfPresent(CompoundTag nbt, String key, Consumer<UUID> setter) {
         if (nbt.hasUUID(key)) {
             setter.accept(nbt.getUUID(key));
-        } else if (hasOldUUID(nbt, key)) {
-            setter.accept(getOldUUID(nbt, key));
         }
     }
 
     public static void setUUIDIfPresentElse(CompoundTag nbt, String key, Consumer<UUID> setter, Runnable notPresent) {
         if (nbt.hasUUID(key)) {
             setter.accept(nbt.getUUID(key));
-        } else if (hasOldUUID(nbt, key)) {
-            setter.accept(getOldUUID(nbt, key));
         } else {
             notPresent.run();
         }

--- a/src/main/java/mekanism/common/util/StackUtils.java
+++ b/src/main/java/mekanism/common/util/StackUtils.java
@@ -36,9 +36,7 @@ public final class StackUtils {
     }
 
     public static void merge(@NotNull List<IInventorySlot> orig, @NotNull List<IInventorySlot> toAdd, List<ItemStack> rejects) {
-        if (orig.size() != toAdd.size()) {
-            throw new IllegalArgumentException("Mismatched slot count");
-        }
+        StorageUtils.validateSizeMatches(orig, toAdd, "slot");
         for (int i = 0; i < toAdd.size(); i++) {
             IInventorySlot toAddSlot = toAdd.get(i);
             if (!toAddSlot.isEmpty()) {

--- a/src/main/java/mekanism/common/util/StorageUtils.java
+++ b/src/main/java/mekanism/common/util/StorageUtils.java
@@ -349,9 +349,7 @@ public class StorageUtils {
     }
 
     public static void mergeFluidTanks(List<IExtendedFluidTank> tanks, List<IExtendedFluidTank> toAdd, List<FluidStack> rejects) {
-        if (tanks.size() != toAdd.size()) {
-            throw new IllegalArgumentException("Mismatched tank count");
-        }
+        validateSizeMatches(tanks, toAdd, "tank");
         for (int i = 0; i < toAdd.size(); i++) {
             IExtendedFluidTank mergeTank = toAdd.get(i);
             if (!mergeTank.isEmpty()) {
@@ -383,9 +381,7 @@ public class StorageUtils {
 
     public static <CHEMICAL extends Chemical<CHEMICAL>, STACK extends ChemicalStack<CHEMICAL>, TANK extends IChemicalTank<CHEMICAL, STACK>> void mergeTanks(
           List<TANK> tanks, List<TANK> toAdd, List<STACK> rejects) {
-        if (tanks.size() != toAdd.size()) {
-            throw new IllegalArgumentException("Mismatched tank count");
-        }
+        validateSizeMatches(tanks, toAdd, "tank");
         for (int i = 0; i < toAdd.size(); i++) {
             TANK mergeTank = toAdd.get(i);
             if (!mergeTank.isEmpty()) {
@@ -415,14 +411,30 @@ public class StorageUtils {
         }
     }
 
-    public static void mergeContainers(IEnergyContainer container, IEnergyContainer mergeContainer) {
-        container.setEnergy(container.getEnergy().add(mergeContainer.getEnergy()));
+    public static void mergeEnergyContainers(List<IEnergyContainer> containers, List<IEnergyContainer> toAdd) {
+        validateSizeMatches(containers, toAdd, "energy container");
+        for (int i = 0; i < toAdd.size(); i++) {
+            IEnergyContainer container = containers.get(i);
+            IEnergyContainer mergeContainer = toAdd.get(i);
+            container.setEnergy(container.getEnergy().add(mergeContainer.getEnergy()));
+        }
     }
 
-    public static void mergeContainers(IHeatCapacitor capacitor, IHeatCapacitor mergeCapacitor) {
-        capacitor.setHeat(capacitor.getHeat() + mergeCapacitor.getHeat());
-        if (capacitor instanceof BasicHeatCapacitor heatCapacitor) {
-            heatCapacitor.setHeatCapacity(capacitor.getHeatCapacity() + mergeCapacitor.getHeatCapacity(), false);
+    public static void mergeHeatCapacitors(List<IHeatCapacitor> capacitors, List<IHeatCapacitor> toAdd) {
+        validateSizeMatches(capacitors, toAdd, "heat capacitor");
+        for (int i = 0; i < toAdd.size(); i++) {
+            IHeatCapacitor capacitor = capacitors.get(i);
+            IHeatCapacitor mergeCapacitor = toAdd.get(i);
+            capacitor.setHeat(capacitor.getHeat() + mergeCapacitor.getHeat());
+            if (capacitor instanceof BasicHeatCapacitor heatCapacitor) {
+                heatCapacitor.setHeatCapacity(capacitor.getHeatCapacity() + mergeCapacitor.getHeatCapacity(), false);
+            }
+        }
+    }
+
+    public static <T> void validateSizeMatches(List<T> base, List<T> toAdd, String type) {
+        if (base.size() != toAdd.size()) {
+            throw new IllegalArgumentException("Mismatched " + type + " count, orig: " + base.size() + ", toAdd: " + toAdd.size());
         }
     }
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Expands the data corruption temp file backup we have for saved data to be used for all our saved data implementations instead of just the QIO item lookup
- Removed the old fallback loading/checks relating to the old UUID format as it was either transitioned over in 1.16 or 1.18 (I forget which) and at this point doesn't serve much purpose
- Reworks how multiblock caches are managed and persisted to be based on a per manager world save data rather than saving multiple bits of copies to individual tiles. Some additional notes about the implementation and what this means:
  - Any existing multiblock contents will be voided/lost, as this change is being made during a breaking change window of changing MC versions this isn't a big deal but is worth mentioning and documenting.
  - If the control block (be it a reactor controller or the randomly chosen block) gets destroyed the contents of the multiblock will be consistently saved instead of the previous case of voided in the majority of situations.
  - When multiblocks reform there is a bit of disk churn as they get new ids and thus the save data becomes dirty and has to save again. This is a side effect of the route taken to avoid tracking what positions are for each cache in a way that doesn't lead to potential dupe issues or multiple now separated multiblocks referencing the same cache. Previously this was a potential issue as well (as noted in the now removed `MultiblockManager#pullInventory` method) though was only limited to portions that were potentially unloaded or inside of things like cardboard boxes. One solution to this would be to track all the positions in the multiblock and then if any are missing when reforming use a new id, but the extra overhead for memory and validating each position does not seem particularly worth it.
  - A lot of the extra cycles relating to trying to keep the `CacheWrapper` up to date with all the different multiblock tiles and having them all have their caches pointing at the same same instance, as well as tracking their current positions is no longer necessary as we remove caches when merging them so if something has a stale id that no longer points at a cache we can just ignore it instead of needing to make sure we clear every reference to the id.