### PR TITLE
Add forge:bioethanol to forge:biofuel tag

### DIFF
--- a/src/datagen/generated/mekanismgenerators/data/forge/tags/fluids/biofuel.json
+++ b/src/datagen/generated/mekanismgenerators/data/forge/tags/fluids/biofuel.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#forge:bioethanol"
+  ]
+}


### PR DESCRIPTION
## Changes proposed in this pull request:
I've seen some mods use forge:biofuel and some use forge:bioethanol, since bioethanol is more specific than biofuel, I've included that tag in the biofuel tag.