### PR TITLE
add mixin and hook to prevent being LivingEquipmentChangeEvent consta…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ plugins {
     id 'maven-publish'
     id 'net.neoforged.gradle' version '[6.0.18,6.2)'
     id 'org.parchmentmc.librarian.forgegradle' version '1.+'
+    id 'org.spongepowered.mixin' version '0.7.+'
 }
 
 tasks.named('wrapper', Wrapper).configure {
@@ -327,11 +328,18 @@ minecraft {
     }
 }
 
+mixin {
+    // MixinGradle Settings
+    add sourceSets.main, 'mixins.mekanism.refmap.json'
+    config 'mixins.mekanism.json'
+}
+
 def setupRunConfig(RunConfig runConfig, boolean supportsGameTests, String directory = "run") {
     runConfig.workingDirectory(file(directory))
     //This fixes Mixin application problems from other mods because their refMaps are SRG-based, but we're in a MCP env
-    runConfig.property 'mixin.env.remapRefMap', 'true'
-    runConfig.property 'mixin.env.refMapRemappingFile', "${projectDir}/build/createSrgToMcp/output.srg"
+    //handled by mixin plugin
+    //runConfig.property 'mixin.env.remapRefMap', 'true'
+    //runConfig.property 'mixin.env.refMapRemappingFile', "${projectDir}/build/createSrgToMcp/output.srg"
     if (supportsGameTests) {
         //Specify all our mods as domains to look for game tests
         runConfig.property 'forge.enabledGameTestNamespaces', 'mekanism,mekanismadditions,mekanismdefense,mekanismgenerators,mekanismtools'
@@ -406,6 +414,7 @@ dependencies {
     minecraft "net.neoforged:forge:${minecraft_version}-${forge_version}"
 
     annotationProcessor project(":annotation-processor")
+    annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:${junit_version}"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junit_version}"

--- a/src/main/java/mekanism/common/content/gear/IModuleContainerItem.java
+++ b/src/main/java/mekanism/common/content/gear/IModuleContainerItem.java
@@ -104,4 +104,15 @@ public interface IModuleContainerItem extends IItemHUDProvider {
         }
         return ret;
     }
+
+    /**
+     * Hook of {@link net.minecraft.world.entity.LivingEntity#equipmentHasChanged(ItemStack, ItemStack)}.
+     *
+     * @param oldItem the previous stack in the slot
+     * @param newItem the current stack in the slot. Item will be the same as oldItem param
+     * @return true if the equipment has changed and needs to trigger attribute modifier calculations and the {@link net.minecraftforge.event.entity.living.LivingEquipmentChangeEvent event}
+     */
+    default boolean hasEquipmentChanged(ItemStack oldItem, ItemStack newItem) {
+        return false;//modules can't change while in an equipment slot
+    }
 }

--- a/src/main/java/mekanism/mixin/MixinLivingEntity.java
+++ b/src/main/java/mekanism/mixin/MixinLivingEntity.java
@@ -1,0 +1,20 @@
+package mekanism.mixin;
+
+import mekanism.common.content.gear.IModuleContainerItem;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(LivingEntity.class)
+public class MixinLivingEntity {
+
+    @Inject(method = "equipmentHasChanged", at = @At("HEAD"), cancellable = true)
+    public void equipmentHasChanged$handleMekGear(ItemStack oldItem, ItemStack newItem, CallbackInfoReturnable<Boolean> ci) {
+        if (oldItem.getItem() == newItem.getItem() && newItem.getItem() instanceof IModuleContainerItem containerItem) {
+            ci.setReturnValue(containerItem.hasEquipmentChanged(oldItem, newItem));
+        }
+    }
+}

--- a/src/main/resources/mixins.mekanism.json
+++ b/src/main/resources/mixins.mekanism.json
@@ -1,0 +1,7 @@
+{
+  "package": "mekanism.mixin",
+  "refmap": "mixins.mekanism.refmap.json",
+  "mixins": [
+    "MixinLivingEntity"
+  ]
+}


### PR DESCRIPTION
…ntly fired due to energy usage

## Changes proposed in this pull request:
adds a simple mixin to prevent firing the event constantly - may mitigate the issue with iFly as well as being slightly more performant as it's not copying the stack every tick