### PR TITLE
Refactor salt disk feature to call vanilla placement method.

### DIFF
--- a/src/datagen/generated/mekanism/.cache/7e4ff443e4c887a90eb807f5e559e71c67949ffc
+++ b/src/datagen/generated/mekanism/.cache/7e4ff443e4c887a90eb807f5e559e71c67949ffc
@@ -1,4 +1,4 @@
-// 1.20.1	2023-09-10T15:23:49.8726052	Datapack registries: mekanism
+// 1.20.1	2024-02-21T08:53:40.5818441	Datapack registries: mekanism
 3569c860b35530ba451e7442db81f25f1491a9c9 data/mekanism/damage_type/laser.json
 3d56d26f6e58ced8680ed0cde116e2b4f3850aef data/mekanism/damage_type/radiation.json
 6222f7bed3dbe2cad38b36dc733d552a267cc508 data/mekanism/forge/biome_modifier/fluorite.json
@@ -40,7 +40,7 @@ b7b822dbb043a13ac11c5090a5609ca9dae59d1b data/mekanism/worldgen/configured_featu
 cfb69c9d2edb55eb8f1ea6cca5dac7c905b6074d data/mekanism/worldgen/configured_feature/ore_uranium_buried_retrogen.json
 454f1a9ab88d910db33b35a65ab9fe4581499731 data/mekanism/worldgen/configured_feature/ore_uranium_small.json
 0a73564d8d19d2cd08507bc7608cd3ed5361ce0b data/mekanism/worldgen/configured_feature/ore_uranium_small_retrogen.json
-7e8999c7cbd1af28f021d34797f2b4479679cec5 data/mekanism/worldgen/configured_feature/salt.json
+d59ce8a4e31b6b2d4b767e1cd76f638dd4668edb data/mekanism/worldgen/configured_feature/salt.json
 ea988d3afac85b04f4ab2ecdd4cb411f4955e253 data/mekanism/worldgen/placed_feature/ore_fluorite_buried.json
 93fe97d3faa48572091e26ed547277fdf276908a data/mekanism/worldgen/placed_feature/ore_fluorite_buried_retrogen.json
 cf7839cd372c2df4f97eefeafa669ebed3f934ca data/mekanism/worldgen/placed_feature/ore_fluorite_normal.json

--- a/src/datagen/generated/mekanism/.cache/7e4ff443e4c887a90eb807f5e559e71c67949ffc
+++ b/src/datagen/generated/mekanism/.cache/7e4ff443e4c887a90eb807f5e559e71c67949ffc
@@ -1,4 +1,4 @@
-// 1.20.1	2024-02-21T08:53:40.5818441	Datapack registries: mekanism
+// 1.20.1	2024-02-21T09:04:10.0095565	Datapack registries: mekanism
 3569c860b35530ba451e7442db81f25f1491a9c9 data/mekanism/damage_type/laser.json
 3d56d26f6e58ced8680ed0cde116e2b4f3850aef data/mekanism/damage_type/radiation.json
 6222f7bed3dbe2cad38b36dc733d552a267cc508 data/mekanism/forge/biome_modifier/fluorite.json
@@ -61,5 +61,5 @@ a1acf418c1ea078a4168760acfcf6b60bf6a9d1a data/mekanism/worldgen/placed_feature/o
 73e4cabd18c10672690461d2bb851f1e2ee6a35f data/mekanism/worldgen/placed_feature/ore_uranium_buried_retrogen.json
 b9f3c4450ad8e974528c2d2d3242aeca9997a68d data/mekanism/worldgen/placed_feature/ore_uranium_small.json
 03874b1ae12a51650fd920cf5b22b198627db2c9 data/mekanism/worldgen/placed_feature/ore_uranium_small_retrogen.json
-600ca97011eebf5342dee67c9917c3e8114b2c72 data/mekanism/worldgen/placed_feature/salt.json
-80c3b08e038f5585ecadb14f7499438db503ed42 data/mekanism/worldgen/placed_feature/salt_retrogen.json
+f2ef4739fd28840f75983cb741f91aa14c5e472e data/mekanism/worldgen/placed_feature/salt.json
+214cc6fcf54e13f900a818478deb96e4154a014e data/mekanism/worldgen/placed_feature/salt_retrogen.json

--- a/src/datagen/generated/mekanism/data/mekanism/worldgen/configured_feature/salt.json
+++ b/src/datagen/generated/mekanism/data/mekanism/worldgen/configured_feature/salt.json
@@ -1,6 +1,9 @@
 {
   "type": "mekanism:disk",
   "config": {
+    "radius": {
+      "type": "mekanism:configurable_uniform"
+    },
     "state_provider": {
       "fallback": {
         "type": "minecraft:simple_state_provider",
@@ -9,6 +12,13 @@
         }
       },
       "rules": []
+    },
+    "target": {
+      "type": "minecraft:matching_blocks",
+      "blocks": [
+        "minecraft:dirt",
+        "minecraft:clay"
+      ]
     }
   }
 }

--- a/src/datagen/generated/mekanism/data/mekanism/worldgen/configured_feature/salt.json
+++ b/src/datagen/generated/mekanism/data/mekanism/worldgen/configured_feature/salt.json
@@ -1,8 +1,14 @@
 {
   "type": "mekanism:disk",
   "config": {
-    "state": {
-      "Name": "mekanism:block_salt"
+    "state_provider": {
+      "fallback": {
+        "type": "minecraft:simple_state_provider",
+        "state": {
+          "Name": "mekanism:block_salt"
+        }
+      },
+      "rules": []
     }
   }
 }

--- a/src/datagen/generated/mekanism/data/mekanism/worldgen/placed_feature/salt.json
+++ b/src/datagen/generated/mekanism/data/mekanism/worldgen/placed_feature/salt.json
@@ -19,6 +19,13 @@
       "heightmap": "OCEAN_FLOOR_WG"
     },
     {
+      "type": "minecraft:block_predicate_filter",
+      "predicate": {
+        "type": "minecraft:matching_fluids",
+        "fluids": "minecraft:water"
+      }
+    },
+    {
       "type": "minecraft:biome"
     }
   ]

--- a/src/datagen/generated/mekanism/data/mekanism/worldgen/placed_feature/salt_retrogen.json
+++ b/src/datagen/generated/mekanism/data/mekanism/worldgen/placed_feature/salt_retrogen.json
@@ -19,6 +19,13 @@
       "heightmap": "OCEAN_FLOOR"
     },
     {
+      "type": "minecraft:block_predicate_filter",
+      "predicate": {
+        "type": "minecraft:matching_fluids",
+        "fluids": "minecraft:water"
+      }
+    },
+    {
       "type": "minecraft:biome"
     }
   ]

--- a/src/datagen/main/java/mekanism/common/registries/MekanismDatapackRegistryProvider.java
+++ b/src/datagen/main/java/mekanism/common/registries/MekanismDatapackRegistryProvider.java
@@ -21,6 +21,7 @@ import mekanism.common.resource.ore.OreType.OreVeinType;
 import mekanism.common.tags.MekanismTags;
 import mekanism.common.util.EnumUtils;
 import mekanism.common.world.ConfigurableConstantInt;
+import mekanism.common.world.ConfigurableUniformInt;
 import mekanism.common.world.DisableableFeaturePlacement;
 import mekanism.common.world.ResizableDiskConfig;
 import mekanism.common.world.ResizableOreFeature;
@@ -39,10 +40,13 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.world.damagesource.DamageType;
 import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.levelgen.GenerationStep;
+import net.minecraft.world.level.levelgen.blockpredicates.BlockPredicate;
 import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
 import net.minecraft.world.level.levelgen.feature.configurations.OreConfiguration;
 import net.minecraft.world.level.levelgen.feature.configurations.OreConfiguration.TargetBlockState;
+import net.minecraft.world.level.levelgen.feature.stateproviders.RuleBasedBlockStateProvider;
 import net.minecraft.world.level.levelgen.placement.BiomeFilter;
 import net.minecraft.world.level.levelgen.placement.CountPlacement;
 import net.minecraft.world.level.levelgen.placement.HeightRangePlacement;
@@ -88,8 +92,11 @@ public class MekanismDatapackRegistryProvider extends BaseDatapackRegistryProvid
                       context.register(configuredFeature(name.withSuffix("_retrogen")), configureOreFeature(oreVeinType, MekanismFeatures.ORE_RETROGEN));
                   }
               }
-              context.register(configuredFeature(Mekanism.rl("salt")), new ConfiguredFeature<>(MekanismFeatures.DISK.get(),
-                    new ResizableDiskConfig(MekanismBlocks.SALT_BLOCK.getBlock().defaultBlockState(), MekanismConfig.world.salt)));
+              context.register(configuredFeature(Mekanism.rl("salt")), new ConfiguredFeature<>(MekanismFeatures.DISK.get(), new ResizableDiskConfig(
+                    RuleBasedBlockStateProvider.simple(MekanismBlocks.SALT_BLOCK.getBlock()),
+                    BlockPredicate.matchesBlocks(Blocks.DIRT, Blocks.CLAY),
+                    ConfigurableUniformInt.SALT
+              )));
           })
           .add(Registries.PLACED_FEATURE, context -> {
               for (OreType type : EnumUtils.ORE_TYPES) {

--- a/src/datagen/main/java/mekanism/common/registries/MekanismDatapackRegistryProvider.java
+++ b/src/datagen/main/java/mekanism/common/registries/MekanismDatapackRegistryProvider.java
@@ -48,12 +48,14 @@ import net.minecraft.world.level.levelgen.feature.configurations.OreConfiguratio
 import net.minecraft.world.level.levelgen.feature.configurations.OreConfiguration.TargetBlockState;
 import net.minecraft.world.level.levelgen.feature.stateproviders.RuleBasedBlockStateProvider;
 import net.minecraft.world.level.levelgen.placement.BiomeFilter;
+import net.minecraft.world.level.levelgen.placement.BlockPredicateFilter;
 import net.minecraft.world.level.levelgen.placement.CountPlacement;
 import net.minecraft.world.level.levelgen.placement.HeightRangePlacement;
 import net.minecraft.world.level.levelgen.placement.InSquarePlacement;
 import net.minecraft.world.level.levelgen.placement.PlacedFeature;
 import net.minecraft.world.level.levelgen.structure.templatesystem.RuleTest;
 import net.minecraft.world.level.levelgen.structure.templatesystem.TagMatchTest;
+import net.minecraft.world.level.material.Fluids;
 import net.minecraftforge.common.world.ForgeBiomeModifiers.AddFeaturesBiomeModifier;
 import net.minecraftforge.registries.ForgeRegistries;
 
@@ -119,6 +121,7 @@ public class MekanismDatapackRegistryProvider extends BaseDatapackRegistryProvid
                     CountPlacement.of(new ConfigurableConstantInt(null, MekanismConfig.world.salt.perChunk)),
                     InSquarePlacement.spread(),
                     retrogen ? PlacementUtils.HEIGHTMAP_OCEAN_FLOOR : PlacementUtils.HEIGHTMAP_TOP_SOLID,
+                    BlockPredicateFilter.forPredicate(BlockPredicate.matchesFluids(Fluids.WATER)),
                     BiomeFilter.biome()
               ));
           })

--- a/src/main/java/mekanism/common/world/ResizableDiskConfig.java
+++ b/src/main/java/mekanism/common/world/ResizableDiskConfig.java
@@ -2,30 +2,30 @@ package mekanism.common.world;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
-import java.util.List;
 import java.util.function.IntSupplier;
 import mekanism.common.config.MekanismConfig;
 import mekanism.common.config.WorldConfig.SaltConfig;
 import net.minecraft.util.valueproviders.IntProvider;
 import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.levelgen.blockpredicates.BlockPredicate;
 import net.minecraft.world.level.levelgen.feature.configurations.FeatureConfiguration;
+import net.minecraft.world.level.levelgen.feature.stateproviders.RuleBasedBlockStateProvider;
 
 public class ResizableDiskConfig implements FeatureConfiguration {
 
     public static final Codec<ResizableDiskConfig> CODEC = RecordCodecBuilder.create(builder -> builder.group(
-          BlockState.CODEC.fieldOf("state").forGetter(config -> config.state)
-    ).apply(builder, state -> new ResizableDiskConfig(state, MekanismConfig.world.salt)));
+            RuleBasedBlockStateProvider.CODEC.fieldOf("state_provider").forGetter(config -> config.stateProvider)
+    ).apply(builder, stateProvider -> new ResizableDiskConfig(stateProvider, MekanismConfig.world.salt)));
 
-    public final BlockState state;
+    public final RuleBasedBlockStateProvider stateProvider;
     public final IntProvider radius;
     public final IntSupplier halfHeight;
-    public final List<BlockState> targets;
+    public final BlockPredicate target;
 
-    public ResizableDiskConfig(BlockState state, SaltConfig saltConfig) {
-        this.state = state;
+    public ResizableDiskConfig(RuleBasedBlockStateProvider stateProvider, SaltConfig saltConfig) {
+        this.stateProvider = stateProvider;
         this.radius = ConfigurableUniformInt.SALT;
         this.halfHeight = saltConfig.halfHeight;
-        this.targets = List.of(Blocks.DIRT.defaultBlockState(), Blocks.CLAY.defaultBlockState(), this.state);
+        this.target = BlockPredicate.matchesBlocks(Blocks.DIRT, Blocks.CLAY);
     }
 }

--- a/src/main/java/mekanism/common/world/ResizableDiskReplaceFeature.java
+++ b/src/main/java/mekanism/common/world/ResizableDiskReplaceFeature.java
@@ -1,16 +1,11 @@
 package mekanism.common.world;
 
 import com.mojang.serialization.Codec;
-import net.minecraft.core.BlockPos;
-import net.minecraft.tags.FluidTags;
-import net.minecraft.world.level.WorldGenLevel;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.feature.Feature;
 import net.minecraft.world.level.levelgen.feature.FeaturePlaceContext;
+import net.minecraft.world.level.levelgen.feature.configurations.DiskConfiguration;
 
-//Modified copy of vanilla's DiskReplaceFeature/BaseDiskFeature but to support ResizableSphereReplaceConfig
-// and without support for falling blocks
+// Wrapper for vanilla's DiskReplaceFeature to support ResizableDiskConfig.halfHeight (mekanism config IntSupplier)
 public class ResizableDiskReplaceFeature extends Feature<ResizableDiskConfig> {
 
     public ResizableDiskReplaceFeature(Codec<ResizableDiskConfig> codec) {
@@ -19,38 +14,21 @@ public class ResizableDiskReplaceFeature extends Feature<ResizableDiskConfig> {
 
     @Override
     public boolean place(FeaturePlaceContext<ResizableDiskConfig> context) {
-        boolean placed = false;
-        BlockPos pos = context.origin();
-        WorldGenLevel world = context.level();
-        if (world.getFluidState(pos).is(FluidTags.WATER)) {
-            ResizableDiskConfig config = context.config();
-            int halfHeight = config.halfHeight.getAsInt();
-            int yMax = pos.getY() + halfHeight;
-            int yMin = pos.getY() - halfHeight - 1;
-            int radius = config.radius.sample(context.random());
-            int radiusSquared = radius * radius;
-            for (int x = pos.getX() - radius; x <= pos.getX() + radius; ++x) {
-                int xRadius = x - pos.getX();
-                int xRadiusSquared = xRadius * xRadius;
-                for (int z = pos.getZ() - radius; z <= pos.getZ() + radius; ++z) {
-                    int zRadius = z - pos.getZ();
-                    if (xRadiusSquared + zRadius * zRadius <= radiusSquared) {
-                        for (int y = yMax; y > yMin; --y) {
-                            BlockPos targetPos = new BlockPos(x, y, z);
-                            Block blockAtTarget = world.getBlockState(targetPos).getBlock();
-                            for (BlockState target : config.targets) {
-                                if (target.is(blockAtTarget)) {
-                                    world.setBlock(targetPos, config.state, Block.UPDATE_CLIENTS);
-                                    markAboveForPostProcessing(world, targetPos);
-                                    placed = true;
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        return placed;
+        ResizableDiskConfig config = context.config();
+        DiskConfiguration vanillaConfig = new DiskConfiguration(
+                config.stateProvider,
+                config.target,
+                config.radius,
+                config.halfHeight.getAsInt()
+        );
+        FeaturePlaceContext<DiskConfiguration> vanillaContext = new FeaturePlaceContext<>(
+                context.topFeature(),
+                context.level(),
+                context.chunkGenerator(),
+                context.random(),
+                context.origin(),
+                vanillaConfig
+        );
+        return Feature.DISK.place(vanillaContext);
     }
 }

--- a/src/main/java/mekanism/common/world/ResizableDiskReplaceFeature.java
+++ b/src/main/java/mekanism/common/world/ResizableDiskReplaceFeature.java
@@ -14,20 +14,13 @@ public class ResizableDiskReplaceFeature extends Feature<ResizableDiskConfig> {
 
     @Override
     public boolean place(FeaturePlaceContext<ResizableDiskConfig> context) {
-        ResizableDiskConfig config = context.config();
-        DiskConfiguration vanillaConfig = new DiskConfiguration(
-                config.stateProvider,
-                config.target,
-                config.radius,
-                config.halfHeight.getAsInt()
-        );
         FeaturePlaceContext<DiskConfiguration> vanillaContext = new FeaturePlaceContext<>(
-                context.topFeature(),
-                context.level(),
-                context.chunkGenerator(),
-                context.random(),
-                context.origin(),
-                vanillaConfig
+              context.topFeature(),
+              context.level(),
+              context.chunkGenerator(),
+              context.random(),
+              context.origin(),
+              context.config().asVanillaConfig()
         );
         return Feature.DISK.place(vanillaContext);
     }


### PR DESCRIPTION
## Changes proposed in this pull request:

The surface salt deposit placements currently use a copy of the vanilla code. This causes them not to pick up changes made by other mods that try to break up the monotony of (or otherwise change) the shapes of the vanilla disks:

![image](https://github.com/mekanism/Mekanism/assets/8829856/2f914784-fb42-4389-bbb3-73245081819c)

By reworking the disk feature in Mekanism to call the vanilla code, the changes are now picked up:

![image](https://github.com/mekanism/Mekanism/assets/8829856/2e103a8f-953b-406f-85a7-792badffa6ee)

Without the mods in question present, Mekanism behaves as it did before:

![image](https://github.com/mekanism/Mekanism/assets/8829856/7882cca1-9f13-48ad-951d-5a69cd47e924)
