### PR TITLE
Add missing lang conversion for "Stabilisation"

### DIFF
--- a/src/datagen/main/java/mekanism/client/lang/NonAmericanLanguageProvider.java
+++ b/src/datagen/main/java/mekanism/client/lang/NonAmericanLanguageProvider.java
@@ -17,6 +17,7 @@ public class NonAmericanLanguageProvider extends ConvertibleLanguageProvider {
         addEntry(map, "Pressurized", "Pressurised");
         addEntry(map, "Stabilizer", "Stabiliser");
         addEntry(map, "Stabilizing", "Stabilising");
+        addEntry(map, "Stabilization", "Stabilisation");
         addEntry(map, "Crystallizer", "Crystalliser");
         addEntry(map, "Nucleosynthesizer", "Nucleosynthesiser");
         addEntry(map, "Color", "Colour");


### PR DESCRIPTION
## Changes proposed in this pull request:
The Gyroscopic Stabilisation Unit has an incorrect name in UK and Australian English ("z" instead of "s"), as the word "Stabilization" isn't included in the autoconversion. This PR simply adds that missing entry.