### PR TITLE
Update to 1.20.4 CC:T

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -439,9 +439,8 @@ dependencies {
     compileOnly("top.theillusivec4.curios:curios-neoforge:${curios_version}:api")
     compileOnly("com.blamejared.recipestages:RecipeStages:${recipe_stages_version}")
     compileOnly("curse.maven:opencomputers2-437654:${oc2_id}")
-    compileOnly("cc.tweaked:cc-tweaked-${previous_minecraft_version}-forge-api:${cc_tweaked_version}")
-    compileOnly("cc.tweaked:cc-tweaked-${previous_minecraft_version}-core-api:${cc_tweaked_version}")
-    //runtimeOnly fg.deobf("cc.tweaked:cc-tweaked-${minecraft_version}-forge:${cc_tweaked_version}")
+    compileOnly("cc.tweaked:cc-tweaked-${minecraft_version}-forge-api:${cc_tweaked_version}")
+    runtimeOnly("cc.tweaked:cc-tweaked-${minecraft_version}-forge:${cc_tweaked_version}")
     compileOnly("curse.maven:female-gender-forge-481655:${wildfire_gender_mod_id}")
 
     //Dependencies for data generators for mod compat reference

--- a/build.gradle
+++ b/build.gradle
@@ -440,7 +440,7 @@ dependencies {
     compileOnly("com.blamejared.recipestages:RecipeStages:${recipe_stages_version}")
     compileOnly("curse.maven:opencomputers2-437654:${oc2_id}")
     compileOnly("cc.tweaked:cc-tweaked-${minecraft_version}-forge-api:${cc_tweaked_version}")
-    runtimeOnly("cc.tweaked:cc-tweaked-${minecraft_version}-forge:${cc_tweaked_version}")
+    //runtimeOnly("cc.tweaked:cc-tweaked-${minecraft_version}-forge:${cc_tweaked_version}")
     compileOnly("curse.maven:female-gender-forge-481655:${wildfire_gender_mod_id}")
 
     //Dependencies for data generators for mod compat reference

--- a/gradle.properties
+++ b/gradle.properties
@@ -56,7 +56,7 @@ glitchcore_version=1.0.0.59
 terrablender_version=3.3.0.12
 
 #Outdated mod dependencies
-cc_tweaked_version=1.109.5
+cc_tweaked_version=1.109.6
 ctm_version=1.1.7+11
 flux_networks_id=4651164
 jeitweaker_version=8.0.5

--- a/src/main/java/mekanism/common/integration/MekanismHooks.java
+++ b/src/main/java/mekanism/common/integration/MekanismHooks.java
@@ -40,25 +40,36 @@ public final class MekanismHooks {
     public static final String TOP_MOD_ID = "theoneprobe";
     public static final String WILDFIRE_GENDER_MOD_ID = "wildfire_gender";
 
-    public boolean CCLoaded;
-    public boolean CraftTweakerLoaded;
-    public boolean CuriosLoaded;
-    public boolean DMELoaded;
-    public boolean FluxNetworksLoaded;
-    public boolean JEILoaded;
-    public boolean JsonThingsLoaded;
-    public boolean OC2Loaded;
-    public boolean ProjectELoaded;
-    public boolean RecipeStagesLoaded;
-    public boolean TOPLoaded;
-    public boolean WildfireGenderModLoaded;
+    public final boolean CCLoaded;
+    public final boolean CraftTweakerLoaded;
+    public final boolean CuriosLoaded;
+    public final boolean DMELoaded;
+    public final boolean FluxNetworksLoaded;
+    public final boolean JEILoaded;
+    public final boolean JsonThingsLoaded;
+    public final boolean OC2Loaded;
+    public final boolean ProjectELoaded;
+    public final boolean RecipeStagesLoaded;
+    public final boolean TOPLoaded;
+    public final boolean WildfireGenderModLoaded;
 
-    public void hookConstructor(final IEventBus bus) {
+    public MekanismHooks() {
         ModList modList = ModList.get();
+        CCLoaded = modList.isLoaded(CC_MOD_ID);
         CraftTweakerLoaded = modList.isLoaded(CRAFTTWEAKER_MOD_ID);
         CuriosLoaded = modList.isLoaded(CURIOS_MODID);
+        DMELoaded = modList.isLoaded(DARK_MODE_EVERYWHERE_MODID);
+        FluxNetworksLoaded = modList.isLoaded(FLUX_NETWORKS_MOD_ID);
+        JEILoaded = modList.isLoaded(JEI_MOD_ID);
         JsonThingsLoaded = modList.isLoaded(JSON_THINGS_MOD_ID);
+        OC2Loaded = modList.isLoaded(OC2_MOD_ID);
         ProjectELoaded = modList.isLoaded(PROJECTE_MOD_ID);
+        RecipeStagesLoaded = modList.isLoaded(RECIPE_STAGES_MOD_ID);
+        TOPLoaded = modList.isLoaded(TOP_MOD_ID);
+        WildfireGenderModLoaded = modList.isLoaded(WILDFIRE_GENDER_MOD_ID);
+    }
+
+    public void hookConstructor(final IEventBus bus) {
         if (CuriosLoaded) {
             CuriosIntegration.addListeners(bus);
         }
@@ -82,21 +93,11 @@ public final class MekanismHooks {
     }
 
     public void hookCapabilityRegistration() {
-        //Note: Caps get registered before common setup, so we need to make sure these values have been set
-        ModList modList = ModList.get();
-        FluxNetworksLoaded = modList.isLoaded(FLUX_NETWORKS_MOD_ID);
-        WildfireGenderModLoaded = modList.isLoaded(WILDFIRE_GENDER_MOD_ID);
         EnergyCompatUtils.initLoadedCache();
     }
 
     public void hookCommonSetup() {
         ModList modList = ModList.get();
-        CCLoaded = modList.isLoaded(CC_MOD_ID);
-        DMELoaded = modList.isLoaded(DARK_MODE_EVERYWHERE_MODID);
-        JEILoaded = modList.isLoaded(JEI_MOD_ID);
-        OC2Loaded = modList.isLoaded(OC2_MOD_ID);
-        RecipeStagesLoaded = modList.isLoaded(RECIPE_STAGES_MOD_ID);
-        TOPLoaded = modList.isLoaded(TOP_MOD_ID);
         if (computerCompatEnabled()) {
             FactoryRegistry.load();
             if (CCLoaded) {

--- a/src/main/java/mekanism/common/integration/computer/computercraft/CCCapabilityHelper.java
+++ b/src/main/java/mekanism/common/integration/computer/computercraft/CCCapabilityHelper.java
@@ -2,27 +2,24 @@ package mekanism.common.integration.computer.computercraft;
 
 import dan200.computercraft.api.ComputerCraftAPI;
 import dan200.computercraft.api.peripheral.IPeripheral;
+import dan200.computercraft.api.peripheral.PeripheralCapability;
 import java.util.function.BooleanSupplier;
 import mekanism.common.capabilities.resolver.BasicCapabilityResolver;
-import mekanism.common.integration.MekanismHooks;
 import mekanism.common.integration.computer.ComputerEnergyHelper;
 import mekanism.common.integration.computer.ComputerFilterHelper;
 import mekanism.common.integration.computer.IComputerTile;
 import mekanism.common.registration.impl.TileEntityTypeDeferredRegister.BlockEntityTypeBuilder;
 import mekanism.common.tile.base.CapabilityTileEntity;
 import net.minecraft.core.Direction;
-import net.minecraft.resources.ResourceLocation;
-import net.neoforged.neoforge.capabilities.BlockCapability;
 import net.neoforged.neoforge.capabilities.ICapabilityProvider;
 import org.jetbrains.annotations.Nullable;
 
 public class CCCapabilityHelper {
 
-    private static final BlockCapability<IPeripheral, @Nullable Direction> CAPABILITY = BlockCapability.createSided(new ResourceLocation(MekanismHooks.CC_MOD_ID, "peripheral"), IPeripheral.class);
     private static final ICapabilityProvider<?, @Nullable Direction, IPeripheral> PROVIDER = getProvider();
 
     private static <TILE extends CapabilityTileEntity & IComputerTile> ICapabilityProvider<TILE, @Nullable Direction, IPeripheral> getProvider() {
-        return CapabilityTileEntity.capabilityProvider(CAPABILITY, (tile, cap) -> {
+        return CapabilityTileEntity.capabilityProvider(PeripheralCapability.get(), (tile, cap) -> {
             if (tile.isComputerCapabilityPersistent()) {
                 return BasicCapabilityResolver.persistent(cap, () -> MekanismPeripheral.create(tile));
             }
@@ -32,7 +29,7 @@ public class CCCapabilityHelper {
 
     @SuppressWarnings("unchecked")
     public static <TILE extends CapabilityTileEntity & IComputerTile> void addCapability(BlockEntityTypeBuilder<TILE> builder, BooleanSupplier supportsComputer) {
-        builder.with(CAPABILITY, (ICapabilityProvider<? super TILE, @Nullable Direction, IPeripheral>) PROVIDER, supportsComputer);
+        builder.with(PeripheralCapability.get(), (ICapabilityProvider<? super TILE, @Nullable Direction, IPeripheral>) PROVIDER, supportsComputer);
     }
 
     public static void registerApis() {

--- a/src/main/java/mekanism/common/integration/computer/computercraft/CCMethodCaller.java
+++ b/src/main/java/mekanism/common/integration/computer/computercraft/CCMethodCaller.java
@@ -36,8 +36,8 @@ public class CCMethodCaller extends BoundMethodHolder {
         if (methodToCall.threadSafe()) {
             return callHandler(arguments, methodToCall);
         }
-        IArguments escaped = arguments.escapes();
-        return context.executeMainThreadTask(() -> callHandler(escaped, methodToCall).getResult());
+        arguments.escapes();
+        return context.executeMainThreadTask(() -> callHandler(arguments, methodToCall).getResult());
     }
 
     @NotNull


### PR DESCRIPTION
This updates the CC:T to use the 1.20.4 version. There's a small change in the API which need to be accounted for:

 - `IArguments.escapes` mutates in place rather than returning a new value.

Also:
 - Use `PeripheralCapability.get()` rather than creating the capability ourselves.
 - Move "is mod loaded" checks to the constructor of `MekanismHooks`. These fields were being read too early, which meant the capabilities weren't being registered. We could move the initialisation, but it seemed better just to make sure this can never happen.