### PR TITLE
Added "isIgnited" to FusionReactorMultiblockData

### DIFF
--- a/src/api/java/mekanism/api/recipes/cache/OneInputCachedRecipe.java
+++ b/src/api/java/mekanism/api/recipes/cache/OneInputCachedRecipe.java
@@ -30,7 +30,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * Base class to help implement handling of recipes with two inputs.
+ * Base class to help implement handling of recipes with one input.
  */
 @NothingNullByDefault
 public class OneInputCachedRecipe<INPUT, OUTPUT, RECIPE extends MekanismRecipe & Predicate<INPUT>> extends CachedRecipe<RECIPE> {

--- a/src/datagen/generated/mekanism/.cache/2ca94f3a6e22cb9eec299788405fc6e4ad158c09
+++ b/src/datagen/generated/mekanism/.cache/2ca94f3a6e22cb9eec299788405fc6e4ad158c09
@@ -1,6 +1,6 @@
-// 1.20.4	2024-04-01T13:34:23.715519	ComputerHelp: mekanism
+// 1.20.4	2024-04-04T20:21:05.3544014	ComputerHelp: mekanism
 94b6d2a203a16827e2f54f7489e90159992acdb3 data/mekanism/computer_help/enums.csv
 b38b847919651e2a55bc3eb8c719b2d92f76de7a data/mekanism/computer_help/enums.json
-b0d0ea50ba3d06cf9b72519f6c333db4c3968696 data/mekanism/computer_help/jekyll.md
-e11332cfebf5acd64a3ddc3bb9058d6e28692ec6 data/mekanism/computer_help/methods.csv
-6f32727c8756e01ba3cfe454eafde3ca0dd2832a data/mekanism/computer_help/methods.json
+03c9d1bfabf36379bcfda75a8431ca230183c635 data/mekanism/computer_help/jekyll.md
+3d72ee50a142f8c4ff9b8b1d6c07e31cbda17d79 data/mekanism/computer_help/methods.csv
+f2c67736745f50fe7e3c2a8b38a514903448aab7 data/mekanism/computer_help/methods.json

--- a/src/datagen/generated/mekanism/data/mekanism/computer_help/jekyll.md
+++ b/src/datagen/generated/mekanism/data/mekanism/computer_help/jekyll.md
@@ -2565,6 +2565,11 @@ methods:
     returns:
       javaType: int
       type: Number (int)
+  - description: Checks if a reaction is occurring.
+    methodName: isIgnited
+    returns:
+      javaType: boolean
+      type: boolean
   - methodName: setInjectionRate
     params:
     - javaType: int
@@ -4579,5 +4584,5 @@ methods:
     returns:
       javaType: boolean
       type: boolean
-version: 10.5.13
+version: 10.5.14
 ---

--- a/src/datagen/generated/mekanism/data/mekanism/computer_help/methods.csv
+++ b/src/datagen/generated/mekanism/data/mekanism/computer_help/methods.csv
@@ -405,6 +405,7 @@ Fusion Reactor Multiblock (formed),getWater,,Table (FluidStack),,false,Get the c
 Fusion Reactor Multiblock (formed),getWaterCapacity,,Number (int),,false,Get the capacity of the water tank.
 Fusion Reactor Multiblock (formed),getWaterFilledPercentage,,Number (double),,false,Get the filled percentage of the water tank.
 Fusion Reactor Multiblock (formed),getWaterNeeded,,Number (int),,false,Get the amount needed to fill the water tank.
+Fusion Reactor Multiblock (formed),isIgnited,,boolean,,false,Checks if a reaction is occurring.
 Fusion Reactor Multiblock (formed),setInjectionRate,rate: Number (int),,,false,
 Fusion Reactor Port,getMode,,boolean,,false,"true -> output, false -> input"
 Fusion Reactor Port,setMode,output: boolean,,,false,"true -> output, false -> input"

--- a/src/datagen/generated/mekanism/data/mekanism/computer_help/methods.json
+++ b/src/datagen/generated/mekanism/data/mekanism/computer_help/methods.json
@@ -3530,6 +3530,14 @@
       }
     },
     {
+      "description": "Checks if a reaction is occurring.",
+      "methodName": "isIgnited",
+      "returns": {
+        "type": "boolean",
+        "javaType": "boolean"
+      }
+    },
+    {
       "methodName": "setInjectionRate",
       "params": [
         {

--- a/src/generators/java/mekanism/generators/common/content/fusion/FusionReactorMultiblockData.java
+++ b/src/generators/java/mekanism/generators/common/content/fusion/FusionReactorMultiblockData.java
@@ -417,6 +417,7 @@ public class FusionReactorMultiblockData extends MultiblockData {
         return maxSteam;
     }
 
+    @ComputerMethod(nameOverride = "isIgnited", methodDescription = "Checks if a reaction is occurring.")
     public boolean isBurning() {
         return burning;
     }


### PR DESCRIPTION
## Changes proposed in this pull request:
Added "isIgnited" to FusionReactorMultiblockData and fixed a typo in OneInputCachedRecipe