### PR TITLE
Nonticking structural

### DIFF
--- a/src/api/java/mekanism/api/MekanismAPI.java
+++ b/src/api/java/mekanism/api/MekanismAPI.java
@@ -29,7 +29,7 @@ public class MekanismAPI {
     /**
      * The version of the api classes - may not always match the mod's version
      */
-    public static final String API_VERSION = "10.5.16";
+    public static final String API_VERSION = "10.5.18";
     /**
      * Mekanism's Mod ID
      */

--- a/src/api/java/mekanism/api/MekanismAPI.java
+++ b/src/api/java/mekanism/api/MekanismAPI.java
@@ -29,7 +29,7 @@ public class MekanismAPI {
     /**
      * The version of the api classes - may not always match the mod's version
      */
-    public static final String API_VERSION = "10.5.15";
+    public static final String API_VERSION = "10.5.16";
     /**
      * Mekanism's Mod ID
      */

--- a/src/api/java/mekanism/api/NBTConstants.java
+++ b/src/api/java/mekanism/api/NBTConstants.java
@@ -124,7 +124,7 @@ public final class NBTConstants {
     public static final String FILTERS = "filters";
     public static final String FINISHED = "finished";
     /**
-     * @since 10.5.16
+     * @since 10.5.18
      */
     public static final String FORMED = "formed";
     public static final String FLUID_STORED = "fluid";
@@ -140,7 +140,7 @@ public final class NBTConstants {
     public static final String GAS_STORED_ALT_2 = "gas2";
     public static final String GAS_TANKS = "GasTanks";
     /**
-     * @since 10.5.16
+     * @since 10.5.18
      */
     public static final String GUI = "gui";
     public static final String HANDLE_SOUND = "handleSound";

--- a/src/api/java/mekanism/api/NBTConstants.java
+++ b/src/api/java/mekanism/api/NBTConstants.java
@@ -123,6 +123,10 @@ public final class NBTConstants {
     public static final String FILTER = "filter";
     public static final String FILTERS = "filters";
     public static final String FINISHED = "finished";
+    /**
+     * @since 10.5.16
+     */
+    public static final String FORMED = "formed";
     public static final String FLUID_STORED = "fluid";
     public static final String FLUID_TANKS = "FluidTanks";
     public static final String FOLLOW = "follow";
@@ -135,6 +139,10 @@ public final class NBTConstants {
     public static final String GAS_STORED_ALT = "gas1";
     public static final String GAS_STORED_ALT_2 = "gas2";
     public static final String GAS_TANKS = "GasTanks";
+    /**
+     * @since 10.5.16
+     */
+    public static final String GUI = "gui";
     public static final String HANDLE_SOUND = "handleSound";
     public static final String HEAT_CAPACITORS = "HeatCapacitors";
     public static final String HEAT_CAPACITY = "heatCapacity";

--- a/src/generators/java/mekanism/generators/common/content/fusion/FusionReactorMultiblockData.java
+++ b/src/generators/java/mekanism/generators/common/content/fusion/FusionReactorMultiblockData.java
@@ -33,6 +33,7 @@ import mekanism.common.inventory.container.sync.dynamic.ContainerSync;
 import mekanism.common.lib.multiblock.IValveHandler.ValveData;
 import mekanism.common.lib.multiblock.MultiblockData;
 import mekanism.common.registries.MekanismGases;
+import mekanism.common.tile.prefab.TileEntityStructuralMultiblock;
 import mekanism.common.util.CableUtils;
 import mekanism.common.util.ChemicalUtil;
 import mekanism.common.util.HeatUtils;
@@ -168,6 +169,11 @@ public class FusionReactorMultiblockData extends MultiblockData {
         }
         biomeAmbientTemp = calculateAverageAmbientTemperature(world);
         deathZone = AABB.encapsulatingFullBlocks(getMinPos().offset(1, 1, 1), getMaxPos().offset(-1, -1, -1));
+    }
+
+    @Override
+    public boolean allowsStructuralGuiAccess(TileEntityStructuralMultiblock multiblock) {
+        return false;
     }
 
     @Override

--- a/src/generators/java/mekanism/generators/common/registries/GeneratorsTileEntityTypes.java
+++ b/src/generators/java/mekanism/generators/common/registries/GeneratorsTileEntityTypes.java
@@ -74,7 +74,6 @@ public class GeneratorsTileEntityTypes {
     //Misc
     public static final TileEntityTypeRegistryObject<TileEntityReactorGlass> REACTOR_GLASS = TILE_ENTITY_TYPES
           .mekBuilder(GeneratorsBlocks.REACTOR_GLASS, TileEntityReactorGlass::new)
-          .serverTicker(TileEntityMekanism::tickServer)
           .withSimple(Capabilities.CONFIGURABLE)
           .build();
     //Fission Reactor

--- a/src/main/java/mekanism/common/block/basic/BlockStructuralGlass.java
+++ b/src/main/java/mekanism/common/block/basic/BlockStructuralGlass.java
@@ -29,12 +29,10 @@ public class BlockStructuralGlass<TILE extends TileEntityStructuralMultiblock> e
         if (tile == null) {
             return InteractionResult.PASS;
         } else if (world.isClientSide) {
-            if (!MekanismUtils.canUseAsWrench(player.getItemInHand(hand))) {
-                if (!tile.structuralGuiAccessAllowed() || !tile.hasFormedMultiblock()) {
-                    //If the block's multiblock doesn't allow gui access via structural multiblocks (for example the evaporation plant),
-                    // or if the multiblock is not formed then pass
-                    return InteractionResult.PASS;
-                }
+            if (!MekanismUtils.canUseAsWrench(player.getItemInHand(hand)) && !tile.structuralGuiAccessAllowed()) {
+                //If the block's multiblock doesn't allow gui access via structural multiblocks (for example the evaporation plant),
+                // or if the multiblock is not formed then pass
+                return InteractionResult.PASS;
             }
             return InteractionResult.SUCCESS;
         }

--- a/src/main/java/mekanism/common/content/boiler/BoilerMultiblockData.java
+++ b/src/main/java/mekanism/common/content/boiler/BoilerMultiblockData.java
@@ -30,6 +30,7 @@ import mekanism.common.integration.computer.annotation.WrappingComputerMethod;
 import mekanism.common.inventory.container.sync.dynamic.ContainerSync;
 import mekanism.common.lib.multiblock.IValveHandler;
 import mekanism.common.lib.multiblock.MultiblockData;
+import mekanism.common.lib.multiblock.Structure;
 import mekanism.common.registries.MekanismGases;
 import mekanism.common.tile.multiblock.TileEntityBoilerCasing;
 import mekanism.common.tile.multiblock.TileEntityBoilerValve;
@@ -136,9 +137,9 @@ public class BoilerMultiblockData extends MultiblockData implements IValveHandle
     }
 
     @Override
-    public void remove(Level world) {
+    public void remove(Level world, Structure oldStructure) {
         hotMap.removeBoolean(inventoryID);
-        super.remove(world);
+        super.remove(world, oldStructure);
     }
 
     @Override

--- a/src/main/java/mekanism/common/content/evaporation/EvaporationMultiblockData.java
+++ b/src/main/java/mekanism/common/content/evaporation/EvaporationMultiblockData.java
@@ -34,6 +34,7 @@ import mekanism.common.inventory.slot.FluidInventorySlot;
 import mekanism.common.inventory.slot.OutputInventorySlot;
 import mekanism.common.lib.multiblock.IValveHandler;
 import mekanism.common.lib.multiblock.MultiblockData;
+import mekanism.common.lib.multiblock.Structure;
 import mekanism.common.recipe.IMekanismRecipeTypeProvider;
 import mekanism.common.recipe.MekanismRecipeType;
 import mekanism.common.recipe.lookup.ISingleRecipeLookupHandler.FluidRecipeLookupHandler;
@@ -41,6 +42,7 @@ import mekanism.common.recipe.lookup.cache.InputRecipeCache.SingleFluid;
 import mekanism.common.recipe.lookup.monitor.RecipeCacheLookupMonitor;
 import mekanism.common.tile.multiblock.TileEntityThermalEvaporationBlock;
 import mekanism.common.tile.prefab.TileEntityRecipeMachine;
+import mekanism.common.tile.prefab.TileEntityStructuralMultiblock;
 import mekanism.common.util.MekanismUtils;
 import mekanism.common.util.NBTUtils;
 import net.minecraft.core.BlockPos;
@@ -156,6 +158,11 @@ public class EvaporationMultiblockData extends MultiblockData implements IValveH
             needsPacket = true;
         }
         return needsPacket;
+    }
+
+    @Override
+    public boolean allowsStructuralGuiAccess(TileEntityStructuralMultiblock multiblock) {
+        return false;
     }
 
     @Override
@@ -302,9 +309,9 @@ public class EvaporationMultiblockData extends MultiblockData implements IValveH
     }
 
     @Override
-    public void remove(Level world) {
+    public void remove(Level world, Structure oldStructure) {
         //Clear the cached solar panels so that we don't hold references to them and prevent them from being able to be garbage collected
         cachedSolar.clear();
-        super.remove(world);
+        super.remove(world, oldStructure);
     }
 }

--- a/src/main/java/mekanism/common/content/matrix/MatrixMultiblockData.java
+++ b/src/main/java/mekanism/common/content/matrix/MatrixMultiblockData.java
@@ -12,6 +12,7 @@ import mekanism.common.inventory.slot.EnergyInventorySlot;
 import mekanism.common.lib.multiblock.IValveHandler.ValveData;
 import mekanism.common.lib.multiblock.MultiblockCache.CacheSubstance;
 import mekanism.common.lib.multiblock.MultiblockData;
+import mekanism.common.lib.multiblock.Structure;
 import mekanism.common.tile.multiblock.TileEntityInductionCasing;
 import mekanism.common.tile.multiblock.TileEntityInductionCell;
 import mekanism.common.tile.multiblock.TileEntityInductionPort;
@@ -112,9 +113,9 @@ public class MatrixMultiblockData extends MultiblockData {
     }
 
     @Override
-    public void remove(Level world) {
+    public void remove(Level world, Structure oldStructure) {
         energyContainer.invalidate();
-        super.remove(world);
+        super.remove(world, oldStructure);
     }
 
     @Override

--- a/src/main/java/mekanism/common/lib/multiblock/FormationProtocol.java
+++ b/src/main/java/mekanism/common/lib/multiblock/FormationProtocol.java
@@ -93,9 +93,9 @@ public class FormationProtocol<T extends MultiblockData> {
             // In theory we could partially get around this issue by keeping track of all the positions for the multiblock in the cache and only
             // reuse the id if we contain all elements we previously had, but doing so is not currently worth all the extra checks
             UUID idToUse = manager.getUniqueInventoryID();
-            if (!result.idsFound.isEmpty()) {
+            if (!result.idsFound().isEmpty()) {
                 RejectContents rejectContents = new RejectContents();
-                for (Map.Entry<UUID, MultiblockCache<T>> entry : result.idsFound.entrySet()) {
+                for (Map.Entry<UUID, MultiblockCache<T>> entry : result.idsFound().entrySet()) {
                     if (cache == null) {
                         cache = entry.getValue();
                     } else {
@@ -105,6 +105,7 @@ public class FormationProtocol<T extends MultiblockData> {
                 //Replace the caches for all the old ids with a singular merged cache with our desired id
                 manager.replaceCaches(result.idsFound().keySet(), idToUse, cache);
                 if (!rejectContents.rejectedItems.isEmpty()) {
+                    //TODO - 1.20.4: Don't drop it in the center if there is no nearest player, maybe drop it on top of the multiblock? Or to one of the sides
                     Vec3 dropPosition = pointerPos.getCenter();
                     //Try to see which player was nearest to multiblocks that have rejected items
                     Player nearestPlayer = world.getNearestPlayer(dropPosition.x, dropPosition.y, dropPosition.z, 25, true);

--- a/src/main/java/mekanism/common/lib/multiblock/IStructuralMultiblock.java
+++ b/src/main/java/mekanism/common/lib/multiblock/IStructuralMultiblock.java
@@ -15,4 +15,8 @@ public interface IStructuralMultiblock extends IMultiblockBase {
      * evaporation plant.
      */
     boolean structuralGuiAccessAllowed();
+
+    void removeStructure(Structure structure);
+
+    void multiblockFormed(MultiblockData multiblock);
 }

--- a/src/main/java/mekanism/common/lib/multiblock/IStructuralMultiblock.java
+++ b/src/main/java/mekanism/common/lib/multiblock/IStructuralMultiblock.java
@@ -16,7 +16,7 @@ public interface IStructuralMultiblock extends IMultiblockBase {
      */
     boolean structuralGuiAccessAllowed();
 
-    void removeStructure(Structure structure);
+    void multiblockUnformed(Structure structure);
 
     void multiblockFormed(MultiblockData multiblock);
 }

--- a/src/main/java/mekanism/common/lib/multiblock/MultiblockData.java
+++ b/src/main/java/mekanism/common/lib/multiblock/MultiblockData.java
@@ -281,7 +281,7 @@ public class MultiblockData implements IMekanismInventory, IMekanismFluidHandler
         for (BlockPos pos : locations) {
             BlockEntity tile = WorldUtils.getTileEntity(world, pos);
             if (tile instanceof IStructuralMultiblock structuralMultiblock) {
-                structuralMultiblock.removeStructure(oldStructure);
+                structuralMultiblock.multiblockUnformed(oldStructure);
             }
         }
         inventoryID = null;

--- a/src/main/java/mekanism/common/lib/multiblock/MultiblockData.java
+++ b/src/main/java/mekanism/common/lib/multiblock/MultiblockData.java
@@ -42,6 +42,7 @@ import mekanism.common.lib.multiblock.FormationProtocol.StructureRequirement;
 import mekanism.common.lib.multiblock.IValveHandler.ValveData;
 import mekanism.common.lib.multiblock.MultiblockCache.CacheSubstance;
 import mekanism.common.tile.prefab.TileEntityMultiblock;
+import mekanism.common.tile.prefab.TileEntityStructuralMultiblock;
 import mekanism.common.util.EnumUtils;
 import mekanism.common.util.NBTUtils;
 import mekanism.common.util.WorldUtils;
@@ -146,6 +147,14 @@ public class MultiblockData implements IMekanismInventory, IMekanismFluidHandler
     }
 
     /**
+     * Returns true if the multiblock's gui can be accessed via structural multiblocks, false otherwise. An example this may be false for would be on a thermal
+     * evaporation plant.
+     */
+    public boolean allowsStructuralGuiAccess(TileEntityStructuralMultiblock multiblock) {
+        return true;
+    }
+
+    /**
      * Tick the multiblock.
      *
      * @return if we need an update packet
@@ -206,6 +215,12 @@ public class MultiblockData implements IMekanismInventory, IMekanismFluidHandler
                 internalMultiblock.setMultiblock(this);
             }
         }
+        for (BlockPos pos : locations) {
+            BlockEntity tile = WorldUtils.getTileEntity(world, pos);
+            if (tile instanceof IStructuralMultiblock structuralMultiblock) {
+                structuralMultiblock.multiblockFormed(this);
+            }
+        }
 
         if (shouldCap(CacheSubstance.FLUID)) {
             for (IExtendedFluidTank tank : getFluidTanks(null)) {
@@ -256,11 +271,17 @@ public class MultiblockData implements IMekanismInventory, IMekanismFluidHandler
         return true;
     }
 
-    public void remove(Level world) {
+    public void remove(Level world, Structure oldStructure) {
         for (BlockPos pos : internalLocations) {
             BlockEntity tile = WorldUtils.getTileEntity(world, pos);
             if (tile instanceof IInternalMultiblock internalMultiblock) {
                 internalMultiblock.setMultiblock(null);
+            }
+        }
+        for (BlockPos pos : locations) {
+            BlockEntity tile = WorldUtils.getTileEntity(world, pos);
+            if (tile instanceof IStructuralMultiblock structuralMultiblock) {
+                structuralMultiblock.removeStructure(oldStructure);
             }
         }
         inventoryID = null;

--- a/src/main/java/mekanism/common/lib/multiblock/MultiblockManager.java
+++ b/src/main/java/mekanism/common/lib/multiblock/MultiblockManager.java
@@ -77,6 +77,11 @@ public class MultiblockManager<T extends MultiblockData> {
         return nameLower;
     }
 
+    @Override
+    public String toString() {
+        return name;
+    }
+
     public boolean isCompatible(BlockEntity tile) {
         if (tile instanceof IMultiblock<?> multiblock) {
             return multiblock.getManager() == this;

--- a/src/main/java/mekanism/common/lib/multiblock/Structure.java
+++ b/src/main/java/mekanism/common/lib/multiblock/Structure.java
@@ -247,30 +247,25 @@ public class Structure {
                 if (n instanceof IStructuralMultiblock structuralN && adj instanceof IStructuralMultiblock structuralAdj) {
                     Set<MultiblockManager<?>> managers = new HashSet<>(structuralN.getStructureMap().keySet());
                     managers.addAll(structuralAdj.getStructureMap().keySet());
-                    // if both are structural, they should merge all manager structures
-                    //TODO - 1.18: Figure out what this should be as having it just be equals seems incorrect.
-                    // My guess is it should be the commented code down below but maybe it should be |= instead
-                    for (MultiblockManager<?> manager : managers) {
-                        didMerge = mergeIfNecessary(n, adj, manager);
-                    }
-                    /*if (!managers.isEmpty()) {
-                        boolean merged = true;
+                    // if both are structural, they try to merge all manager structures
+                    if (!managers.isEmpty()) {
+                        boolean merged = false;
                         for (MultiblockManager<?> manager : managers) {
-                            merged &= mergeIfNecessary(n, adj, manager);
+                            merged |= mergeIfNecessary(n, adj, manager, true);
                         }
                         didMerge = merged;
-                    }*/
+                    }
                 } else if (n instanceof IStructuralMultiblock) {
                     // validate from the perspective of the IMultiblock
-                    if (!hasStructure(n, (IMultiblock<?>) adj)) {
-                        validate(adj, chunks);
+                    if (adj instanceof IMultiblock<?> adjMultiblock && !hasStructure(n, adjMultiblock)) {
+                        adjMultiblock.getStructure().markForUpdate(level, true);
                     }
                     return false;
                 } else if (adj instanceof IStructuralMultiblock) {
-                    didMerge = mergeIfNecessary(n, adj, getManager(n));
+                    didMerge = mergeIfNecessary(n, adj, getManager(n), false);
                 } else { // both are regular IMultiblocks
                     // we know the structures are compatible so managers must be the same for both
-                    didMerge = mergeIfNecessary(n, adj, getManager(n));
+                    didMerge = mergeIfNecessary(n, adj, getManager(n), false);
                 }
                 return didMerge;
             }
@@ -282,7 +277,7 @@ public class Structure {
         return structural.getStructure(multiblock.getManager()) == multiblock.getStructure();
     }
 
-    private static boolean mergeIfNecessary(IMultiblockBase node, IMultiblockBase adj, MultiblockManager<?> manager) {
+    private static boolean mergeIfNecessary(IMultiblockBase node, IMultiblockBase adj, MultiblockManager<?> manager, boolean bothStructural) {
         // reset the structures if they're invalid
         Structure nodeStructure = node.getStructure(manager);
         if (!nodeStructure.isValid()) {
@@ -294,6 +289,18 @@ public class Structure {
         }
         // only merge if the structures are different
         if (!node.hasStructure(adjStructure)) {
+            if (bothStructural) {
+                boolean nodeFormed = nodeStructure.getMultiblockData() != null && nodeStructure.getMultiblockData().isFormed();
+                boolean adjFormed = adjStructure.getMultiblockData() != null && adjStructure.getMultiblockData().isFormed();
+                if (nodeFormed || adjFormed) {
+                    //If at least one is formed, but they aren't both formed then don't merge them
+                    // as it means we are placing a structural multiblock against another structural one that is already formed,
+                    // so it has to be outside the bounds
+                    if (nodeFormed != adjFormed) {
+                        return false;
+                    }
+                }
+            }
             Structure changed;
             // merge into the bigger structure for efficiency
             if (nodeStructure.size() >= adjStructure.size() || (nodeStructure.getManager() != null && adjStructure.getManager() == null)) {

--- a/src/main/java/mekanism/common/lib/multiblock/Structure.java
+++ b/src/main/java/mekanism/common/lib/multiblock/Structure.java
@@ -216,7 +216,7 @@ public class Structure {
 
     public void removeMultiblock(Level world) {
         if (multiblockData != null) {
-            multiblockData.remove(world);
+            multiblockData.remove(world, this);
             multiblockData = null;
         }
     }
@@ -236,8 +236,6 @@ public class Structure {
                 // from a structural multiblock's perspective
                 multiblock.resetStructure(multiblock.getManager());
             }
-        } else if (node instanceof IStructuralMultiblock) {
-            node.resetStructure(null);
         }
         FormationProtocol.explore(node.getLevel(), chunkMap, node.getBlockPos(), node, (level, chunks, start, n, pos) -> {
             if (pos.equals(start)) {
@@ -247,8 +245,7 @@ public class Structure {
             if (tile instanceof IMultiblockBase adj && isCompatible(n, adj)) {
                 boolean didMerge = false;
                 if (n instanceof IStructuralMultiblock structuralN && adj instanceof IStructuralMultiblock structuralAdj) {
-                    Set<MultiblockManager<?>> managers = new HashSet<>();
-                    managers.addAll(structuralN.getStructureMap().keySet());
+                    Set<MultiblockManager<?>> managers = new HashSet<>(structuralN.getStructureMap().keySet());
                     managers.addAll(structuralAdj.getStructureMap().keySet());
                     // if both are structural, they should merge all manager structures
                     //TODO - 1.18: Figure out what this should be as having it just be equals seems incorrect.

--- a/src/main/java/mekanism/common/registries/MekanismTileEntityTypes.java
+++ b/src/main/java/mekanism/common/registries/MekanismTileEntityTypes.java
@@ -392,7 +392,6 @@ public class MekanismTileEntityTypes {
           .build();
     public static final TileEntityTypeRegistryObject<TileEntityStructuralGlass> STRUCTURAL_GLASS = TILE_ENTITY_TYPES
           .mekBuilder(MekanismBlocks.STRUCTURAL_GLASS, TileEntityStructuralGlass::new)
-          .serverTicker(TileEntityMekanism::tickServer)
           .withSimple(Capabilities.CONFIGURABLE)
           .build();
     public static final TileEntityTypeRegistryObject<TileEntitySuperheatingElement> SUPERHEATING_ELEMENT = TILE_ENTITY_TYPES.mekBuilder(MekanismBlocks.SUPERHEATING_ELEMENT, TileEntitySuperheatingElement::new)

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityStructuralMultiblock.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityStructuralMultiblock.java
@@ -53,21 +53,24 @@ public abstract class TileEntityStructuralMultiblock extends TileEntityMekanism 
         if (!removing) {
             //Don't try to remove it from the tile when the tile is the thing being removed
             if (structures.remove(structure.getManager(), structure)) {
+                boolean hasFormed = false;
+                boolean canAccess = false;
                 for (Structure struct : structures.values()) {
                     MultiblockData multiblock = getMultiblockData(struct);
                     if (multiblock != null && multiblock.isFormed()) {
-                        updateFormedMultiblock(true, multiblock.allowsStructuralGuiAccess(this));
-                        return;
+                        hasFormed = true;
+                        canAccess |= multiblock.allowsStructuralGuiAccess(this);
                     }
                 }
-                updateFormedMultiblock(false, false);
+                updateFormedMultiblock(hasFormed, canAccess);
             }
         }
     }
 
     @Override
     public void multiblockFormed(MultiblockData multiblock) {
-        updateFormedMultiblock(true, multiblock.allowsStructuralGuiAccess(this));
+        //Note: We pass the existing value of canAccessGui, as then we will validate when interacting, and only allow interacting with a specific sub one
+        updateFormedMultiblock(true, canAccessGui || multiblock.allowsStructuralGuiAccess(this));
     }
 
     private void updateFormedMultiblock(boolean hasFormed, boolean canAccess) {

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityStructuralMultiblock.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityStructuralMultiblock.java
@@ -52,17 +52,22 @@ public abstract class TileEntityStructuralMultiblock extends TileEntityMekanism 
     public void removeStructure(Structure structure) {
         if (!removing) {
             //Don't try to remove it from the tile when the tile is the thing being removed
-            if (structures.remove(structure.getManager(), structure)) {
-                boolean hasFormed = false;
-                boolean canAccess = false;
-                for (Structure struct : structures.values()) {
-                    MultiblockData multiblock = getMultiblockData(struct);
-                    if (multiblock != null && multiblock.isFormed()) {
-                        hasFormed = true;
-                        canAccess |= multiblock.allowsStructuralGuiAccess(this);
+            if (hasFormedMultiblock || canAccessGui) {
+                MultiblockManager<?> manager = structure.getManager();
+                if (structures.get(manager) == structure) {
+                    boolean hasFormed = false;
+                    boolean canAccess = false;
+                    for (Structure struct : structures.values()) {
+                        if (struct != structure) {
+                            MultiblockData multiblock = getMultiblockData(struct);
+                            if (multiblock != null && multiblock.isFormed()) {
+                                hasFormed = true;
+                                canAccess |= multiblock.allowsStructuralGuiAccess(this);
+                            }
+                        }
                     }
+                    updateFormedMultiblock(hasFormed, canAccess);
                 }
-                updateFormedMultiblock(hasFormed, canAccess);
             }
         }
     }
@@ -109,7 +114,7 @@ public abstract class TileEntityStructuralMultiblock extends TileEntityMekanism 
     @Nullable
     private MultiblockData getMultiblockData(Structure structure) {
         //Like the getMultiblockData(MultiblockManager) method except can assume the structure is indeed in our structures map,
-        // so we can slightly short circuit lookup
+        // so we can slightly short circuit lookup, and return null if there is no data
         MultiblockData data = structure.getMultiblockData();
         if (data != null && data.isFormed()) {
             return data;

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityStructuralMultiblock.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityStructuralMultiblock.java
@@ -25,8 +25,9 @@ import org.jetbrains.annotations.Nullable;
 
 public abstract class TileEntityStructuralMultiblock extends TileEntityMekanism implements IStructuralMultiblock, IConfigurable {
 
-    //Note: We never expect this to actually be filled, but we set the default to six in case it somehow is part of a structure in every direction
-    // given our expected is so low we use an array map
+    //Note: We never expect this to really get past two (and at an absolute max of nine if the player intentionally does weird things),
+    // we just use an array map as it has better performance, and on chunk unload or server restart it will get back to being a capacity
+    // of two
     private final Map<MultiblockManager<?>, Structure> structures = new Reference2ObjectArrayMap<>(2);
     private final Structure invalidStructure = Structure.INVALID;
     private final MultiblockData defaultMultiblock = new MultiblockData(this);

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityStructuralMultiblock.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityStructuralMultiblock.java
@@ -1,9 +1,7 @@
 package mekanism.common.tile.prefab;
 
-import java.util.HashMap;
-import java.util.Iterator;
+import it.unimi.dsi.fastutil.objects.Reference2ObjectArrayMap;
 import java.util.Map;
-import java.util.Objects;
 import mekanism.api.IConfigurable;
 import mekanism.api.NBTConstants;
 import mekanism.api.providers.IBlockProvider;
@@ -14,10 +12,8 @@ import mekanism.common.lib.multiblock.MultiblockData;
 import mekanism.common.lib.multiblock.MultiblockManager;
 import mekanism.common.lib.multiblock.Structure;
 import mekanism.common.tile.base.TileEntityMekanism;
-import mekanism.common.util.MekanismUtils;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.Tag;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
@@ -25,14 +21,18 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public abstract class TileEntityStructuralMultiblock extends TileEntityMekanism implements IStructuralMultiblock, IConfigurable {
 
-    private final Map<MultiblockManager<?>, Structure> structures = new HashMap<>();
+    //Note: We never expect this to actually be filled, but we set the default to six in case it somehow is part of a structure in every direction
+    // given our expected is so low we use an array map
+    private final Map<MultiblockManager<?>, Structure> structures = new Reference2ObjectArrayMap<>(6);
     private final Structure invalidStructure = Structure.INVALID;
     private final MultiblockData defaultMultiblock = new MultiblockData(this);
-
-    private String clientActiveMultiblock = null;
+    private boolean removing;
+    private boolean hasFormedMultiblock = false;
+    private boolean canAccessGui = false;
 
     public TileEntityStructuralMultiblock(IBlockProvider provider, BlockPos pos, BlockState state) {
         super(provider, pos, state);
@@ -49,6 +49,36 @@ public abstract class TileEntityStructuralMultiblock extends TileEntityMekanism 
     }
 
     @Override
+    public void removeStructure(Structure structure) {
+        if (!removing) {
+            //Don't try to remove it from the tile when the tile is the thing being removed
+            if (structures.remove(structure.getManager(), structure)) {
+                for (Structure struct : structures.values()) {
+                    MultiblockData multiblock = getMultiblockData(struct);
+                    if (multiblock != null && multiblock.isFormed()) {
+                        updateFormedMultiblock(true, multiblock.allowsStructuralGuiAccess(this));
+                        return;
+                    }
+                }
+                updateFormedMultiblock(false, false);
+            }
+        }
+    }
+
+    @Override
+    public void multiblockFormed(MultiblockData multiblock) {
+        updateFormedMultiblock(true, multiblock.allowsStructuralGuiAccess(this));
+    }
+
+    private void updateFormedMultiblock(boolean hasFormed, boolean canAccess) {
+        if (hasFormedMultiblock != hasFormed || canAccessGui != canAccess) {
+            hasFormedMultiblock = hasFormed;
+            canAccessGui = canAccess;
+            sendUpdatePacket();
+        }
+    }
+
+    @Override
     public Structure getStructure(MultiblockManager<?> manager) {
         return structures.getOrDefault(manager, invalidStructure);
     }
@@ -60,16 +90,12 @@ public abstract class TileEntityStructuralMultiblock extends TileEntityMekanism 
 
     @Override
     public boolean hasFormedMultiblock() {
-        return clientActiveMultiblock != null;
+        return hasFormedMultiblock;
     }
 
     @Override
     public boolean structuralGuiAccessAllowed() {
-        return hasFormedMultiblock() && structuralGuiAccessAllowed(clientActiveMultiblock);
-    }
-
-    protected boolean structuralGuiAccessAllowed(@NotNull String multiblock) {
-        return !multiblock.contains("fusion") && !multiblock.contains("evaporation");
+        return hasFormedMultiblock && canAccessGui;
     }
 
     @Override
@@ -77,6 +103,7 @@ public abstract class TileEntityStructuralMultiblock extends TileEntityMekanism 
         return structures;
     }
 
+    @Nullable
     private MultiblockData getMultiblockData(Structure structure) {
         //Like the getMultiblockData(MultiblockManager) method except can assume the structure is indeed in our structures map,
         // so we can slightly short circuit lookup
@@ -84,64 +111,40 @@ public abstract class TileEntityStructuralMultiblock extends TileEntityMekanism 
         if (data != null && data.isFormed()) {
             return data;
         }
-        return getDefaultData();
+        return null;
     }
 
     @Override
-    protected boolean onUpdateServer() {
-        boolean sendUpdatePacket = super.onUpdateServer();
-        if (ticker % MekanismUtils.TICKS_PER_HALF_SECOND == 0) {
-            String activeMultiblock = null;
-            if (!structures.isEmpty()) {
-                Iterator<Map.Entry<MultiblockManager<?>, Structure>> iterator = structures.entrySet().iterator();
-                while (iterator.hasNext()) {
-                    Map.Entry<MultiblockManager<?>, Structure> entry = iterator.next();
-                    Structure structure = entry.getValue();
-                    if (structure.isValid()) {
-                        if (activeMultiblock == null && structure.getController() != null && getMultiblockData(structure).isFormed()) {
-                            activeMultiblock = entry.getKey().getNameLower();
-                        }
-                    } else {
-                        iterator.remove();
-                    }
-                }
-            }
-            if (ticker >= 3 && structures.isEmpty()) {
-                invalidStructure.tick(this, true);
-                //If we managed to find any structures check which one is active
-                for (Map.Entry<MultiblockManager<?>, Structure> entry : structures.entrySet()) {
-                    Structure structure = entry.getValue();
-                    if (structure.getController() != null && getMultiblockData(structure).isFormed()) {
-                        activeMultiblock = entry.getKey().getNameLower();
-                        break;
-                    }
-                }
-            }
-            // this could potentially fail if this structural multiblock tracks multiple structures, but 99.99% of the time this will be accurate
-            if (!Objects.equals(activeMultiblock, clientActiveMultiblock)) {
-                clientActiveMultiblock = activeMultiblock;
-                sendUpdatePacket = true;
-            }
-        }
-        return sendUpdatePacket;
+    public void onAdded() {
+        super.onAdded();
+        //Ensure placing a structural multiblock tries to form the connected multiblock
+        invalidStructure.tick(this, true);
     }
 
     @Override
     public InteractionResult onActivate(Player player, InteractionHand hand, ItemStack stack) {
-        for (Map.Entry<MultiblockManager<?>, Structure> entry : structures.entrySet()) {
-            Structure structure = entry.getValue();
-            IMultiblock<?> master = structure.getController();
-            if (master != null) {
-                MultiblockData data = getMultiblockData(structure);
-                if (data.isFormed() && structuralGuiAccessAllowed(entry.getKey().getNameLower())) {
-                    // make sure this block is on the structure first
-                    if (data.getBounds().getRelativeLocation(getBlockPos()).isWall()) {
-                        return master.onActivate(player, hand, stack);
+        if (!structuralGuiAccessAllowed()) {
+            //If we don't have any structures that allow gui access, just short circuit and pass
+            return InteractionResult.PASS;
+        }
+        InteractionResult result = InteractionResult.PASS;
+        for (Structure structure : structures.values()) {
+            //If we already have an interaction that has been handled with one of our multiblocks just pass
+            // in 99% of cases we will not have a second iteration of the loop
+            if (result == InteractionResult.PASS) {
+                IMultiblock<?> master = structure.getController();
+                if (master != null) {
+                    MultiblockData data = getMultiblockData(structure);
+                    if (data != null && data.isFormed() && data.allowsStructuralGuiAccess(this)) {
+                        // make sure this block is on the structure first
+                        if (data.getBounds().getRelativeLocation(getBlockPos()).isWall()) {
+                            result = master.onActivate(player, hand, stack);
+                        }
                     }
                 }
             }
         }
-        return InteractionResult.PASS;
+        return result;
     }
 
     @Override
@@ -152,9 +155,9 @@ public abstract class TileEntityStructuralMultiblock extends TileEntityMekanism 
             for (Structure s : structures.values()) {
                 //For each structure this structural multiblock is a part of
                 if (s.getController() != null) {
-                    MultiblockData multiblockData = getMultiblockData(s);
-                    if (multiblockData.isPositionInsideBounds(s, neighborPos)) {
-                        if (level.isEmptyBlock(neighborPos) || !multiblockData.internalLocations.contains(neighborPos)) {
+                    MultiblockData multiblock = getMultiblockData(s);
+                    if (multiblock != null && multiblock.isPositionInsideBounds(s, neighborPos)) {
+                        if (level.isEmptyBlock(neighborPos) || !multiblock.internalLocations.contains(neighborPos)) {
                             //And we are not already an internal part of the structure, or we are changing an internal part to air
                             // then we mark the structure as needing to be re-validated
                             //Note: This isn't a super accurate check as if a node gets replaced by command or mod with say dirt
@@ -169,18 +172,23 @@ public abstract class TileEntityStructuralMultiblock extends TileEntityMekanism 
 
     @Override
     public InteractionResult onRightClick(Player player) {
-        if (!isRemote()) {
-            for (Structure s : structures.values()) {
-                if (s.getController() != null && !getMultiblockData(s).isFormed()) {
-                    FormationResult result = s.runUpdate(this);
+        if (isRemote()) {
+            return InteractionResult.PASS;
+        }
+        InteractionResult interactionResult = InteractionResult.PASS;
+        for (Structure structure : structures.values()) {
+            if (interactionResult == InteractionResult.PASS && structure.getController() != null) {
+                MultiblockData multiblock = getMultiblockData(structure);
+                if (multiblock == null || !multiblock.isFormed()) {
+                    FormationResult result = structure.runUpdate(this);
                     if (!result.isFormed() && result.getResultText() != null) {
                         player.sendSystemMessage(result.getResultText());
-                        return InteractionResult.sidedSuccess(isRemote());
+                        interactionResult = InteractionResult.sidedSuccess(isRemote());
                     }
                 }
             }
         }
-        return InteractionResult.PASS;
+        return interactionResult;
     }
 
     @Override
@@ -192,22 +200,23 @@ public abstract class TileEntityStructuralMultiblock extends TileEntityMekanism 
     @Override
     public CompoundTag getReducedUpdateTag() {
         CompoundTag updateTag = super.getReducedUpdateTag();
-        if (clientActiveMultiblock != null) {
-            updateTag.putString(NBTConstants.ACTIVE_STATE, clientActiveMultiblock);
-        }
+        updateTag.putBoolean(NBTConstants.FORMED, hasFormedMultiblock);
+        updateTag.putBoolean(NBTConstants.GUI, canAccessGui);
         return updateTag;
     }
 
     @Override
     public void handleUpdateTag(@NotNull CompoundTag tag) {
         super.handleUpdateTag(tag);
-        clientActiveMultiblock = tag.contains(NBTConstants.ACTIVE_STATE, Tag.TAG_STRING) ? tag.getString(NBTConstants.ACTIVE_STATE) : null;
+        hasFormedMultiblock = tag.getBoolean(NBTConstants.FORMED);
+        canAccessGui = tag.getBoolean(NBTConstants.GUI);
     }
 
     @Override
     public void setRemoved() {
         super.setRemoved();
         if (!isRemote()) {
+            removing = true;
             for (Structure s : structures.values()) {
                 s.invalidate(level);
             }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Makes Structural glass and reactor glass no longer be Ticking BEs
- Improves handling of structural blocks when they have multiple structures (still shouldn't be any cases this is a thing for yet)
- Improve handling so that placing structural blocks next to formed multiblocks is better at not causing them to reform