### PR TITLE
[1.19.2 Bug Fix] Fixes the rendering of Structural Glasses

### DIFF
--- a/src/main/java/mekanism/common/block/basic/BlockStructuralGlass.java
+++ b/src/main/java/mekanism/common/block/basic/BlockStructuralGlass.java
@@ -43,4 +43,14 @@ public class BlockStructuralGlass<TILE extends TileEntityStructuralMultiblock> e
         }
         return tile.onActivate(player, hand, player.getItemInHand(hand));
     }
+
+    @Override
+    @Deprecated
+    public boolean skipRendering(@NotNull BlockState state, @NotNull BlockState adjacentBlockState, @NotNull Direction side) {
+        Block blockOffset = adjacentBlockState.getBlock();
+        if ( blockOffset instanceof BlockBasicMultiblock<?>) {
+            return true;
+        }
+        return super.skipRendering(state, adjacentBlockState, side);
+    }
 }


### PR DESCRIPTION
A small fix to skip the rendering of Structural Glasses adiacent to Basic Multiblock Blocks (including the traslucent Laser Focus Matrix), making it seamless.
