### PR TITLE
Fix two recipe viewer issues

### DIFF
--- a/src/main/java/mekanism/client/recipe_viewer/emi/widget/MekanismTankEmiWidget.java
+++ b/src/main/java/mekanism/client/recipe_viewer/emi/widget/MekanismTankEmiWidget.java
@@ -64,7 +64,7 @@ public class MekanismTankEmiWidget extends SlotWidget {
             int y = bounds.y() + 1;
             int width = bounds.width() - 2;
             int height = bounds.height() - 2;
-            int desiredHeight = MathUtils.clampToInt(height * (double) stack.getAmount() / capacity);
+            int desiredHeight = MathUtils.clampToInt(height * (double) ingredient.getAmount() / capacity);
             if (desiredHeight < 1) {
                 desiredHeight = 1;
             }

--- a/src/main/java/mekanism/client/recipe_viewer/jei/ChemicalStackHelper.java
+++ b/src/main/java/mekanism/client/recipe_viewer/jei/ChemicalStackHelper.java
@@ -119,7 +119,7 @@ public abstract class ChemicalStackHelper<CHEMICAL extends Chemical<CHEMICAL>, S
         return getRegistry().getTags()
               .filter(pair -> {
                   Named<CHEMICAL> tag = pair.getSecond();
-                  return tag.size() == expected && tag.stream().allMatch(tag::contains);
+                  return tag.size() == expected && tag.stream().allMatch(holder -> values.contains(holder.value()));
               }).map(pair -> pair.getFirst().location())
               .findFirst();
     }


### PR DESCRIPTION
## Changes proposed in this pull request:
Fixes one issue in the Emi integration and another one in the Jei integration:

1. Fixes wrong tag names in Jei tooltip for chemicals. Before it would iterate over all tags and check if the size of the tag was right and then check if the tag contained all elements of itself instead of all elements of the searched tag.
2. Fixes tank widgets in Emi with tag ingredients that have an amount higher than 1 not being filled completely by using the amount of the ingredient instead of the stacks.

Both problems can be observed when looking at recipes with water vapor in the Chemical Injection Chamber.