### PR TITLE
Add AE2 facade integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -425,6 +425,7 @@ dependencies {
     //localRuntime(jeiTweaker)
 
     compileOnly("dev.gigaherz.jsonthings:JsonThings-${previous_minecraft_version}:${json_things_version}")
+    implementation("appeng:appliedenergistics2-neoforge:${ae2_version}")
 
     //Mods we have dependencies on but don't bother loading into the dev environment
     //compileOnly("curse.maven:projecte-api-226410:${projecte_api_id}")
@@ -438,8 +439,6 @@ dependencies {
     compileOnly("curse.maven:female-gender-forge-481655:${wildfire_gender_mod_id}")
 
     //Dependencies for data generators for mod compat reference
-    //TODO: Switch back to datagenMainImplementation when it updated
-    datagenMainCompileOnly("appeng:appliedenergistics2-neoforge:${ae2_version}")
     datagenMainRuntimeOnly("com.github.glitchfiend:GlitchCore-neoforge:${minecraft_version}-${glitchcore_version}")
     datagenMainRuntimeOnly("com.github.glitchfiend:TerraBlender-neoforge:${minecraft_version}-${terrablender_version}")
     datagenMainImplementation("com.github.glitchfiend:BiomesOPlenty-neoforge:${minecraft_version}-${biomesoplenty_version}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,6 +40,7 @@ jade_api_id=5427895
 jade_id=5427817
 top_version=1.21_neo-12.0.0-1
 wthit_version=12.1.2
+ae2_version=19.0.2-alpha
 
 #Mod dependency min version ranges
 
@@ -68,6 +69,5 @@ recipe_stages_version=8.0.0.2
 wildfire_gender_mod_id=5357649
 
 #Outdated mod dependencies for recipes
-ae2_version=18.1.3-alpha
 farmers_delight_id=5051242
 projecte_id=4860859

--- a/src/api/java/mekanism/api/SerializationConstants.java
+++ b/src/api/java/mekanism/api/SerializationConstants.java
@@ -287,4 +287,5 @@ public final class SerializationConstants {
     public static final String VALUES = "values";
     public static final String VERSION = "version";
     public static final String WORLD_GEN_VERSION = "mek_world_gen_version";
+    public static final String FACADES = "facades";
 }

--- a/src/main/java/mekanism/client/render/obj/TransmitterModel.java
+++ b/src/main/java/mekanism/client/render/obj/TransmitterModel.java
@@ -1,6 +1,9 @@
 package mekanism.client.render.obj;
 
 import java.util.function.Function;
+import appeng.client.render.cablebus.CableBusModel;
+import appeng.client.render.cablebus.FacadeBuilder;
+import mekanism.common.Mekanism;
 import net.minecraft.client.renderer.block.model.ItemOverrides;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.resources.model.BakedModel;
@@ -28,7 +31,13 @@ public class TransmitterModel implements IUnbakedGeometry<TransmitterModel> {
     @Override
     public BakedModel bake(IGeometryBakingContext owner, ModelBaker baker, Function<Material, TextureAtlasSprite> spriteGetter, ModelState modelTransform,
           ItemOverrides overrides) {
-        return new TransmitterBakedModel(internal, glass, owner, baker, spriteGetter, modelTransform, overrides);
+        if (Mekanism.hooks.AE2Loaded) {
+            BakedModel facadeModel = baker.bake(CableBusModel.TRANSLUCENT_FACADE_MODEL, modelTransform, spriteGetter);
+            FacadeBuilder facadeBuilder = new FacadeBuilder(baker, facadeModel);
+            return new TransmitterBakedModel(internal, glass, owner, baker, spriteGetter, modelTransform, overrides, facadeBuilder);
+        } else {
+            return new TransmitterBakedModel(internal, glass, owner, baker, spriteGetter, modelTransform, overrides, null);
+        }
     }
 
     @Override

--- a/src/main/java/mekanism/common/block/transmitter/BlockTransmitter.java
+++ b/src/main/java/mekanism/common/block/transmitter/BlockTransmitter.java
@@ -1,26 +1,34 @@
 package mekanism.common.block.transmitter;
 
+import appeng.api.implementations.items.IFacadeItem;
 import it.unimi.dsi.fastutil.shorts.Short2ObjectMap;
 import it.unimi.dsi.fastutil.shorts.Short2ObjectMaps;
 import it.unimi.dsi.fastutil.shorts.Short2ObjectOpenHashMap;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.UnaryOperator;
+import mekanism.common.Mekanism;
 import mekanism.common.block.attribute.AttributeTier;
 import mekanism.common.block.interfaces.IHasTileEntity;
 import mekanism.common.block.prefab.BlockBase.BlockBaseModel;
 import mekanism.common.content.blocktype.BlockTypeTile;
+import mekanism.common.integration.ae2.AE2Integration;
 import mekanism.common.lib.transmitter.ConnectionType;
 import mekanism.common.registration.impl.TileEntityTypeRegistryObject;
 import mekanism.common.registries.MekanismItems;
 import mekanism.common.tile.transmitter.TileEntityTransmitter;
 import mekanism.common.util.EnumUtils;
+import mekanism.common.util.MekanismUtils;
 import mekanism.common.util.MultipartUtils;
 import mekanism.common.util.MultipartUtils.AdvancedRayTraceResult;
 import mekanism.common.util.VoxelShapeUtils;
 import mekanism.common.util.WorldUtils;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.ItemInteractionResult;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
@@ -28,6 +36,7 @@ import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.PushReaction;
 import net.minecraft.world.level.pathfinder.PathComputationType;
+import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.shapes.BooleanOp;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.EntityCollisionContext;
@@ -36,9 +45,14 @@ import org.jetbrains.annotations.NotNull;
 
 public abstract class BlockTransmitter<TILE extends TileEntityTransmitter> extends BlockBaseModel<BlockTypeTile<TILE>> implements IHasTileEntity<TILE> {
 
+    private static final VoxelShape[] FACADES = new VoxelShape[EnumUtils.DIRECTIONS.length];
     //Max retained size if we used a HashMap with a key of record(Size, ConnectionType[6]) ~= 1,343,576B
     //Max retained size packing it like this 163,987B
     private static final Short2ObjectMap<VoxelShape> cachedShapes = Short2ObjectMaps.synchronize(new Short2ObjectOpenHashMap<>());
+
+    static {
+        VoxelShapeUtils.setShape(box(0, 0, 0, 16, 1, 16), FACADES, true);
+    }
 
     protected BlockTransmitter(BlockTypeTile<TILE> type) {
         this(type, properties -> {
@@ -156,6 +170,73 @@ public abstract class BlockTransmitter<TILE extends TileEntityTransmitter> exten
             }
             cachedShapes.put(packed, shape);
         }
+        if (!tile.getTransmitter().getFacades().isEmpty()) {
+            shape = VoxelShapeUtils.batchCombine(shape, BooleanOp.OR, true, getFacadeShapes(tile));
+        }
         return shape;
+    }
+
+    public static List<VoxelShape> getFacadeShapes(TileEntityTransmitter tile) {
+        if (!tile.getTransmitter().getFacades().isEmpty()) {
+            List<VoxelShape> shapes = new ArrayList<>();
+            for (Direction side : EnumUtils.DIRECTIONS) {
+                Block facade = tile.getTransmitter().getFacade(side);
+                if (facade != null) {
+                    shapes.add(FACADES[side.ordinal()]);
+                }
+            }
+            return shapes;
+        } else {
+            return List.of();
+        }
+    }
+
+    @Override
+    public @NotNull ItemInteractionResult useItemOn(@NotNull ItemStack stack, @NotNull BlockState state, @NotNull Level world, @NotNull BlockPos pos, @NotNull Player player, @NotNull InteractionHand hand, @NotNull BlockHitResult hit) {
+        if (Mekanism.hooks.AE2Loaded) {
+            TileEntityTransmitter tile = WorldUtils.getTileEntity(TileEntityTransmitter.class, world, pos);
+            if (tile != null) {
+                if (player.isShiftKeyDown() && MekanismUtils.canUseAsWrench(stack)) {
+                    if (!world.isClientSide) {
+                        //Get the facade the player is really clicking
+                        AdvancedRayTraceResult result = MultipartUtils.collisionRayTrace(player, pos, tile.getCollisionBoxes());
+                        Direction side = null;
+                        for (int i = 0; i < EnumUtils.DIRECTIONS.length; i++) {
+                            if (FACADES[i] == result.bounds) {
+                                side = EnumUtils.DIRECTIONS[i];
+                            }
+                        }
+                        if (side == null) {
+                            //Try adding all facades to the players inv before dismantling the whole transmitter
+                            WorldUtils.tryGivePlayer(world, player, tile.getTransmitter().getFacades().stream().map(AE2Integration::getFacadeItem).toList());
+                            tile.getTransmitter().clearFacades();
+                            tile.setChanged();
+                            WorldUtils.dismantleBlock(state, world, pos, player, stack);
+                        } else {
+                            //Remove only the facade on the side
+                            WorldUtils.tryGivePlayer(world, player, AE2Integration.getFacadeItem(tile.getTransmitter().getFacade(side)));
+                            tile.getTransmitter().setFacade(side, null);
+                            tile.setChanged();
+                            tile.sendUpdatePacket();
+                        }
+                    }
+                    return ItemInteractionResult.SUCCESS;
+                } else if (player.getMainHandItem().getItem() instanceof IFacadeItem facadeItem && tile.getTransmitter().getFacade(hit.getDirection()) == null) {
+                    if (!world.isClientSide) {
+                        tile.getTransmitter().setFacade(hit.getDirection(), facadeItem.getTextureBlockState(stack).getBlock());
+                        tile.setChanged();
+                        tile.sendUpdatePacket();
+                        if (!player.isCreative()) {
+                            stack.shrink(1);
+                            if (stack.isEmpty()) {
+                                player.setItemInHand(hand, ItemStack.EMPTY);
+                            }
+                        }
+                    }
+                    return ItemInteractionResult.SUCCESS;
+                }
+            }
+        }
+        return super.useItemOn(stack, state, world, pos, player, hand, hit);
     }
 }

--- a/src/main/java/mekanism/common/integration/MekanismHooks.java
+++ b/src/main/java/mekanism/common/integration/MekanismHooks.java
@@ -42,6 +42,7 @@ public final class MekanismHooks {
     public static final String RECIPE_STAGES_MOD_ID = "recipestages";
     public static final String TOP_MOD_ID = "theoneprobe";
     public static final String WILDFIRE_GENDER_MOD_ID = "wildfire_gender";
+    public static final String AE2_MOD_ID = "ae2";
 
     public final boolean CCLoaded;
     public final boolean CraftTweakerLoaded;
@@ -56,6 +57,7 @@ public final class MekanismHooks {
     public final boolean RecipeStagesLoaded;
     public final boolean TOPLoaded;
     public final boolean WildfireGenderModLoaded;
+    public final boolean AE2Loaded;
 
     public MekanismHooks() {
         ModList modList = ModList.get();
@@ -74,6 +76,7 @@ public final class MekanismHooks {
         RecipeStagesLoaded = loadedCheck.test(RECIPE_STAGES_MOD_ID);
         TOPLoaded = loadedCheck.test(TOP_MOD_ID);
         WildfireGenderModLoaded = loadedCheck.test(WILDFIRE_GENDER_MOD_ID);
+        AE2Loaded = loadedCheck.test(AE2_MOD_ID);
     }
 
     public void hookConstructor(final IEventBus bus) {

--- a/src/main/java/mekanism/common/integration/ae2/AE2Integration.java
+++ b/src/main/java/mekanism/common/integration/ae2/AE2Integration.java
@@ -1,0 +1,41 @@
+package mekanism.common.integration.ae2;
+
+import appeng.client.render.cablebus.CableBusRenderState;
+import appeng.client.render.cablebus.FacadeRenderState;
+import appeng.core.definitions.AEItems;
+import mekanism.common.lib.transmitter.ConnectionType;
+import mekanism.common.tile.transmitter.TileEntityTransmitter;
+import mekanism.common.util.EnumUtils;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+
+public class AE2Integration {
+
+    public static CableBusRenderState getFacadeRenderData(TileEntityTransmitter transmitter, BlockGetter level) {
+        CableBusRenderState renderState = new CableBusRenderState();
+        renderState.setPos(transmitter.getBlockPos());
+        //Sets null attachments on all connected sides so the anchor is not rendered
+        for (Direction side : EnumUtils.DIRECTIONS) {
+            if (transmitter.getTransmitter().getConnectionType(side) != ConnectionType.NONE) {
+                renderState.getAttachments().put(side, null);
+            }
+        }
+        for (Direction side : EnumUtils.DIRECTIONS) {
+            Block facade = transmitter.getTransmitter().getFacade(side);
+            if (facade != null) {
+                BlockState state = facade.defaultBlockState();
+                renderState.getFacades().put(side, new FacadeRenderState(state, !state.isSolidRender(level, transmitter.getBlockPos())));
+            }
+        }
+        return renderState;
+    }
+
+    public static ItemStack getFacadeItem(Block facade) {
+        return AEItems.FACADE.asItem().createFacadeForItemUnchecked(new ItemStack(facade));
+    }
+
+}

--- a/src/main/java/mekanism/common/util/WorldUtils.java
+++ b/src/main/java/mekanism/common/util/WorldUtils.java
@@ -421,13 +421,7 @@ public class WorldUtils {
     public static void dismantleBlock(BlockState state, Level world, BlockPos pos, @Nullable BlockEntity tile, @Nullable Entity entity, ItemStack tool) {
         if (world instanceof ServerLevel level) {
             if (entity instanceof Player player) {
-                for (ItemStack dropStack : getDrops(state, level, pos, tile, entity, tool)) {
-                    if (player.addItem(dropStack)) {
-                        world.playSound(null, entity.getX(), entity.getY(), entity.getZ(), SoundEvents.ITEM_PICKUP, SoundSource.PLAYERS, 0.2F, (world.random.nextFloat() - world.random.nextFloat()) * 1.4F + 2.0F);
-                    } else {
-                        player.drop(dropStack, false);
-                    }
-                }
+                tryGivePlayer(world, player, getDrops(state, level, pos, tile, entity, tool));
             } else {
                 for (ItemEntity drop : getDrops(state, level, pos, tile, entity, tool, true)) {
                     if (!drop.getItem().isEmpty()) {
@@ -488,6 +482,26 @@ public class WorldUtils {
             }
         }
         return result;
+	}
+
+    /**
+     * Adds the stacks to the player inventory or drops them if there is no space.
+     */
+    public static void tryGivePlayer(Level world, Player player, Iterable<ItemStack> stacks) {
+        for (ItemStack dropStack : stacks) {
+            tryGivePlayer(world, player, dropStack);
+        }
+    }
+
+    /**
+     * Adds the stack to the player inventory or drops it if there is no space.
+     */
+    public static void tryGivePlayer(Level world, Player player, ItemStack stack) {
+        if (player.addItem(stack)) {
+            world.playSound(null, player.getX(), player.getY(), player.getZ(), SoundEvents.ITEM_PICKUP, SoundSource.PLAYERS, 0.2F, (world.random.nextFloat() - world.random.nextFloat()) * 1.4F + 2.0F);
+        } else {
+            player.drop(stack, false);
+        }
     }
 
     /**


### PR DESCRIPTION
## Changes proposed in this pull request:
Adds an integration with AE2 facades. The facades can now be placed on all transmitters and transmitters can connect trough facades just like in AE. They can be removed by shift right clicking with the configurator in wrench mode. 

Just the blocks of the facades are saved in the NBT data of the transmitter and because it wasn't really possible to completely move rendering with AE into separate classes there are some places were `Object` is used instead of the actual type so everything still works without it.

I know performance of the transmitters is pretty critical so I hope performance is still good, especially when no facades are used.
I also removed the `datagenMainCompileOnly` dependency because it looked like it is also covered by the implementation one, but if you set it to `compileOnly` you will probably have to add a `datagenMainRuntimeOnly` back.

![2024-06-18_17 01 15](https://github.com/mekanism/Mekanism/assets/69975756/724d2286-6c72-4a74-b8c2-ca039e0002ac)
