### PR TITLE
Move to Curios continuation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -328,7 +328,7 @@ repositories { RepositoryHandler handler ->
         filter.includeGroup('org.openzen.zencode')
     })
     exclusiveRepo(handler, 'https://maven.terraformersmc.com/', 'dev.emi')
-    exclusiveRepo(handler, 'https://maven.theillusivec4.top/', 'top.theillusivec4.curios')
+    exclusiveRepo(handler, 'https://maven.octo-studios.com/releases/', 'top.theillusivec4.curios')
     exclusiveRepo(handler, 'https://maven.tterrag.com/', 'team.chisel.ctm')
     exclusiveRepo(handler, 'https://squiddev.cc/maven/', 'cc.tweaked', 'org.squiddev')
     exclusiveRepo(handler, 'https://dogforce-games.com/maven/', 'dev.gigaherz.jsonthings')

--- a/gradle.properties
+++ b/gradle.properties
@@ -55,7 +55,7 @@ terrablender_version=4.0.0.1
 #Outdated mod dependencies
 cc_tweaked_version=1.111.0
 crafttweaker_version=19.0.10
-curios_version=8.0.0+1.20.6
+curios_version=9.0.2+1.21
 ctm_version=1.1.7+11
 emi_version=1.1.6
 flux_networks_id=5234697


### PR DESCRIPTION
## Changes proposed in this pull request:
TheIllusiveC4 has finally released 1.20.6 stable version for Curios, and it has entering maintenance mode. Unfortunately, it's also been said that they're abandoning curios, and that anyone else can update curios themselves for 21.0.

[Curios continuation](https://github.com/SSKirillSS/Curios) seems to be the most popular alternative.
Hence, this change seems right. The mod id and the packages are the same for the sake of backwards compatibility.

This has been discussed in the NeoForge discord with CodexAdrian, TG, me and many more

The idea of making a similar API in Neo has been proposed. But until then, this is vital for having curios for 21.0 for now