### PR TITLE
Fix Boiler Valve Having Wrong Text Color

### DIFF
--- a/src/main/java/mekanism/common/block/attribute/AttributeStateBoilerValveMode.java
+++ b/src/main/java/mekanism/common/block/attribute/AttributeStateBoilerValveMode.java
@@ -46,7 +46,7 @@ public class AttributeStateBoilerValveMode implements AttributeState {
     @NothingNullByDefault
     public enum BoilerValveMode implements StringRepresentable, IHasTextComponent, IIncrementalEnum<BoilerValveMode> {
         INPUT("input", MekanismLang.BOILER_VALVE_MODE_INPUT, EnumColor.BRIGHT_GREEN),
-        OUTPUT_STEAM("output_steam", MekanismLang.BOILER_VALVE_MODE_OUTPUT_STEAM, EnumColor.GRAY),
+        OUTPUT_STEAM("output_steam", MekanismLang.BOILER_VALVE_MODE_OUTPUT_STEAM, EnumColor.RED),
         OUTPUT_COOLANT("output_coolant", MekanismLang.BOILER_VALVE_MODE_OUTPUT_COOLANT, EnumColor.DARK_AQUA);
 
         public static final IntFunction<BoilerValveMode> BY_ID = ByIdMap.continuous(BoilerValveMode::ordinal, values(), ByIdMap.OutOfBoundsStrategy.WRAP);


### PR DESCRIPTION
## Changes proposed in this pull request:

Fixed boiler valve output steam mode wrong colored configurator text. Fixes https://github.com/mekanism/Mekanism/issues/8176. The "output steam" text color now matches the valve color, just like other valves.