### PR TITLE
Auto eject round robin

### DIFF
--- a/src/main/java/mekanism/client/gui/element/window/GuiTransporterConfig.java
+++ b/src/main/java/mekanism/client/gui/element/window/GuiTransporterConfig.java
@@ -47,6 +47,9 @@ public class GuiTransporterConfig<TILE extends TileEntityMekanism & ISideConfigu
         addChild(new ColorButton(gui, relativeX + 112, relativeY + 49, 16, 16, () -> this.tile.getEjector().getOutputColor(),
               (element, mouseX, mouseY) -> PacketUtils.sendToServer(new PacketEjectColor(this.tile.getBlockPos(), MekClickType.left(Screen.hasShiftDown()))),
               (element, mouseX, mouseY) -> PacketUtils.sendToServer(new PacketEjectColor(this.tile.getBlockPos(), MekClickType.RIGHT))));
+        addChild(new MekanismImageButton(gui, relativeX + 136, relativeY + 20, 14, getButtonLocation("round_robin"),
+              (element, mouseX, mouseY) -> PacketUtils.sendToServer(new PacketGuiInteract(GuiInteraction.ROUND_ROBIN_BUTTON, this.tile))))
+              .setTooltip(MekanismLang.SORTER_ROUND_ROBIN_DESCRIPTION);
         addSideDataButton(RelativeSide.BOTTOM, 41, 64 + 16);
         addSideDataButton(RelativeSide.TOP, 41, 34);
         addSideDataButton(RelativeSide.FRONT, 41, 57);

--- a/src/main/java/mekanism/common/content/network/transmitter/LogisticalTransporterBase.java
+++ b/src/main/java/mekanism/common/content/network/transmitter/LogisticalTransporterBase.java
@@ -26,6 +26,8 @@ import mekanism.common.network.PacketUtils;
 import mekanism.common.network.to_client.transmitter.PacketTransporterBatch;
 import mekanism.common.network.to_client.transmitter.PacketTransporterSync;
 import mekanism.common.tier.TransporterTier;
+import mekanism.common.tile.component.TileComponentEjector;
+import mekanism.common.tile.prefab.TileEntityConfigurableMachine;
 import mekanism.common.tile.transmitter.TileEntityTransmitter;
 import mekanism.common.util.MekanismUtils;
 import mekanism.common.util.TransporterUtils;
@@ -398,6 +400,14 @@ public abstract class LogisticalTransporterBase extends Transmitter<IItemHandler
 
     public <BE extends BlockEntity & IAdvancedTransportEjector> TransitResponse insertMaybeRR(@Nullable BE outputter, BlockPos outputterPos, TransitRequest request, @Nullable EnumColor color, boolean doEmit, int min) {
         if (outputter != null && outputter.getRoundRobin()) {
+            return insert(outputter, outputterPos, request, color, min, doEmit, TransporterStack::recalculateRRPath);
+        }
+        return insert(outputter, outputterPos, request, color, doEmit, min);
+    }
+
+    public TransitResponse insertMaybeRR(@NotNull TileEntityConfigurableMachine outputter, BlockPos outputterPos, TransitRequest request, @Nullable EnumColor color, boolean doEmit, int min) {
+        TileComponentEjector ejector = outputter.getEjector();
+        if (ejector != null && ejector.getRoundRobin()) {
             return insert(outputter, outputterPos, request, color, min, doEmit, TransporterStack::recalculateRRPath);
         }
         return insert(outputter, outputterPos, request, color, doEmit, min);

--- a/src/main/java/mekanism/common/content/transporter/TransporterStack.java
+++ b/src/main/java/mekanism/common/content/transporter/TransporterStack.java
@@ -17,6 +17,7 @@ import mekanism.common.content.transporter.TransporterPathfinder.IdlePathData;
 import mekanism.common.lib.inventory.IAdvancedTransportEjector;
 import mekanism.common.lib.inventory.TransitRequest;
 import mekanism.common.lib.inventory.TransitRequest.TransitResponse;
+import mekanism.common.tile.prefab.TileEntityConfigurableMachine;
 import mekanism.common.util.NBTUtils;
 import mekanism.common.util.WorldUtils;
 import net.minecraft.core.BlockPos;
@@ -228,7 +229,15 @@ public class TransporterStack {
         return recalculateRRPath(request, outputter, transporter, min, true);
     }
 
+    public <BE extends TileEntityConfigurableMachine> TransitResponse recalculateRRPath(TransitRequest request, BE outputter, LogisticalTransporterBase transporter, int min, boolean updateFlowing) {
+        return getTransitResponseInner(request, outputter.getEjector(), transporter, min, updateFlowing);
+    }
+
     public <BE extends BlockEntity & IAdvancedTransportEjector> TransitResponse recalculateRRPath(TransitRequest request, BE outputter, LogisticalTransporterBase transporter, int min, boolean updateFlowing) {
+        return getTransitResponseInner(request, outputter, transporter, min, updateFlowing);
+    }
+
+    public TransitResponse getTransitResponseInner(TransitRequest request, IAdvancedTransportEjector outputter, LogisticalTransporterBase transporter, int min, boolean updateFlowing) {
         Destination newPath = TransporterPathfinder.getNewRRPath(transporter, this, request, outputter, min);
         if (newPath == null) {
             return request.getEmptyResponse();

--- a/src/main/java/mekanism/common/lib/inventory/TransitRequest.java
+++ b/src/main/java/mekanism/common/lib/inventory/TransitRequest.java
@@ -11,6 +11,7 @@ import mekanism.common.capabilities.item.CursedTransporterItemHandler;
 import mekanism.common.content.network.transmitter.LogisticalTransporterBase;
 import mekanism.common.content.transporter.TransporterManager;
 import mekanism.common.lib.inventory.TransitRequest.ItemData;
+import mekanism.common.tile.prefab.TileEntityConfigurableMachine;
 import mekanism.common.util.StackUtils;
 import mekanism.common.util.WorldUtils;
 import net.minecraft.core.BlockPos;
@@ -77,6 +78,22 @@ public abstract class TransitRequest implements Iterable<ItemData> {
         } else if (target instanceof CursedTransporterItemHandler cursed) {
             LogisticalTransporterBase transporter = cursed.getTransporter();
             return transporter.insert(outputter, outputterPos, this, outputColor.apply(transporter), true, min);
+        }
+        return addToInventoryUnchecked(target, min);
+    }
+
+    public TransitResponse ejectMaybeRR(TileEntityConfigurableMachine outputter, @Nullable IItemHandler target, int min, Function<LogisticalTransporterBase, EnumColor> outputColor) {
+        return ejectMaybeRR(outputter, outputter.getBlockPos(), target, min, outputColor);
+    }
+
+    @NotNull
+    public TransitResponse ejectMaybeRR(TileEntityConfigurableMachine outputter, BlockPos outputterPos, @Nullable IItemHandler target, int min,
+          Function<LogisticalTransporterBase, EnumColor> outputColor) {
+        if (isEmpty()) {//Short circuit if our request is empty
+            return getEmptyResponse();
+        } else if (target instanceof CursedTransporterItemHandler cursed) {
+            LogisticalTransporterBase transporter = cursed.getTransporter();
+            return transporter.insertMaybeRR(outputter, outputterPos, this, outputColor.apply(transporter), true, min);
         }
         return addToInventoryUnchecked(target, min);
     }

--- a/src/main/java/mekanism/common/network/to_server/PacketGuiInteract.java
+++ b/src/main/java/mekanism/common/network/to_server/PacketGuiInteract.java
@@ -30,6 +30,7 @@ import mekanism.common.tile.laser.TileEntityLaserAmplifier;
 import mekanism.common.tile.machine.TileEntityDigitalMiner;
 import mekanism.common.tile.machine.TileEntityDimensionalStabilizer;
 import mekanism.common.tile.machine.TileEntityFormulaicAssemblicator;
+import mekanism.common.tile.prefab.TileEntityConfigurableMachine;
 import mekanism.common.tile.qio.TileEntityQIODashboard;
 import mekanism.common.tile.qio.TileEntityQIOExporter;
 import mekanism.common.tile.qio.TileEntityQIOImporter;
@@ -415,6 +416,8 @@ public class PacketGuiInteract implements IMekanismPacket {
         ROUND_ROBIN_BUTTON((tile, player, extra) -> {
             if (tile instanceof IAdvancedTransportEjector sorter) {
                 sorter.toggleRoundRobin();
+            } else if (tile instanceof TileEntityConfigurableMachine machine) {
+                machine.getEjector().toggleRoundRobin();
             }
         }),
         SINGLE_ITEM_BUTTON((tile, player, extra) -> {

--- a/src/main/java/mekanism/common/tile/component/config/ConfigInfo.java
+++ b/src/main/java/mekanism/common/tile/component/config/ConfigInfo.java
@@ -24,6 +24,7 @@ public class ConfigInfo implements IPersistentConfigInfo {
     //TODO: Ejecting/can eject, how do we want to use these
     private boolean canEject;
     private boolean ejecting;
+    private boolean roundRobin;//items only
     private final Map<RelativeSide, DataType> sideConfig;
     private final Map<DataType, ISlotInfo> slotInfo;
     // used so slot & tank GUIs can quickly reference which color overlay to render
@@ -37,6 +38,7 @@ public class ConfigInfo implements IPersistentConfigInfo {
     public ConfigInfo() {
         canEject = true;
         ejecting = false;
+        roundRobin = false;
         sideConfig = new EnumMap<>(RelativeSide.class);
         for (RelativeSide side : EnumUtils.SIDES) {
             sideConfig.put(side, DataType.NONE);
@@ -60,6 +62,14 @@ public class ConfigInfo implements IPersistentConfigInfo {
 
     public void setEjecting(boolean ejecting) {
         this.ejecting = ejecting;
+    }
+
+    public boolean isRoundRobin() {
+        return roundRobin;
+    }
+
+    public void setRoundRobin(boolean newRR) {
+        this.roundRobin = newRR;
     }
 
     public void addDisabledSides(@NotNull RelativeSide... sides) {


### PR DESCRIPTION
## Changes proposed in this pull request:
Gives machines with a Transporter config the ability to do round robin auto-eject like a logistical sorter

### Todo
- [ ] Rejig the GUI to have both Strict Input and RR be the new on/off buttons