### PR TITLE
Blasting Highlight Event Visual Bug?

### DIFF
--- a/src/main/java/mekanism/client/render/RenderTickHandler.java
+++ b/src/main/java/mekanism/client/render/RenderTickHandler.java
@@ -385,7 +385,9 @@ public class RenderTickHandler {
                         Lazy<VertexConsumer> lineConsumer = Lazy.of(() -> renderer.getBuffer(RenderType.lines()));
                         for (Entry<BlockPos, BlockState> block : blocks.entrySet()) {
                             BlockPos blastingTarget = block.getKey();
-                            if (!pos.equals(blastingTarget) && !ClientHooks.onDrawHighlight(levelRenderer, info, rayTraceResult, event.getDeltaTracker(), matrix, renderer)) {
+                            // simulate ray tracing results for all block positions
+                            var currResult = new BlockHitResult(rayTraceResult.getLocation(), rayTraceResult.getDirection(), blastingTarget, rayTraceResult.isInside());
+                            if (!pos.equals(blastingTarget) && !ClientHooks.onDrawHighlight(levelRenderer, info, currResult, event.getDeltaTracker(), matrix, renderer)) {
                                 levelRenderer.renderHitOutline(matrix, lineConsumer.get(), player, renderView.x, renderView.y, renderView.z, blastingTarget, block.getValue());
                             }
                         }

--- a/src/main/java/mekanism/client/render/RenderTickHandler.java
+++ b/src/main/java/mekanism/client/render/RenderTickHandler.java
@@ -386,7 +386,7 @@ public class RenderTickHandler {
                         for (Entry<BlockPos, BlockState> block : blocks.entrySet()) {
                             BlockPos blastingTarget = block.getKey();
                             // simulate ray tracing results for all block positions
-                            var currResult = new BlockHitResult(rayTraceResult.getLocation(), rayTraceResult.getDirection(), blastingTarget, rayTraceResult.isInside());
+                            BlockHitResult currResult = new BlockHitResult(rayTraceResult.getLocation(), rayTraceResult.getDirection(), blastingTarget, rayTraceResult.isInside());
                             if (!pos.equals(blastingTarget) && !ClientHooks.onDrawHighlight(levelRenderer, info, currResult, event.getDeltaTracker(), matrix, renderer)) {
                                 levelRenderer.renderHitOutline(matrix, lineConsumer.get(), player, renderView.x, renderView.y, renderView.z, blastingTarget, block.getValue());
                             }

--- a/src/main/java/mekanism/client/render/RenderTickHandler.java
+++ b/src/main/java/mekanism/client/render/RenderTickHandler.java
@@ -386,8 +386,7 @@ public class RenderTickHandler {
                         for (Entry<BlockPos, BlockState> block : blocks.entrySet()) {
                             BlockPos blastingTarget = block.getKey();
                             // simulate ray tracing results for all block positions
-                            BlockHitResult currResult = new BlockHitResult(rayTraceResult.getLocation(), rayTraceResult.getDirection(), blastingTarget, rayTraceResult.isInside());
-                            if (!pos.equals(blastingTarget) && !ClientHooks.onDrawHighlight(levelRenderer, info, currResult, event.getDeltaTracker(), matrix, renderer)) {
+                            if (!pos.equals(blastingTarget) && !ClientHooks.onDrawHighlight(levelRenderer, info, rayTraceResult.withPosition(blastingTarget), event.getDeltaTracker(), matrix, renderer)) {
                                 levelRenderer.renderHitOutline(matrix, lineConsumer.get(), player, renderView.x, renderView.y, renderView.z, blastingTarget, block.getValue());
                             }
                         }


### PR DESCRIPTION
This is my first time trying to contribute something to someone else's repo, please be kind.

## Problem
I was looking at the `RenderHighlightEvent` code for the AoE blasting, and I noticed that you are calling recursive  `RenderHighlightEvent`s for each block affected, so that they may have a chance to cancel themselves. 

However, when creating those recursive events, you pass the original `rayTraceResult` as parameter. I believe this means that instead of simulating one event for each block in the AoE, you actually simulate the origin-block's event many times over.

## Changes proposed in this pull request:
Create a seperate `BlockHitResult` for each `blastingTarget` blockPos. For its parameters, I essentially cloned the original `BlockHitResult`, changing only the blockPos. So for example if the original block was 'hit' at the top left, every AoE block is going to simulate a top left hit aswell.