### PR TITLE
Adapt the "onAlloyIteraction" and "canUpgrade" methods to subclasses of "ITier"

### DIFF
--- a/src/api/java/mekanism/api/IAlloyInteraction.java
+++ b/src/api/java/mekanism/api/IAlloyInteraction.java
@@ -19,5 +19,5 @@ public interface IAlloyInteraction {
      * @param stack  - the stack of alloy being right-clicked
      * @param tier   - the tier of the alloy
      */
-    <TIER extends ITier> void onAlloyInteraction(Player player, ItemStack stack, @NotNull TIER tier);
+    void onAlloyInteraction(Player player, ItemStack stack, @NotNull ITier tier);
 }

--- a/src/api/java/mekanism/api/IAlloyInteraction.java
+++ b/src/api/java/mekanism/api/IAlloyInteraction.java
@@ -1,6 +1,6 @@
 package mekanism.api;
 
-import mekanism.api.tier.AlloyTier;
+import mekanism.api.tier.ITier;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
@@ -19,5 +19,5 @@ public interface IAlloyInteraction {
      * @param stack  - the stack of alloy being right-clicked
      * @param tier   - the tier of the alloy
      */
-    void onAlloyInteraction(Player player, ItemStack stack, @NotNull AlloyTier tier);
+    <TIER extends ITier> void onAlloyInteraction(Player player, ItemStack stack, @NotNull TIER tier);
 }

--- a/src/api/java/mekanism/api/tier/BaseTier.java
+++ b/src/api/java/mekanism/api/tier/BaseTier.java
@@ -18,7 +18,7 @@ import org.jetbrains.annotations.NotNull;
  *
  * @author aidancbrady
  */
-public enum BaseTier implements StringRepresentable, SupportsColorMap {
+public enum BaseTier implements StringRepresentable, SupportsColorMap, IBasicTier {
     BASIC("Basic", new int[]{95, 255, 184}, MapColor.COLOR_LIGHT_GREEN),
     ADVANCED("Advanced", new int[]{255, 128, 106}, MapColor.TERRACOTTA_PINK),
     ELITE("Elite", new int[]{75, 248, 255}, MapColor.DIAMOND),

--- a/src/api/java/mekanism/api/tier/IBasicTier.java
+++ b/src/api/java/mekanism/api/tier/IBasicTier.java
@@ -1,0 +1,7 @@
+package mekanism.api.tier;
+
+/**
+ * If you want to add a new Tier type, you can inherit this interface.
+ */
+public interface IBasicTier {
+}

--- a/src/api/java/mekanism/api/tier/ITier.java
+++ b/src/api/java/mekanism/api/tier/ITier.java
@@ -5,5 +5,5 @@ public interface ITier {
     /**
      * Gets the base tier version of this tiered object.
      */
-    BaseTier getBaseTier();
+    IBasicTier getBaseTier();
 }

--- a/src/main/java/mekanism/common/content/network/transmitter/IUpgradeableTransmitter.java
+++ b/src/main/java/mekanism/common/content/network/transmitter/IUpgradeableTransmitter.java
@@ -1,6 +1,5 @@
 package mekanism.common.content.network.transmitter;
 
-import mekanism.api.tier.AlloyTier;
 import mekanism.api.tier.ITier;
 import mekanism.common.upgrade.transmitter.TransmitterUpgradeData;
 import org.jetbrains.annotations.NotNull;
@@ -15,7 +14,7 @@ public interface IUpgradeableTransmitter<DATA extends TransmitterUpgradeData> {
 
     ITier getTier();
 
-    default boolean canUpgrade(AlloyTier alloyTier) {
+    default <TIER extends ITier> boolean canUpgrade(TIER alloyTier) {
         return alloyTier.getBaseTier().ordinal() == getTier().getBaseTier().ordinal() + 1;
     }
 }

--- a/src/main/java/mekanism/common/content/network/transmitter/IUpgradeableTransmitter.java
+++ b/src/main/java/mekanism/common/content/network/transmitter/IUpgradeableTransmitter.java
@@ -14,7 +14,7 @@ public interface IUpgradeableTransmitter<DATA extends TransmitterUpgradeData> {
 
     ITier getTier();
 
-    default <TIER extends ITier> boolean canUpgrade(TIER alloyTier) {
+    default boolean canUpgrade(ITier alloyTier) {
         return alloyTier.getBaseTier().ordinal() == getTier().getBaseTier().ordinal() + 1;
     }
 }

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityLogisticalTransporter.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityLogisticalTransporter.java
@@ -2,6 +2,7 @@ package mekanism.common.tile.transmitter;
 
 import mekanism.api.providers.IBlockProvider;
 import mekanism.api.tier.BaseTier;
+import mekanism.api.tier.IBasicTier;
 import mekanism.client.model.data.TransmitterModelData;
 import mekanism.common.block.states.BlockStateHelper;
 import mekanism.common.block.states.TransmitterType;
@@ -40,8 +41,8 @@ public class TileEntityLogisticalTransporter extends TileEntityLogisticalTranspo
 
     @NotNull
     @Override
-    protected BlockState upgradeResult(@NotNull BlockState current, @NotNull BaseTier tier) {
-        return BlockStateHelper.copyStateData(current, switch (tier) {
+    protected BlockState upgradeResult(@NotNull BlockState current, @NotNull IBasicTier tier) {
+        return BlockStateHelper.copyStateData(current, switch ((BaseTier) tier) {
             case BASIC -> MekanismBlocks.BASIC_LOGISTICAL_TRANSPORTER;
             case ADVANCED -> MekanismBlocks.ADVANCED_LOGISTICAL_TRANSPORTER;
             case ELITE -> MekanismBlocks.ELITE_LOGISTICAL_TRANSPORTER;

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityMechanicalPipe.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityMechanicalPipe.java
@@ -6,6 +6,7 @@ import mekanism.api.SerializationConstants;
 import mekanism.api.fluid.IExtendedFluidTank;
 import mekanism.api.providers.IBlockProvider;
 import mekanism.api.tier.BaseTier;
+import mekanism.api.tier.IBasicTier;
 import mekanism.common.block.states.BlockStateHelper;
 import mekanism.common.block.states.TransmitterType;
 import mekanism.common.capabilities.Capabilities;
@@ -66,8 +67,8 @@ public class TileEntityMechanicalPipe extends TileEntityTransmitter implements I
 
     @NotNull
     @Override
-    protected BlockState upgradeResult(@NotNull BlockState current, @NotNull BaseTier tier) {
-        return BlockStateHelper.copyStateData(current, switch (tier) {
+    protected BlockState upgradeResult(@NotNull BlockState current, @NotNull IBasicTier tier) {
+        return BlockStateHelper.copyStateData(current, switch ((BaseTier) tier) {
             case BASIC -> MekanismBlocks.BASIC_MECHANICAL_PIPE;
             case ADVANCED -> MekanismBlocks.ADVANCED_MECHANICAL_PIPE;
             case ELITE -> MekanismBlocks.ELITE_MECHANICAL_PIPE;

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityPressurizedTube.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityPressurizedTube.java
@@ -10,6 +10,7 @@ import mekanism.api.math.MathUtils;
 import mekanism.api.providers.IBlockProvider;
 import mekanism.api.radiation.IRadiationManager;
 import mekanism.api.tier.BaseTier;
+import mekanism.api.tier.IBasicTier;
 import mekanism.common.block.states.BlockStateHelper;
 import mekanism.common.block.states.TransmitterType;
 import mekanism.common.capabilities.Capabilities;
@@ -72,8 +73,8 @@ public class TileEntityPressurizedTube extends TileEntityTransmitter implements 
 
     @NotNull
     @Override
-    protected BlockState upgradeResult(@NotNull BlockState current, @NotNull BaseTier tier) {
-        return BlockStateHelper.copyStateData(current, switch (tier) {
+    protected BlockState upgradeResult(@NotNull BlockState current, @NotNull IBasicTier tier) {
+        return BlockStateHelper.copyStateData(current, switch ((BaseTier) tier) {
             case BASIC -> MekanismBlocks.BASIC_PRESSURIZED_TUBE;
             case ADVANCED -> MekanismBlocks.ADVANCED_PRESSURIZED_TUBE;
             case ELITE -> MekanismBlocks.ELITE_PRESSURIZED_TUBE;

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityThermodynamicConductor.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityThermodynamicConductor.java
@@ -6,6 +6,7 @@ import mekanism.api.heat.IHeatCapacitor;
 import mekanism.api.heat.IMekanismHeatHandler;
 import mekanism.api.providers.IBlockProvider;
 import mekanism.api.tier.BaseTier;
+import mekanism.api.tier.IBasicTier;
 import mekanism.common.block.states.BlockStateHelper;
 import mekanism.common.block.states.TransmitterType;
 import mekanism.common.capabilities.Capabilities;
@@ -63,8 +64,8 @@ public class TileEntityThermodynamicConductor extends TileEntityTransmitter {
 
     @NotNull
     @Override
-    protected BlockState upgradeResult(@NotNull BlockState current, @NotNull BaseTier tier) {
-        return BlockStateHelper.copyStateData(current, switch (tier) {
+    protected BlockState upgradeResult(@NotNull BlockState current, @NotNull IBasicTier tier) {
+        return BlockStateHelper.copyStateData(current, switch ((BaseTier) tier) {
             case BASIC -> MekanismBlocks.BASIC_THERMODYNAMIC_CONDUCTOR;
             case ADVANCED -> MekanismBlocks.ADVANCED_THERMODYNAMIC_CONDUCTOR;
             case ELITE -> MekanismBlocks.ELITE_THERMODYNAMIC_CONDUCTOR;

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityTransmitter.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityTransmitter.java
@@ -7,8 +7,8 @@ import mekanism.api.IAlloyInteraction;
 import mekanism.api.IConfigurable;
 import mekanism.api.providers.IBlockProvider;
 import mekanism.api.text.EnumColor;
-import mekanism.api.tier.AlloyTier;
 import mekanism.api.tier.BaseTier;
+import mekanism.api.tier.ITier;
 import mekanism.client.model.data.TransmitterModelData;
 import mekanism.common.Mekanism;
 import mekanism.common.MekanismLang;
@@ -322,7 +322,7 @@ public abstract class TileEntityTransmitter extends CapabilityTileEntity impleme
     }
 
     @Override
-    public void onAlloyInteraction(Player player, ItemStack stack, @NotNull AlloyTier tier) {
+    public <TIER extends ITier> void onAlloyInteraction(Player player, ItemStack stack, @NotNull TIER tier) {
         if (getLevel() != null && getTransmitter().hasTransmitterNetwork()) {
             DynamicNetwork<?, ?, ?> transmitterNetwork = getTransmitter().getTransmitterNetwork();
             List<Transmitter<?, ?, ?>> list = new ArrayList<>(transmitterNetwork.getTransmitters());

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityTransmitter.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityTransmitter.java
@@ -322,7 +322,7 @@ public abstract class TileEntityTransmitter extends CapabilityTileEntity impleme
     }
 
     @Override
-    public <TIER extends ITier> void onAlloyInteraction(Player player, ItemStack stack, @NotNull TIER tier) {
+    public void onAlloyInteraction(Player player, ItemStack stack, @NotNull ITier tier) {
         if (getLevel() != null && getTransmitter().hasTransmitterNetwork()) {
             DynamicNetwork<?, ?, ?> transmitterNetwork = getTransmitter().getTransmitterNetwork();
             List<Transmitter<?, ?, ?>> list = new ArrayList<>(transmitterNetwork.getTransmitters());

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityTransmitter.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityTransmitter.java
@@ -8,6 +8,7 @@ import mekanism.api.IConfigurable;
 import mekanism.api.providers.IBlockProvider;
 import mekanism.api.text.EnumColor;
 import mekanism.api.tier.BaseTier;
+import mekanism.api.tier.IBasicTier;
 import mekanism.api.tier.ITier;
 import mekanism.client.model.data.TransmitterModelData;
 import mekanism.common.Mekanism;
@@ -399,7 +400,7 @@ public abstract class TileEntityTransmitter extends CapabilityTileEntity impleme
     }
 
     @NotNull
-    protected BlockState upgradeResult(@NotNull BlockState current, @NotNull BaseTier tier) {
+    protected BlockState upgradeResult(@NotNull BlockState current, @NotNull IBasicTier tier) {
         return current;
     }
 

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityUniversalCable.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityUniversalCable.java
@@ -7,6 +7,7 @@ import mekanism.api.energy.IEnergyContainer;
 import mekanism.api.math.MathUtils;
 import mekanism.api.providers.IBlockProvider;
 import mekanism.api.tier.BaseTier;
+import mekanism.api.tier.IBasicTier;
 import mekanism.common.block.states.BlockStateHelper;
 import mekanism.common.block.states.TransmitterType;
 import mekanism.common.capabilities.energy.DynamicStrictEnergyHandler;
@@ -66,8 +67,8 @@ public class TileEntityUniversalCable extends TileEntityTransmitter implements I
 
     @NotNull
     @Override
-    protected BlockState upgradeResult(@NotNull BlockState current, @NotNull BaseTier tier) {
-        return BlockStateHelper.copyStateData(current, switch (tier) {
+    protected BlockState upgradeResult(@NotNull BlockState current, @NotNull IBasicTier tier) {
+        return BlockStateHelper.copyStateData(current, switch ((BaseTier) tier) {
             case BASIC -> MekanismBlocks.BASIC_UNIVERSAL_CABLE;
             case ADVANCED -> MekanismBlocks.ADVANCED_UNIVERSAL_CABLE;
             case ELITE -> MekanismBlocks.ELITE_UNIVERSAL_CABLE;


### PR DESCRIPTION
## Changes proposed in this pull request:
1.When adding extra alloys, the "AlloyTier" accepted by "onAlloyIteraction" is too limited. It would be better to replace it with  a subclass of "ITier", at least I don't have to do repetitive work.
2.I modified the parameters in 'canUpgrade' to also adapt to subclasses of 'ITier', reducing unnecessary forced conversions.
3.Please forgive me for using a translator.
Thank you for everything you have done for mek.