### PR TITLE
Fixed render crash when placing Universal Cables on ValkyrienSkies ships

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -399,6 +399,7 @@ repositories { RepositoryHandler handler ->
     exclusiveRepo(handler, 'https://modmaven.dev/', 'appeng', 'mcjty.theoneprobe')
     exclusiveRepo(handler, 'https://maven.thiakil.com', 'com.thiakil')
     exclusiveRepo(handler, 'https://maven.parchmentmc.org/', 'org.parchmentmc.data')
+    exclusiveRepo(handler, 'https://thedarkcolour.github.io/KotlinForForge/', 'thedarkcolour')
 }
 
 test {
@@ -465,6 +466,11 @@ dependencies {
     datagenMainRuntimeOnly fg.deobf("curse.maven:projecte-226410:${projecte_id}")
 
     datagenNonMod "com.thiakil:yaml-ops:${yamlops_version}"
+
+    //kotlinforforge is a dependency of Valkyrien Skies
+    runtimeOnly(fg.deobf("thedarkcolour:kotlinforforge:${kotlin_for_forge_version}"))
+    runtimeOnly(fg.deobf("curse.maven:valkyrien-skies-258371:${valkyrien_skies_mod_id}"))
+    runtimeOnly(fg.deobf("curse.maven:eureka-ships-654384:${eureka_mod_id}"))
 }
 
 def getManifestAttributes(String title) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -41,6 +41,9 @@ recipe_stages_version=8.0.0.1
 top_version=1.20.1-10.0.1-3
 wildfire_gender_mod_id=4603538
 wthit_version=8.4.0
+kotlin_for_forge_version=4.10.0
+valkyrien_skies_mod_id=5212232
+eureka_mod_id=5321630
 
 #Mod dependency min version ranges
 crafttweaker_version_range=[14.0.7,)

--- a/src/main/java/mekanism/client/render/tileentity/MekanismTileEntityRenderer.java
+++ b/src/main/java/mekanism/client/render/tileentity/MekanismTileEntityRenderer.java
@@ -44,10 +44,12 @@ public abstract class MekanismTileEntityRenderer<TILE extends BlockEntity> imple
     @Override
     public void render(TILE tile, float partialTick, PoseStack matrix, MultiBufferSource renderer, int light, int overlayLight) {
         if (tile.getLevel() != null) {
-            ProfilerFiller profiler = tile.getLevel().getProfiler();
-            profiler.push(getProfilerSection());
-            render(tile, partialTick, matrix, renderer, light, overlayLight, profiler);
-            profiler.pop();
+            if (this.shouldRender(tile, getCamera().getPosition())) {
+                ProfilerFiller profiler = tile.getLevel().getProfiler();
+                profiler.push(getProfilerSection());
+                render(tile, partialTick, matrix, renderer, light, overlayLight, profiler);
+                profiler.pop();
+            }
         }
     }
 

--- a/src/main/java/mekanism/client/render/transmitter/RenderUniversalCable.java
+++ b/src/main/java/mekanism/client/render/transmitter/RenderUniversalCable.java
@@ -5,6 +5,7 @@ import mekanism.api.annotations.NothingNullByDefault;
 import mekanism.client.render.MekanismRenderer;
 import mekanism.common.base.ProfilerConstants;
 import mekanism.common.content.network.EnergyNetwork;
+import mekanism.common.content.network.transmitter.Transmitter;
 import mekanism.common.content.network.transmitter.UniversalCable;
 import mekanism.common.tile.transmitter.TileEntityUniversalCable;
 import net.minecraft.client.renderer.LightTexture;
@@ -24,11 +25,23 @@ public class RenderUniversalCable extends RenderTransmitterBase<TileEntityUniver
     @Override
     protected void render(TileEntityUniversalCable tile, float partialTick, PoseStack matrix, MultiBufferSource renderer, int light, int overlayLight,
           ProfilerFiller profiler) {
-        EnergyNetwork network = tile.getTransmitter().getTransmitterNetwork();
+
+        UniversalCable cable = tile.getTransmitter();
+        if (cable == null || !cable.hasTransmitterNetwork())
+        {
+            return;
+        }
+
+        EnergyNetwork network = cable.getTransmitterNetwork();
+        if (network == null)
+        {
+            return;
+        }
+
         matrix.pushPose();
         matrix.translate(0.5, 0.5, 0.5);
         renderModel(tile, matrix, renderer.getBuffer(Sheets.translucentCullBlockSheet()), 0xFFFFFF, network.currentScale, LightTexture.FULL_BRIGHT,
-              overlayLight, MekanismRenderer.energyIcon);
+            overlayLight, MekanismRenderer.energyIcon);
         matrix.popPose();
     }
 

--- a/src/main/java/mekanism/client/render/transmitter/RenderUniversalCable.java
+++ b/src/main/java/mekanism/client/render/transmitter/RenderUniversalCable.java
@@ -26,18 +26,7 @@ public class RenderUniversalCable extends RenderTransmitterBase<TileEntityUniver
     protected void render(TileEntityUniversalCable tile, float partialTick, PoseStack matrix, MultiBufferSource renderer, int light, int overlayLight,
           ProfilerFiller profiler) {
 
-        UniversalCable cable = tile.getTransmitter();
-        if (cable == null || !cable.hasTransmitterNetwork())
-        {
-            return;
-        }
-
-        EnergyNetwork network = cable.getTransmitterNetwork();
-        if (network == null)
-        {
-            return;
-        }
-
+        EnergyNetwork network = tile.getTransmitter().getTransmitterNetwork();
         matrix.pushPose();
         matrix.translate(0.5, 0.5, 0.5);
         renderModel(tile, matrix, renderer.getBuffer(Sheets.translucentCullBlockSheet()), 0xFFFFFF, network.currentScale, LightTexture.FULL_BRIGHT,


### PR DESCRIPTION
## Changes proposed in this pull request:

- Added ValkyrienSkies and Eureka as runtime mods to help with mod compatibility testing. (KotlinForForge as well since VS relies on it)
- Updated the render function in RenderUniversalCable.java to check against null refs. Previously, getTransmitterNetwork() would return null when initially placing or removing a cable from a VS ship which would cause the client to crash.

Now with this fix, the client no longer crashes and players are able to place cables on VS ships.