### PR TITLE
Raised HUD compatibility

### DIFF
--- a/src/main/java/mekanism/client/ClientRegistration.java
+++ b/src/main/java/mekanism/client/ClientRegistration.java
@@ -315,7 +315,7 @@ public class ClientRegistration {
         event.registerAbove(VanillaGuiLayers.ARMOR_LEVEL, Mekanism.rl("energy_level"), MekaSuitEnergyLevel.INSTANCE);
         //Render status overlay after item name rather than action bar (record_overlay) so that things like the sleep fade will render in front of our overlay
         event.registerAbove(VanillaGuiLayers.SELECTED_ITEM_NAME, Mekanism.rl("status_overlay"), MekanismStatusOverlay.INSTANCE);
-        event.registerAbove(VanillaGuiLayers.HOTBAR, Mekanism.rl("hud"), MekanismHUD.INSTANCE);
+        event.registerBelow(VanillaGuiLayers.SLEEP_OVERLAY, Mekanism.rl("hud"), MekanismHUD.INSTANCE);
     }
 
     @SubscribeEvent


### PR DESCRIPTION
As originally discussed in https://github.com/mekanism/Mekanism/issues/8268 I have taken it upon myself to learn how to create a pull request in order to get this pushed and implemented in the foreseeable future. Already done some testing in a personalized instance to ensure no breakage which given the small change has not occurred, luckily. This does however result in the Raised mod's hotbar modification no longer affecting that of really any HUD elements also being moved alongside which is exactly what this intends to do.
 
## Changes proposed in this pull request:
moving status layer to be below VanillaGuiLayers.SLEEP_OVERLAY rather than above VanillaGuiLayer.HOTBAR, retaining the same type of implementation but with a different variable in use