### PR TITLE
Fix for EMI module crash when a food has a negative nutritional value.

### DIFF
--- a/src/main/java/mekanism/common/tile/machine/TileEntityNutritionalLiquifier.java
+++ b/src/main/java/mekanism/common/tile/machine/TileEntityNutritionalLiquifier.java
@@ -195,7 +195,7 @@ public class TileEntityNutritionalLiquifier extends TileEntityProgressMachine<It
             return null;
         }
         FoodProperties food = stack.getFoodProperties(null);
-        if (food == null || food.nutrition() == 0) {
+        if (food == null || food.nutrition() <= 0) {
             //If the food provides no healing don't allow consuming it as it won't provide any paste
             return null;
         }


### PR DESCRIPTION
This fixes Mekanism recipes module failing to load with the error "Fluid output cannot be empty". Item 'Human flesh' provided by Butcher has a negative nutrition value and was not caught. Issue found with Mekanism-1.21.1-10.7.8.70, Butcher-2.8, and emi-1.1.18+1.21.1+neoforge, on Neoforge-21.1.90.