### PR TITLE
Disambiguate some SaveHandler names.

### DIFF
--- a/src/main/java/mekanism/common/advancements/triggers/UseTierInstallerTrigger.java
+++ b/src/main/java/mekanism/common/advancements/triggers/UseTierInstallerTrigger.java
@@ -49,7 +49,7 @@ public class UseTierInstallerTrigger extends SimpleCriterionTrigger<UseTierInsta
         }
     }
 
-    public record TriggerInstance(Optional<ContextAwarePredicate> player, TierUsed action) implements SimpleInstance {
+    public record TriggerInstance(Optional<ContextAwarePredicate> player, TierUsed action) implements SimpleCriterionTrigger.SimpleInstance {
 
         public static final Codec<TriggerInstance> CODEC = RecordCodecBuilder.create(instance -> instance.group(
                     EntityPredicate.ADVANCEMENT_CODEC.optionalFieldOf(SerializationConstants.PLAYER).forGetter(TriggerInstance::player),

--- a/src/main/java/mekanism/common/content/network/distribution/EnergyTransmitterSaveTarget.java
+++ b/src/main/java/mekanism/common/content/network/distribution/EnergyTransmitterSaveTarget.java
@@ -12,7 +12,7 @@ public class EnergyTransmitterSaveTarget extends EnergySaveTarget<CableSaveHandl
     }
 
     @NothingNullByDefault
-    public static class CableSaveHandler extends SaveHandler {
+    public static class CableSaveHandler extends EnergySaveTarget.SaveHandler {
 
         private final UniversalCable transmitter;
 


### PR DESCRIPTION
Similar to in 577523afffbbafafa46de8b4653d632ffff7b744, there are some ambiguous inner-class names that cause some compilers to whine/choke.
