### PR TITLE
Set up two new source-sets that allow IntelliJ to resolve module dependencies for runs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,6 +127,10 @@ def setupExtraSourceSets(SourceSet base, boolean includeExtra = true) {
     if (base != project.sourceSets.gameTest) {
         project.sourceSets.gameTest.compileClasspath += base.output
     }
+    // Add the directory where Gradle would usually put the AP sources explicitly so IntelliJ picks it up
+    // If we don't do this, IJ seems to run a weird heuristic on where to put the AP sources and put them
+    // into the generated resource directory instead
+    base.java.srcDir project.file("build/generated/sources/annotationProcessor/java/${base.name}")
     //Setup and extend configurations for alternate modules. First by making the implementation, compileOnly, runtimeOnly equivalents
     // for those modules extend the main ones
     def baseImplementation = project.configurations.maybeCreate(base.getTaskName(null, 'implementation'))

--- a/build.gradle
+++ b/build.gradle
@@ -312,8 +312,6 @@ neoForge {
                 jvmArguments.addAll('-XX:+IgnoreUnrecognizedVMOptions', '-XX:+AllowEnhancedClassRedefinition')
             }
 
-            gameDirectory = project.file("runs/$name")
-
             // Uncomment this to get verbose debug logging
             // logLevel = org.slf4j.event.Level.DEBUG
 

--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,20 @@ sourceSets {
     gameTest {
         compileClasspath += api.output
     }
+    // These source-sets only exist for the sake of assembling a dependency graph
+    // for IntelliJ. Each of these will become an IntelliJ module when the project is imported,
+    // and will be set as the "main module" for the IntelliJ runs. A compile dependency
+    // on the other source sets is enough, since runtime classpath is managed by MDG anyway.
+    runMain {
+        runtimeClasspath += main.runtimeClasspath
+        runtimeClasspath += api.runtimeClasspath
+        compileClasspath += main.output
+        compileClasspath += api.output
+    }
+    runData {
+        compileClasspath += runMain.compileClasspath
+        runtimeClasspath += runMain.runtimeClasspath
+    }
 }
 
 configurations {
@@ -136,6 +150,8 @@ def setupExtraSourceSets(SourceSet base, boolean includeExtra = true) {
             def implExtends = [baseImplementation]
             if (extraType == 'datagen') {
                 implExtends.add(project.configurations.named('datagenNonMod').get())
+                sourceSets.runData.compileClasspath += extraSourceSet.output
+                sourceSets.runData.runtimeClasspath += extraSourceSet.runtimeClasspath
             }
             project.configurations.maybeCreate(extraSourceSet.getTaskName(null, 'implementation')).extendsFrom(*implExtends)
             project.configurations.maybeCreate(extraSourceSet.getTaskName(null, 'compileOnly')).extendsFrom(baseCompileOnly)
@@ -143,6 +159,9 @@ def setupExtraSourceSets(SourceSet base, boolean includeExtra = true) {
             project.configurations.maybeCreate(extraSourceSet.getTaskName(null, 'localRuntime')).extendsFrom(baseLocalRuntime)
         }
     }
+
+    sourceSets.runMain.compileClasspath += base.output
+    sourceSets.runMain.runtimeClasspath += base.runtimeClasspath
 }
 
 SourceSet setupExtraSourceSet(SourceSet baseSourceSet, String extra) {
@@ -290,6 +309,8 @@ neoForge {
 
             // Uncomment this to get verbose debug logging
             // logLevel = org.slf4j.event.Level.DEBUG
+
+            sourceSet = sourceSets.runMain
         }
         //Note: To enable logging into the client account, set the mc_devlogin property to true in your gradle user home
         // You can also run gradlew runClient -Pmc_devlogin=true
@@ -333,7 +354,7 @@ neoForge {
             programArguments.addAll('--all', '--output', file('src/datagen/generated/').absolutePath,
                     '--mod', 'mekanism', '--existing', file('src/main/resources/').absolutePath)
 
-            sourceSet = sourceSets.datagenMain
+            sourceSet = sourceSets.runData
             loadedMods = [mods.mekanismData]
 
             for (String name : secondaryModules) {

--- a/build.gradle
+++ b/build.gradle
@@ -308,6 +308,8 @@ neoForge {
                 jvmArguments.addAll('-XX:+IgnoreUnrecognizedVMOptions', '-XX:+AllowEnhancedClassRedefinition')
             }
 
+            gameDirectory = project.file("runs/$name")
+
             // Uncomment this to get verbose debug logging
             // logLevel = org.slf4j.event.Level.DEBUG
 

--- a/build.gradle
+++ b/build.gradle
@@ -140,6 +140,7 @@ def setupExtraSourceSets(SourceSet base, boolean includeExtra = true) {
         baseRuntimeOnly.extendsFrom(project.configurations.named('runtimeOnly').get())
         baseLocalRuntime.extendsFrom(project.configurations.named('localRuntime').get())
     }
+    base.runtimeClasspath += baseLocalRuntime
     if (includeExtra) {
         //And then setup and have all the extra sourceSets have their configurations extend the ones for the base module so that they can
         // properly access the dependency


### PR DESCRIPTION
Basically IJ (well, and Gradle) need a way to know which submodules need to be built when you run the various runs.
There is no sourceSet / module that actually depends on all the parts that are required.

This PR introduces the source sets `runMain` and `runData`, which have no actual sources. Since IJ imports source sets as IJ modules, they can be set as the main module of a IJ run configuration, and IJ will compile the dependent modules correctly.

To this end, I set up runMain to depend on api, main and the secondary modules, while runData inherits everything from runMain, plus all the datagen sets. There's no third source set for the game tests, since the game test source set already has the necessary dependencies for IJ.

Note on delegation: This will make running without delegating the build to Gradle possible, and also fixes running with delegation enabled. In delegation-mode, IJ only runs `:classes` (for the main module), which only compiles *compile time* dependencies of the `main` source set. By setting the module in IJ to `runMain`, it will run `:runMainClasses`, which builds the correct dependences in delegate-to-Gradle mode too.