### PR TITLE
temporary portable teleporter fix

### DIFF
--- a/src/main/java/mekanism/client/gui/element/custom/GuiFrequencySelector.java
+++ b/src/main/java/mekanism/client/gui/element/custom/GuiFrequencySelector.java
@@ -88,8 +88,9 @@ public class GuiFrequencySelector<FREQ extends Frequency> extends GuiElement {
         setButton = addChild(new TranslationButton(frequencySelector, 27, yStart + 113, buttonWidth, 18, MekanismLang.BUTTON_SET, (element, mouseX, mouseY) -> {
             int selection = this.scrollList.getSelection();
             if (selection != -1) {
-                Frequency frequency = getFrequencies().get(selection);
+                FREQ frequency = getFrequencies().get(selection);
                 setFrequency(frequency.getName(), frequency.getOwner());
+                frequencySelector.setFrequency(frequency);
             }
             //Note: We update the buttons regardless so that if something went wrong, and we don't have a selection
             // we will disable the ability to press the set button
@@ -239,6 +240,8 @@ public class GuiFrequencySelector<FREQ extends Frequency> extends GuiElement {
         @Nullable
         FREQ getFrequency();
 
+        void setFrequency(FREQ freq);
+
         List<FREQ> getPublicFrequencies();
 
         List<FREQ> getTrustedFrequencies();
@@ -283,6 +286,8 @@ public class GuiFrequencySelector<FREQ extends Frequency> extends GuiElement {
             return getTileEntity().getFrequency(getFrequencyType());
         }
 
+        default void setFrequency(FREQ freq) {}
+
         @Override
         default List<FREQ> getPublicFrequencies() {
             return getTileEntity().getPublicCache(getFrequencyType());
@@ -321,6 +326,10 @@ public class GuiFrequencySelector<FREQ extends Frequency> extends GuiElement {
         @Override
         default FREQ getFrequency() {
             return getFrequencyContainer().getFrequency();
+        }
+
+        default void setFrequency(FREQ freq) {
+            getFrequencyContainer().setFrequency(freq);
         }
 
         @Override

--- a/src/main/java/mekanism/common/inventory/container/item/FrequencyItemContainer.java
+++ b/src/main/java/mekanism/common/inventory/container/item/FrequencyItemContainer.java
@@ -38,6 +38,10 @@ public abstract class FrequencyItemContainer<FREQ extends Frequency> extends Mek
         return freq;
     }
 
+    public void setFrequency(FREQ frequency) {
+        freq = frequency;
+    }
+
     public List<FREQ> getPublicCache() {
         return publicCache;
     }


### PR DESCRIPTION
we update frequency on client every time it changes to get rid of desync in portable teleporter