### PR TITLE
Fix baby creeper music disk drops in 1.20.x.

### DIFF
--- a/src/datagen/additions/java/mekanism/additions/common/loot/AdditionsEntityLootTables.java
+++ b/src/datagen/additions/java/mekanism/additions/common/loot/AdditionsEntityLootTables.java
@@ -38,7 +38,7 @@ public class AdditionsEntityLootTables extends BaseEntityLootTables {
                           )
               ).withPool(LootPool.lootPool()
                     .name("music_discs")
-                    .add(TagEntry.expandTag(ItemTags.MUSIC_DISCS))
+                    .add(TagEntry.expandTag(ItemTags.CREEPER_DROP_MUSIC_DISCS))
                     .when(LootItemEntityPropertyCondition.hasProperties(LootContext.EntityTarget.KILLER, EntityPredicate.Builder.entity().of(EntityTypeTags.SKELETONS)))
               )
         );

--- a/src/datagen/generated/mekanism/.cache/2ca94f3a6e22cb9eec299788405fc6e4ad158c09
+++ b/src/datagen/generated/mekanism/.cache/2ca94f3a6e22cb9eec299788405fc6e4ad158c09
@@ -1,6 +1,6 @@
-// 1.20.1	2024-02-21T09:25:49.6546537	ComputerHelp: mekanism
+// 1.20.1	2025-03-02T15:45:04.5585355	ComputerHelp: mekanism
 94b6d2a203a16827e2f54f7489e90159992acdb3 data/mekanism/computer_help/enums.csv
 b38b847919651e2a55bc3eb8c719b2d92f76de7a data/mekanism/computer_help/enums.json
-998898ef68a2494f14d74df80861566d500c4cb2 data/mekanism/computer_help/jekyll.md
+5c12a25f0ed337759264024cf674fb0f2a76b678 data/mekanism/computer_help/jekyll.md
 2144f7ee4dfd00bfdfb7969c3497f22a4e841781 data/mekanism/computer_help/methods.csv
 1bc03705513685d0612588d200070d7b8ba12bb7 data/mekanism/computer_help/methods.json

--- a/src/datagen/generated/mekanism/data/mekanism/computer_help/jekyll.md
+++ b/src/datagen/generated/mekanism/data/mekanism/computer_help/jekyll.md
@@ -4569,5 +4569,5 @@ methods:
     returns:
       javaType: boolean
       type: boolean
-version: 10.4.6
+version: 10.4.14
 ---

--- a/src/datagen/generated/mekanismadditions/.cache/59eb3dbb5f86130e09b3c62d89b9525ee01cf52d
+++ b/src/datagen/generated/mekanismadditions/.cache/59eb3dbb5f86130e09b3c62d89b9525ee01cf52d
@@ -1,4 +1,4 @@
-// 1.20.1	2023-06-22T11:05:41.6271597	Loot Tables
+// 1.20.1	2025-03-02T15:45:04.7745571	Loot Tables
 ebaa6ce2198087b82ee29bbae644670c6c9b02c6 data/mekanismadditions/loot_tables/blocks/aqua_glow_panel.json
 64433f06f22aa8e7afe74713f5ae323ab205981d data/mekanismadditions/loot_tables/blocks/aqua_plastic.json
 5bbcc78135e54027cc0dddceddd9dbe11dcc681a data/mekanismadditions/loot_tables/blocks/aqua_plastic_fence.json
@@ -270,7 +270,7 @@ ca53334d21eed1baad4a48937f5edfdc8fe1e1bc data/mekanismadditions/loot_tables/bloc
 55a1affcb9a090ad8a6a6a922ee5543e37ce3cb0 data/mekanismadditions/loot_tables/blocks/yellow_plastic_transparent_stairs.json
 74f1be6237e71a392040c0a50cc601d72385cd2f data/mekanismadditions/loot_tables/blocks/yellow_reinforced_plastic.json
 b330bdc6fc194a88bd69486ec40d5e922e2aa812 data/mekanismadditions/loot_tables/blocks/yellow_slick_plastic.json
-3c533b4d6979e8cf33ed28699b8a584137aa56e2 data/mekanismadditions/loot_tables/entities/baby_creeper.json
+4db3346598260d4508ae93fd979bce061f38a93b data/mekanismadditions/loot_tables/entities/baby_creeper.json
 ec283404cf232dc5ab9e7dd54f31708b121d2b33 data/mekanismadditions/loot_tables/entities/baby_enderman.json
 0f8b188fe5d528fe2adc03ed82b6225797f3738b data/mekanismadditions/loot_tables/entities/baby_skeleton.json
 47e34aeb8b17d5393222d375d5545a37e9e5fef4 data/mekanismadditions/loot_tables/entities/baby_stray.json

--- a/src/datagen/generated/mekanismadditions/data/mekanismadditions/loot_tables/entities/baby_creeper.json
+++ b/src/datagen/generated/mekanismadditions/data/mekanismadditions/loot_tables/entities/baby_creeper.json
@@ -46,7 +46,7 @@
         {
           "type": "minecraft:tag",
           "expand": true,
-          "name": "minecraft:music_discs"
+          "name": "minecraft:creeper_drop_music_discs"
         }
       ],
       "name": "music_discs",


### PR DESCRIPTION
## Changes proposed in this pull request:

Make baby creepers only drop disks that vanilla creepers drop, instead of all disks.

This PR finishes the job started in this abandoned PR - https://github.com/mekanism/Mekanism/pull/8280.