### PR TITLE
Improve diagnosis of 'invalid inner' formation result

### DIFF
--- a/src/datagen/generated/mekanism/.cache/c10fcd8abbb6a520fc3ac2cf14b627d36958dd55
+++ b/src/datagen/generated/mekanism/.cache/c10fcd8abbb6a520fc3ac2cf14b627d36958dd55
@@ -1,5 +1,5 @@
-// 1.21.1	2025-02-25T12:15:01.862441	Languages: en_us for mod: mekanism
+// 1.21.1	2025-03-07T11:42:01.4474882	Languages: en_us for mod: mekanism
 bcd4b37f2bbe40ca304a7e21398dbdfdd3ad7f96 assets/mekanism/lang/en_au.json
 bcd4b37f2bbe40ca304a7e21398dbdfdd3ad7f96 assets/mekanism/lang/en_gb.json
-355ba2ff13cdd5b9d1cba0ace1f2a071ebde4570 assets/mekanism/lang/en_ud.json
-1d435d01b52cab2ef4966ad68c71c85a7349ddf6 assets/mekanism/lang/en_us.json
+d7384c24dc7950b472507a53d53890ce640326f1 assets/mekanism/lang/en_ud.json
+8f6b2253026844c8a17f056439421a9ed7f68b2a assets/mekanism/lang/en_us.json

--- a/src/datagen/generated/mekanism/assets/mekanism/lang/en_ud.json
+++ b/src/datagen/generated/mekanism/assets/mekanism/lang/en_ud.json
@@ -2753,7 +2753,7 @@
   "multiblock.mekanism.incomplete": "ǝʇǝꞁdɯoɔuI",
   "multiblock.mekanism.invalid_controller_conflict": "˙%s ʇɐ ɹǝꞁꞁoɹʇuoɔ ɐɹʇxǝ punoɟ :ʇɔᴉꞁɟuoɔ ɹǝꞁꞁoɹʇuoƆ",
   "multiblock.mekanism.invalid_frame": "˙%s ʇɐ ʞɔoꞁq pᴉꞁɐʌuᴉ 'ǝɯɐɹɟ ǝʇɐǝɹɔ ʇ,upꞁnoƆ",
-  "multiblock.mekanism.invalid_inner": "˙%s ʇɐ ʞɔoꞁq pᴉꞁɐʌuᴉ punoɟ 'ɹǝʇuǝɔ ǝʇɐpᴉꞁɐʌ ʇ,upꞁnoƆ",
+  "multiblock.mekanism.invalid_inner": "˙%s ʇɐ pǝʇɐɔoꞁ (%s) ʞɔoꞁq ꞁɐᵷǝꞁꞁᴉ uɐ suᴉɐʇuoɔ ǝɹnʇɔnɹʇs ɹǝuuI",
   "multiblock.mekanism.invalid_no_controller": "˙punoɟ ɹǝꞁꞁoɹʇuoɔ ou 'ɯɹoɟ ʇ,upꞁnoƆ",
   "network.mekanism.chemical": "ʞɹoʍʇǝNꞁɐɔᴉɯǝɥƆ",
   "network.mekanism.description": "˙sɹoʇdǝɔɔɐ %3$s 'sɹǝʇʇᴉɯsuɐɹʇ %s [%1$s]",

--- a/src/datagen/generated/mekanism/assets/mekanism/lang/en_us.json
+++ b/src/datagen/generated/mekanism/assets/mekanism/lang/en_us.json
@@ -2756,7 +2756,7 @@
   "multiblock.mekanism.incomplete": "Incomplete",
   "multiblock.mekanism.invalid_controller_conflict": "Controller conflict: found extra controller at %1$s.",
   "multiblock.mekanism.invalid_frame": "Couldn't create frame, invalid block at %1$s.",
-  "multiblock.mekanism.invalid_inner": "Couldn't validate center, found invalid block at %1$s.",
+  "multiblock.mekanism.invalid_inner": "Inner structure contains an illegal block (%2$s) located at %1$s.",
   "multiblock.mekanism.invalid_no_controller": "Couldn't form, no controller found.",
   "network.mekanism.chemical": "ChemicalNetwork",
   "network.mekanism.description": "[%1$s] %2$s transmitters, %3$s acceptors.",

--- a/src/datagen/main/java/mekanism/client/lang/MekanismLangProvider.java
+++ b/src/datagen/main/java/mekanism/client/lang/MekanismLangProvider.java
@@ -917,7 +917,7 @@ public class MekanismLangProvider extends BaseLanguageProvider {
         add(MekanismLang.OFFHAND, "Hand 2");
         //Multiblock
         add(MekanismLang.MULTIBLOCK_INVALID_FRAME, "Couldn't create frame, invalid block at %1$s.");
-        add(MekanismLang.MULTIBLOCK_INVALID_INNER, "Couldn't validate center, found invalid block at %1$s.");
+        add(MekanismLang.MULTIBLOCK_INVALID_INNER, "Inner structure contains an illegal block (%2$s) located at %1$s.");
         add(MekanismLang.MULTIBLOCK_INVALID_CONTROLLER_CONFLICT, "Controller conflict: found extra controller at %1$s.");
         add(MekanismLang.MULTIBLOCK_INVALID_NO_CONTROLLER, "Couldn't form, no controller found.");
         //SPS

--- a/src/main/java/mekanism/common/lib/multiblock/CuboidStructureValidator.java
+++ b/src/main/java/mekanism/common/lib/multiblock/CuboidStructureValidator.java
@@ -82,7 +82,7 @@ public abstract class CuboidStructureValidator<T extends MultiblockData> impleme
                 return ret;
             }
         } else if (!validateInner(state, chunkMap, pos)) {
-            return FormationResult.fail(MekanismLang.MULTIBLOCK_INVALID_INNER, pos);
+            return FormationResult.fail(MekanismLang.MULTIBLOCK_INVALID_INNER, pos, state);
         } else if (!state.isAir()) {
             //Make sure the position is immutable before we store it
             ctx.internalLocations.add(pos.immutable());

--- a/src/main/java/mekanism/common/lib/multiblock/FormationProtocol.java
+++ b/src/main/java/mekanism/common/lib/multiblock/FormationProtocol.java
@@ -26,6 +26,7 @@ import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.phys.Vec3;
 
@@ -157,6 +158,10 @@ public class FormationProtocol<T extends MultiblockData> {
         return MekanismLang.GENERIC_PARENTHESIS.translate(MekanismLang.GENERIC_BLOCK_POS.translate(pos.getX(), pos.getY(), pos.getZ()));
     }
 
+    protected static Component text(BlockState state) {
+        return state.getBlock().getName();
+    }
+
     @FunctionalInterface
     public interface FormationChecker<NODE> {
 
@@ -216,6 +221,14 @@ public class FormationProtocol<T extends MultiblockData> {
 
         public static FormationResult fail(ILangEntry text, BlockPos pos, boolean noIgnore) {
             return fail(text.translateColored(EnumColor.GRAY, EnumColor.INDIGO, text(pos)), noIgnore);
+        }
+
+        public static FormationResult fail(ILangEntry text, BlockPos pos, BlockState state) {
+            return fail(text, pos, state, false);
+        }
+
+        public static FormationResult fail(ILangEntry text, BlockPos pos, BlockState state, boolean noIgnore) {
+            return fail(text.translateColored(EnumColor.GRAY, EnumColor.INDIGO, text(pos), EnumColor.WHITE, text(state)), noIgnore);
         }
 
         public static FormationResult fail(ILangEntry text) {


### PR DESCRIPTION
## Changes proposed in this pull request:
Edit `MULTIBLOCK_INVALID_INNER` language entry to accommodate a block name.

Add methods:
- `FormationResult#text()` to produce a `Component` from a `BlockState`
- `FormationResult#fail()` to produce a `FormationResult` from a `BlockPos` and `BlockState`

Adapt `CuboidStructure#validateNode()` to use the latter method.