### PR TITLE
Extract `IFreeRunnersItem`, add integration with Curio

### DIFF
--- a/src/main/java/mekanism/common/CommonPlayerTickHandler.java
+++ b/src/main/java/mekanism/common/CommonPlayerTickHandler.java
@@ -23,6 +23,7 @@ import mekanism.common.item.gear.ItemFreeRunners;
 import mekanism.common.item.gear.ItemMekaSuitArmor;
 import mekanism.common.item.gear.ItemScubaMask;
 import mekanism.common.item.gear.ItemScubaTank;
+import mekanism.common.item.interfaces.IFreeRunnersItem;
 import mekanism.common.item.interfaces.IJetpackItem;
 import mekanism.common.item.interfaces.IJetpackItem.JetpackMode;
 import mekanism.common.lib.radiation.RadiationManager;
@@ -73,10 +74,10 @@ public class CommonPlayerTickHandler {
         if (player.isShiftKeyDown()) {
             return 0;
         }
-        ItemStack stack = player.getItemBySlot(EquipmentSlot.FEET);
+        ItemStack stack = IFreeRunnersItem.getFreeRunners(player);
         if (stack.isEmpty()) {
             return 0;
-        } else if (stack.getItem() instanceof ItemFreeRunners freeRunners && freeRunners.getMode(stack).providesStepBoost()) {
+        } else if (stack.getItem() instanceof IFreeRunnersItem freeRunners && freeRunners.getFreeRunnersMode(stack).providesStepBoost()) {
             return 0.5F;
         }
         IModule<ModuleHydraulicPropulsionUnit> hydraulic = IModuleHelper.INSTANCE.getIfEnabled(stack, MekanismModules.HYDRAULIC_PROPULSION_UNIT);
@@ -289,18 +290,22 @@ public class CommonPlayerTickHandler {
      */
     @Nullable
     private FallEnergyInfo getFallAbsorptionEnergyInfo(LivingEntity base) {
+        ItemStack freeRunners = IFreeRunnersItem.getFreeRunners(base);
+        if (!freeRunners.isEmpty()) {
+            if (freeRunners.getItem() instanceof IFreeRunnersItem boots && boots.getFreeRunnersMode(freeRunners).preventsFallDamage()) {
+                return new FallEnergyInfo(StorageUtils.getEnergyContainer(freeRunners, 0), MekanismConfig.gear.freeRunnerFallDamageRatio,
+                          MekanismConfig.gear.freeRunnerFallEnergyCost);
+            }
+        }
+
         ItemStack feetStack = base.getItemBySlot(EquipmentSlot.FEET);
         if (!feetStack.isEmpty()) {
-            if (feetStack.getItem() instanceof ItemFreeRunners boots) {
-                if (boots.getMode(feetStack).preventsFallDamage()) {
-                    return new FallEnergyInfo(StorageUtils.getEnergyContainer(feetStack, 0), MekanismConfig.gear.freeRunnerFallDamageRatio,
-                          MekanismConfig.gear.freeRunnerFallEnergyCost);
-                }
-            } else if (feetStack.getItem() instanceof ItemMekaSuitArmor) {
+            if (feetStack.getItem() instanceof ItemMekaSuitArmor) {
                 return new FallEnergyInfo(StorageUtils.getEnergyContainer(feetStack, 0), MekanismConfig.gear.mekaSuitFallDamageRatio,
                       MekanismConfig.gear.mekaSuitEnergyUsageFall);
             }
         }
+
         return null;
     }
 

--- a/src/main/java/mekanism/common/item/gear/ItemFreeRunners.java
+++ b/src/main/java/mekanism/common/item/gear/ItemFreeRunners.java
@@ -1,20 +1,14 @@
 package mekanism.common.item.gear;
 
-import com.mojang.serialization.Codec;
-import io.netty.buffer.ByteBuf;
 import java.util.List;
-import java.util.Locale;
 import java.util.function.Consumer;
-import java.util.function.IntFunction;
-import mekanism.api.IIncrementalEnum;
-import mekanism.api.annotations.NothingNullByDefault;
+
 import mekanism.api.text.EnumColor;
-import mekanism.api.text.IHasTextComponent.IHasEnumNameTextComponent;
-import mekanism.api.text.ILangEntry;
 import mekanism.common.Mekanism;
 import mekanism.common.MekanismLang;
 import mekanism.common.config.MekanismConfig;
-import mekanism.common.item.gear.ItemFreeRunners.FreeRunnerMode;
+import mekanism.common.item.interfaces.IFreeRunnersItem;
+import mekanism.common.item.interfaces.IFreeRunnersItem.FreeRunnersMode;
 import mekanism.common.item.interfaces.IHasConditionalAttributes;
 import mekanism.common.item.interfaces.IItemHUDProvider;
 import mekanism.common.item.interfaces.IModeItem.IAttachmentBasedModeItem;
@@ -25,10 +19,6 @@ import mekanism.common.util.StorageUtils;
 import net.minecraft.core.Holder;
 import net.minecraft.core.component.DataComponentType;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.codec.ByteBufCodecs;
-import net.minecraft.network.codec.StreamCodec;
-import net.minecraft.util.ByIdMap;
-import net.minecraft.util.StringRepresentable;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.EquipmentSlotGroup;
 import net.minecraft.world.entity.LivingEntity;
@@ -45,7 +35,7 @@ import net.minecraft.world.item.TooltipFlag;
 import net.neoforged.neoforge.event.ItemAttributeModifierEvent;
 import org.jetbrains.annotations.NotNull;
 
-public class ItemFreeRunners extends ItemSpecialArmor implements IItemHUDProvider, ICustomCreativeTabContents, IAttachmentBasedModeItem<FreeRunnerMode>,
+public class ItemFreeRunners extends ItemSpecialArmor implements IItemHUDProvider, IFreeRunnersItem, ICustomCreativeTabContents, IAttachmentBasedModeItem<FreeRunnersMode>,
       IHasConditionalAttributes {
 
     private static final AttributeModifier MOVEMENT_EFFICIENCY = new AttributeModifier(Mekanism.rl("free_runners"), 1, Operation.ADD_VALUE);
@@ -56,7 +46,7 @@ public class ItemFreeRunners extends ItemSpecialArmor implements IItemHUDProvide
 
     public ItemFreeRunners(Holder<ArmorMaterial> material, Properties properties) {
         super(material, ArmorItem.Type.BOOTS, properties.rarity(Rarity.RARE).setNoRepair().stacksTo(1)
-              .component(MekanismDataComponents.FREE_RUNNER_MODE, FreeRunnerMode.NORMAL)
+              .component(MekanismDataComponents.FREE_RUNNER_MODE, FreeRunnersMode.NORMAL)
         );
     }
 
@@ -92,13 +82,13 @@ public class ItemFreeRunners extends ItemSpecialArmor implements IItemHUDProvide
     }
 
     @Override
-    public DataComponentType<FreeRunnerMode> getModeDataType() {
+    public DataComponentType<FreeRunnersMode> getModeDataType() {
         return MekanismDataComponents.FREE_RUNNER_MODE.get();
     }
 
     @Override
-    public FreeRunnerMode getDefaultMode() {
-        return FreeRunnerMode.NORMAL;
+    public FreeRunnersMode getDefaultMode() {
+        return FreeRunnersMode.NORMAL;
     }
 
     @Override
@@ -111,8 +101,8 @@ public class ItemFreeRunners extends ItemSpecialArmor implements IItemHUDProvide
 
     @Override
     public void changeMode(@NotNull Player player, @NotNull ItemStack stack, int shift, DisplayChange displayChange) {
-        FreeRunnerMode mode = getMode(stack);
-        FreeRunnerMode newMode = mode.adjust(shift);
+        FreeRunnersMode mode = getMode(stack);
+        FreeRunnersMode newMode = mode.adjust(shift);
         if (mode != newMode) {
             setMode(stack, player, newMode);
             displayChange.sendMessage(player, newMode, MekanismLang.FREE_RUNNER_MODE_CHANGE::translate);
@@ -126,56 +116,13 @@ public class ItemFreeRunners extends ItemSpecialArmor implements IItemHUDProvide
 
     @Override
     public void adjustAttributes(ItemAttributeModifierEvent event) {
-        if (getMode(event.getItemStack()) == FreeRunnerMode.NORMAL) {
+        if (getMode(event.getItemStack()) == FreeRunnersMode.NORMAL) {
             event.addModifier(Attributes.MOVEMENT_EFFICIENCY, MOVEMENT_EFFICIENCY, EquipmentSlotGroup.FEET);
         }
     }
 
-    @NothingNullByDefault
-    public enum FreeRunnerMode implements IIncrementalEnum<FreeRunnerMode>, IHasEnumNameTextComponent, StringRepresentable {
-        NORMAL(MekanismLang.FREE_RUNNER_NORMAL, EnumColor.DARK_GREEN, true, true),
-        SAFETY(MekanismLang.FREE_RUNNER_SAFETY, EnumColor.ORANGE, true, false),
-        DISABLED(MekanismLang.FREE_RUNNER_DISABLED, EnumColor.DARK_RED, false, false);
-
-        public static final Codec<FreeRunnerMode> CODEC = StringRepresentable.fromEnum(FreeRunnerMode::values);
-        public static final IntFunction<FreeRunnerMode> BY_ID = ByIdMap.continuous(FreeRunnerMode::ordinal, values(), ByIdMap.OutOfBoundsStrategy.WRAP);
-        public static final StreamCodec<ByteBuf, FreeRunnerMode> STREAM_CODEC = ByteBufCodecs.idMapper(BY_ID, FreeRunnerMode::ordinal);
-
-        private final String serializedName;
-        private final boolean preventsFallDamage;
-        private final boolean providesStepBoost;
-        private final ILangEntry langEntry;
-        private final EnumColor color;
-
-        FreeRunnerMode(ILangEntry langEntry, EnumColor color, boolean preventsFallDamage, boolean providesStepBoost) {
-            this.serializedName = name().toLowerCase(Locale.ROOT);
-            this.preventsFallDamage = preventsFallDamage;
-            this.providesStepBoost = providesStepBoost;
-            this.langEntry = langEntry;
-            this.color = color;
-        }
-
-        public boolean preventsFallDamage() {
-            return preventsFallDamage;
-        }
-
-        public boolean providesStepBoost() {
-            return providesStepBoost;
-        }
-
-        @Override
-        public Component getTextComponent() {
-            return langEntry.translateColored(color);
-        }
-
-        @Override
-        public FreeRunnerMode byIndex(int index) {
-            return BY_ID.apply(index);
-        }
-
-        @Override
-        public String getSerializedName() {
-            return serializedName;
-        }
+    @Override
+    public FreeRunnersMode getFreeRunnersMode(ItemStack stack) {
+        return getMode(stack);
     }
 }

--- a/src/main/java/mekanism/common/item/interfaces/IFreeRunnersItem.java
+++ b/src/main/java/mekanism/common/item/interfaces/IFreeRunnersItem.java
@@ -1,0 +1,101 @@
+package mekanism.common.item.interfaces;
+
+import com.mojang.serialization.Codec;
+import io.netty.buffer.ByteBuf;
+import mekanism.api.IIncrementalEnum;
+import mekanism.api.annotations.NothingNullByDefault;
+import mekanism.api.text.EnumColor;
+import mekanism.api.text.IHasTextComponent;
+import mekanism.api.text.ILangEntry;
+import mekanism.common.Mekanism;
+import mekanism.common.MekanismLang;
+import mekanism.common.integration.curios.CuriosIntegration;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.util.ByIdMap;
+import net.minecraft.util.StringRepresentable;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Locale;
+import java.util.function.IntFunction;
+import java.util.function.Predicate;
+
+public interface IFreeRunnersItem {
+    FreeRunnersMode getFreeRunnersMode(ItemStack stack);
+
+    @NothingNullByDefault
+    enum FreeRunnersMode implements IIncrementalEnum<FreeRunnersMode>, IHasTextComponent.IHasEnumNameTextComponent, StringRepresentable {
+        NORMAL(MekanismLang.FREE_RUNNER_NORMAL, EnumColor.DARK_GREEN, true, true),
+        SAFETY(MekanismLang.FREE_RUNNER_SAFETY, EnumColor.ORANGE, true, false),
+        DISABLED(MekanismLang.FREE_RUNNER_DISABLED, EnumColor.DARK_RED, false, false);
+
+        public static final Codec<FreeRunnersMode> CODEC = StringRepresentable.fromEnum(FreeRunnersMode::values);
+        public static final IntFunction<FreeRunnersMode> BY_ID = ByIdMap.continuous(FreeRunnersMode::ordinal, values(), ByIdMap.OutOfBoundsStrategy.WRAP);
+        public static final StreamCodec<ByteBuf, FreeRunnersMode> STREAM_CODEC = ByteBufCodecs.idMapper(BY_ID, FreeRunnersMode::ordinal);
+
+        private final String serializedName;
+        private final boolean preventsFallDamage;
+        private final boolean providesStepBoost;
+        private final ILangEntry langEntry;
+        private final EnumColor color;
+
+        FreeRunnersMode(ILangEntry langEntry, EnumColor color, boolean preventsFallDamage, boolean providesStepBoost) {
+            this.serializedName = name().toLowerCase(Locale.ROOT);
+            this.preventsFallDamage = preventsFallDamage;
+            this.providesStepBoost = providesStepBoost;
+            this.langEntry = langEntry;
+            this.color = color;
+        }
+
+        public boolean preventsFallDamage() {
+            return preventsFallDamage;
+        }
+
+        public boolean providesStepBoost() {
+            return providesStepBoost;
+        }
+
+        @Override
+        public Component getTextComponent() {
+            return langEntry.translateColored(color);
+        }
+
+        @Override
+        public FreeRunnersMode byIndex(int index) {
+            return BY_ID.apply(index);
+        }
+
+        @Override
+        public String getSerializedName() {
+            return serializedName;
+        }
+    }
+
+    /**
+     * Gets the first found free runners from an entity, if one is worn. Purpose of this is to get the correct free
+     * runners mode to use.
+     * <br>
+     * If Curios is loaded, the curio slots will be checked as well.
+     *
+     * @param entity the entity on which to look for the free runners
+     *
+     * @return the free runners stack if present, otherwise an empty stack
+     */
+    @NotNull
+    static ItemStack getFreeRunners(LivingEntity entity) {
+        Predicate<ItemStack> matcher = stack -> stack.getItem() instanceof IFreeRunnersItem;
+
+        ItemStack feet = entity.getItemBySlot(EquipmentSlot.FEET);
+        if (matcher.test(feet)) {
+            return feet;
+        } else if (Mekanism.hooks.curios.isLoaded()) {
+            return CuriosIntegration.findFirstCurio(entity, matcher);
+        }
+
+        return ItemStack.EMPTY;
+    }
+}

--- a/src/main/java/mekanism/common/registries/MekanismDataComponents.java
+++ b/src/main/java/mekanism/common/registries/MekanismDataComponents.java
@@ -33,7 +33,7 @@ import mekanism.common.content.teleporter.TeleporterFrequency;
 import mekanism.common.item.ItemConfigurator.ConfiguratorMode;
 import mekanism.common.item.gear.ItemAtomicDisassembler.DisassemblerMode;
 import mekanism.common.item.gear.ItemFlamethrower.FlamethrowerMode;
-import mekanism.common.item.gear.ItemFreeRunners.FreeRunnerMode;
+import mekanism.common.item.interfaces.IFreeRunnersItem.FreeRunnersMode;
 import mekanism.common.item.interfaces.IJetpackItem.JetpackMode;
 import mekanism.common.lib.frequency.Frequency;
 import mekanism.common.lib.frequency.FrequencyType;
@@ -116,9 +116,9 @@ public class MekanismDataComponents {
           builder -> builder.persistent(FlamethrowerMode.CODEC)
                 .networkSynchronized(FlamethrowerMode.STREAM_CODEC)
     );
-    public static final MekanismDeferredHolder<DataComponentType<?>, DataComponentType<FreeRunnerMode>> FREE_RUNNER_MODE = DATA_COMPONENTS.simple("free_runner_mode",
-          builder -> builder.persistent(FreeRunnerMode.CODEC)
-                .networkSynchronized(FreeRunnerMode.STREAM_CODEC)
+    public static final MekanismDeferredHolder<DataComponentType<?>, DataComponentType<FreeRunnersMode>> FREE_RUNNER_MODE = DATA_COMPONENTS.simple("free_runner_mode",
+          builder -> builder.persistent(FreeRunnersMode.CODEC)
+                .networkSynchronized(FreeRunnersMode.STREAM_CODEC)
     );
     public static final MekanismDeferredHolder<DataComponentType<?>, DataComponentType<JetpackMode>> JETPACK_MODE = DATA_COMPONENTS.simple("jetpack_mode",
           builder -> builder.persistent(JetpackMode.CODEC)


### PR DESCRIPTION
## Changes proposed in this pull request:
This patch introduces integration of Free Runners with Curio slots. As side effect it introduces `IFreeRunners` interface and extracts shared logic into it. It also renames `FreeRunnerMode` to `FreeRunnersMode` to comply to other class names, let me know if it needs to get renamed back

It is my first contribution to Minecraft mod (and Java project too), so I might make some mistakes (although I tested it myself)