### PR TITLE
Paxels now can have custom durability

### DIFF
--- a/src/tools/java/mekanism/tools/common/item/ItemMekanismPaxel.java
+++ b/src/tools/java/mekanism/tools/common/item/ItemMekanismPaxel.java
@@ -9,6 +9,7 @@ import mekanism.tools.common.ToolsTags;
 import mekanism.tools.common.material.IPaxelMaterial;
 import mekanism.tools.common.material.MaterialCreator;
 import mekanism.tools.common.material.VanillaPaxelMaterialCreator;
+import mekanism.tools.common.registries.ToolsItems;
 import mekanism.tools.common.util.ToolsUtils;
 import net.minecraft.Util;
 import net.minecraft.advancements.CriteriaTriggers;
@@ -48,14 +49,14 @@ public class ItemMekanismPaxel extends DiggerItem {
 
     private final IPaxelMaterial material;
 
-    public ItemMekanismPaxel(MaterialCreator material, Item.Properties properties) {
-        super(material, ToolsTags.Blocks.MINEABLE_WITH_PAXEL, properties.
+    public ItemMekanismPaxel(MaterialCreator material, ToolsItems.LockableProperties properties) {
+        super(material, ToolsTags.Blocks.MINEABLE_WITH_PAXEL, properties.durability(material.getPaxelDurability()).lockDurability().
               attributes(createAttributes(material, material.getPaxelDamage(), material.getPaxelAtkSpeed())));
         this.material = material;
     }
 
-    public ItemMekanismPaxel(VanillaPaxelMaterialCreator material, Item.Properties properties) {
-        super(material.getVanillaTier(), ToolsTags.Blocks.MINEABLE_WITH_PAXEL, properties.
+    public ItemMekanismPaxel(VanillaPaxelMaterialCreator material, ToolsItems.LockableProperties properties) {
+        super(material.getVanillaTier(), ToolsTags.Blocks.MINEABLE_WITH_PAXEL, properties.durability(material.getPaxelDurability()).lockDurability().
               attributes(createAttributes(material.getVanillaTier(), material.getPaxelDamage(), material.getPaxelAtkSpeed())));
         this.material = material;
     }

--- a/src/tools/java/mekanism/tools/common/registries/ToolsItems.java
+++ b/src/tools/java/mekanism/tools/common/registries/ToolsItems.java
@@ -139,9 +139,9 @@ public class ToolsItems {
 
     private static ItemRegistryObject<ItemMekanismPaxel> registerPaxel(VanillaPaxelMaterialCreator material) {
         if (material.getVanillaTier() == Tiers.NETHERITE) {
-            return ITEMS.registerUnburnable(material.getRegistryPrefix() + "_paxel", properties -> new ItemMekanismPaxel(material, properties));
+            return ITEMS.register(material.getRegistryPrefix() + "_paxel", () -> new ItemMekanismPaxel(material, new LockableProperties().fireResistant()));
         }
-        return ITEMS.registerItem(material.getRegistryPrefix() + "_paxel", properties -> new ItemMekanismPaxel(material, properties));
+        return ITEMS.register(material.getRegistryPrefix() + "_paxel", () -> new ItemMekanismPaxel(material, new LockableProperties()));
     }
 
     private static ItemRegistryObject<ItemMekanismArmor> registerArmor(Holder<ArmorMaterial> armorMaterial, MaterialCreator material, ArmorItem.Type armorType) {
@@ -153,15 +153,15 @@ public class ToolsItems {
               .durability(material.getDurabilityForType(armorType))));
     }
 
-    private static <ITEM extends Item> ItemRegistryObject<ITEM> register(BiFunction<MaterialCreator, Item.Properties, ITEM> itemCreator, String suffix,
+    private static <ITEM extends Item> ItemRegistryObject<ITEM> register(BiFunction<MaterialCreator, LockableProperties, ITEM> itemCreator, String suffix,
           MaterialCreator material) {
         return ITEMS.register(material.getRegistryPrefix() + suffix, () -> itemCreator.apply(material, getBaseProperties(material)));
     }
 
-    private static Item.Properties getBaseProperties(BaseMekanismMaterial material) {
-        Item.Properties properties = new Item.Properties();
+    private static LockableProperties getBaseProperties(BaseMekanismMaterial material) {
+        LockableProperties properties = new LockableProperties();
         if (!material.burnsInFire()) {
-            properties = properties.fireResistant();
+            properties.fireResistant();
         }
         return properties;
     }
@@ -170,5 +170,29 @@ public class ToolsItems {
     private interface ArmorCreator {
 
         ItemMekanismArmor create(Holder<ArmorMaterial> material, ArmorItem.Type armorType, Item.Properties properties);
+    }
+
+    public static class LockableProperties extends Item.Properties {
+
+        private boolean durabilityLocked = false;
+
+        public LockableProperties lockDurability() {
+            durabilityLocked = true;
+            return this;
+        }
+
+        @Override
+        public LockableProperties durability(int maxDamage) {
+            if (!durabilityLocked) {
+                super.durability(maxDamage);
+            }
+            return this;
+        }
+
+        @Override
+        public LockableProperties fireResistant() {
+            super.fireResistant();
+            return this;
+        }
     }
 }


### PR DESCRIPTION
`TieredItem` calls `Item.Properties#durability` in its constructor, which overrides any prior durability configurations. To address this, I've introduced `LockableProperties`, enabling the durability to be locked. This allows tools like paxels to maintain its custom durability settings.  May not be an ideal solution though.
