### PR TITLE
Make coolant types more generic

### DIFF
--- a/src/api/java/mekanism/api/MekanismAPI.java
+++ b/src/api/java/mekanism/api/MekanismAPI.java
@@ -11,12 +11,17 @@ import mekanism.api.robit.RobitSkin;
 import net.minecraft.core.DefaultedRegistry;
 import net.minecraft.core.Holder;
 import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.material.Fluid;
+import net.minecraft.world.level.material.Fluids;
 import net.neoforged.neoforge.registries.DeferredHolder;
 import net.neoforged.neoforge.registries.DeferredRegister;
 import net.neoforged.neoforge.registries.RegistryBuilder;
 import org.slf4j.Logger;
+
+import java.util.Objects;
 
 @NothingNullByDefault
 public class MekanismAPI {
@@ -164,4 +169,10 @@ public class MekanismAPI {
      */
     public static final Holder<Chemical> EMPTY_CHEMICAL_HOLDER = DeferredHolder.create(EMPTY_CHEMICAL_KEY);
 
+    public static final ResourceLocation EMPTY_FLUID_NAME = BuiltInRegistries.FLUID.getKey(Fluids.EMPTY);
+
+    @SuppressWarnings("unchecked,rawtypes")
+    public static boolean isEmptyKey(Holder<?> holder) {
+        return holder.is(EMPTY_FLUID_NAME) || holder.is((ResourceKey) MekanismAPI.EMPTY_CHEMICAL_KEY);
+    }
 }

--- a/src/api/java/mekanism/api/chemical/attribute/ChemicalAttributes.java
+++ b/src/api/java/mekanism/api/chemical/attribute/ChemicalAttributes.java
@@ -209,7 +209,7 @@ public class ChemicalAttributes {
         public CooledCoolant(mekanism.api.datamaps.chemical.attribute.CooledCoolant coolant) {
             super(coolant.thermalEnthalpy(), coolant.conductivity());
             this.modernRepresentation = coolant;
-            this.heatedChemical = () -> this.modernRepresentation.otherVariant().value();
+            this.heatedChemical = () -> this.modernRepresentation.otherChemical().value();
         }
 
         /**
@@ -288,7 +288,7 @@ public class ChemicalAttributes {
             //Note: The value for conductivity used to have a different meaning/none so we ignore it here
             super(coolant.thermalEnthalpy(), 1);
             this.modernRepresentation = coolant;
-            this.cooledChemical = () -> this.modernRepresentation.otherVariant().value();
+            this.cooledChemical = () -> this.modernRepresentation.otherChemical().value();
         }
 
         /**

--- a/src/api/java/mekanism/api/datamaps/chemical/attribute/CooledCoolant.java
+++ b/src/api/java/mekanism/api/datamaps/chemical/attribute/CooledCoolant.java
@@ -38,9 +38,8 @@ public record CooledCoolant(Holder<?> otherVariant, double thermalEnthalpy, doub
           SerializationConstants.HOT_VARIANT, 1
     ).apply(instance, CooledCoolant::new));
 
-    public static CooledCoolant create(Holder<?> otherVariant, double thermalEnthalpy, double conductivity) {
+    public CooledCoolant {
         IChemicalCoolant.validateCoolantParams(otherVariant, thermalEnthalpy, conductivity);
-        return new CooledCoolant(otherVariant, thermalEnthalpy, conductivity);
     }
 
     /**

--- a/src/api/java/mekanism/api/datamaps/chemical/attribute/CooledCoolant.java
+++ b/src/api/java/mekanism/api/datamaps/chemical/attribute/CooledCoolant.java
@@ -4,7 +4,6 @@ import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import mekanism.api.MekanismAPI;
 import mekanism.api.SerializationConstants;
-import mekanism.api.chemical.Chemical;
 import mekanism.api.chemical.ChemicalStack;
 import mekanism.api.chemical.attribute.ChemicalAttributes;
 import net.minecraft.core.Holder;
@@ -22,7 +21,7 @@ import org.jetbrains.annotations.ApiStatus.Internal;
  *
  * @since 10.7.11
  */
-public record CooledCoolant(Holder<?> otherVariant, double thermalEnthalpy, double conductivity) implements IChemicalCoolant {
+public record CooledCoolant(Holder<?> otherVariant, HolderType otherType, double thermalEnthalpy, double conductivity) implements IChemicalCoolant {
 
     /**
      * The ID of the data map.
@@ -37,6 +36,10 @@ public record CooledCoolant(Holder<?> otherVariant, double thermalEnthalpy, doub
     public static final Codec<CooledCoolant> CODEC = RecordCodecBuilder.create(instance -> IChemicalCoolant.createBaseCodec(instance,
           SerializationConstants.HOT_VARIANT, 1
     ).apply(instance, CooledCoolant::new));
+
+    public CooledCoolant(Holder<?> otherVariant, double thermalEnthalpy, double conductivity) {
+        this(otherVariant, HolderType.forHolder(otherVariant), thermalEnthalpy, conductivity);
+    }
 
     public CooledCoolant {
         IChemicalCoolant.validateCoolantParams(otherVariant, thermalEnthalpy, conductivity);

--- a/src/api/java/mekanism/api/datamaps/chemical/attribute/CooledCoolant.java
+++ b/src/api/java/mekanism/api/datamaps/chemical/attribute/CooledCoolant.java
@@ -38,7 +38,7 @@ public record CooledCoolant(Holder<?> otherVariant, double thermalEnthalpy, doub
           SerializationConstants.HOT_VARIANT, 1
     ).apply(instance, CooledCoolant::new));
 
-    public static CooledCoolant create(Holder<Chemical> otherVariant, double thermalEnthalpy, double conductivity) {
+    public static CooledCoolant create(Holder<?> otherVariant, double thermalEnthalpy, double conductivity) {
         IChemicalCoolant.validateCoolantParams(otherVariant, thermalEnthalpy, conductivity);
         return new CooledCoolant(otherVariant, thermalEnthalpy, conductivity);
     }

--- a/src/api/java/mekanism/api/datamaps/chemical/attribute/CooledCoolant.java
+++ b/src/api/java/mekanism/api/datamaps/chemical/attribute/CooledCoolant.java
@@ -22,7 +22,7 @@ import org.jetbrains.annotations.ApiStatus.Internal;
  *
  * @since 10.7.11
  */
-public record CooledCoolant(Holder<Chemical> otherVariant, double thermalEnthalpy, double conductivity) implements IChemicalCoolant {
+public record CooledCoolant(Holder<?> otherVariant, double thermalEnthalpy, double conductivity) implements IChemicalCoolant {
 
     /**
      * The ID of the data map.
@@ -38,8 +38,9 @@ public record CooledCoolant(Holder<Chemical> otherVariant, double thermalEnthalp
           SerializationConstants.HOT_VARIANT, 1
     ).apply(instance, CooledCoolant::new));
 
-    public CooledCoolant {
+    public static CooledCoolant create(Holder<Chemical> otherVariant, double thermalEnthalpy, double conductivity) {
         IChemicalCoolant.validateCoolantParams(otherVariant, thermalEnthalpy, conductivity);
+        return new CooledCoolant(otherVariant, thermalEnthalpy, conductivity);
     }
 
     /**
@@ -50,7 +51,7 @@ public record CooledCoolant(Holder<Chemical> otherVariant, double thermalEnthalp
      * @return Chemical stack representing the heated coolant.
      */
     public ChemicalStack heat(long amountHeated) {
-        return new ChemicalStack(otherVariant, amountHeated);
+        return new ChemicalStack(otherChemical(), amountHeated);
     }
 
     @Internal

--- a/src/api/java/mekanism/api/datamaps/chemical/attribute/CooledCoolant.java
+++ b/src/api/java/mekanism/api/datamaps/chemical/attribute/CooledCoolant.java
@@ -50,6 +50,7 @@ public record CooledCoolant(Holder<?> otherVariant, double thermalEnthalpy, doub
      *
      * @return Chemical stack representing the heated coolant.
      */
+    @Deprecated(forRemoval = true)
     public ChemicalStack heat(long amountHeated) {
         return new ChemicalStack(otherChemical(), amountHeated);
     }

--- a/src/api/java/mekanism/api/datamaps/chemical/attribute/HeatedCoolant.java
+++ b/src/api/java/mekanism/api/datamaps/chemical/attribute/HeatedCoolant.java
@@ -72,6 +72,7 @@ public record HeatedCoolant(Holder<?> otherVariant, double thermalEnthalpy, doub
      *
      * @return Chemical stack representing the cooled coolant.
      */
+    @Deprecated(forRemoval = true)
     public ChemicalStack cool(long amountCooled) {
         return new ChemicalStack(otherChemical(), amountCooled);
     }

--- a/src/api/java/mekanism/api/datamaps/chemical/attribute/HeatedCoolant.java
+++ b/src/api/java/mekanism/api/datamaps/chemical/attribute/HeatedCoolant.java
@@ -31,7 +31,7 @@ import org.jetbrains.annotations.ApiStatus.Internal;
  *
  * @since 10.7.11
  */
-public record HeatedCoolant(Holder<Chemical> otherVariant, double thermalEnthalpy, double conductivity, double temperature) implements IChemicalCoolant {
+public record HeatedCoolant(Holder<?> otherVariant, double thermalEnthalpy, double conductivity, double temperature) implements IChemicalCoolant {
 
     private static final double BASE_COOLING_EFFICIENCY = 0.4;
     private static final double BASE_COOLANT_TEMP = 100_000;
@@ -59,7 +59,7 @@ public record HeatedCoolant(Holder<Chemical> otherVariant, double thermalEnthalp
     }
 
     public HeatedCoolant {
-        IChemicalCoolant.validateCoolantParams(otherVariant, thermalEnthalpy, conductivity);
+        IChemicalCoolant.validateCoolantParams(otherChemical(), thermalEnthalpy, conductivity);
         if (temperature <= 0 || temperature > MAX_COOLANT_TEMP) {
             throw new IllegalArgumentException("Coolant attributes must have a temperature greater than zero and at most " + MAX_COOLANT_TEMP + "! Temperature: " + temperature);
         }
@@ -73,7 +73,7 @@ public record HeatedCoolant(Holder<Chemical> otherVariant, double thermalEnthalp
      * @return Chemical stack representing the cooled coolant.
      */
     public ChemicalStack cool(long amountCooled) {
-        return new ChemicalStack(otherVariant, amountCooled);
+        return new ChemicalStack(otherChemical(), amountCooled);
     }
 
     @Override

--- a/src/api/java/mekanism/api/datamaps/chemical/attribute/HeatedCoolant.java
+++ b/src/api/java/mekanism/api/datamaps/chemical/attribute/HeatedCoolant.java
@@ -5,7 +5,6 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 import java.util.List;
 import mekanism.api.MekanismAPI;
 import mekanism.api.SerializationConstants;
-import mekanism.api.chemical.Chemical;
 import mekanism.api.chemical.ChemicalStack;
 import mekanism.api.chemical.attribute.ChemicalAttributes;
 import mekanism.api.text.APILang;
@@ -31,7 +30,7 @@ import org.jetbrains.annotations.ApiStatus.Internal;
  *
  * @since 10.7.11
  */
-public record HeatedCoolant(Holder<?> otherVariant, double thermalEnthalpy, double conductivity, double temperature) implements IChemicalCoolant {
+public record HeatedCoolant(Holder<?> otherVariant, HolderType otherType, double thermalEnthalpy, double conductivity, double temperature) implements IChemicalCoolant {
 
     private static final double BASE_COOLING_EFFICIENCY = 0.4;
     private static final double BASE_COOLANT_TEMP = 100_000;
@@ -56,6 +55,10 @@ public record HeatedCoolant(Holder<?> otherVariant, double thermalEnthalpy, doub
 
     public HeatedCoolant(Holder<?> otherVariant, double thermalEnthalpy) {
         this(otherVariant, thermalEnthalpy, BASE_COOLING_EFFICIENCY, BASE_COOLANT_TEMP);
+    }
+
+    public HeatedCoolant(Holder<?> otherVariant, double thermalEnthalpy, double conductivity, double temperature) {
+        this(otherVariant, HolderType.forHolder(otherVariant), thermalEnthalpy, conductivity, temperature);
     }
 
     public HeatedCoolant {

--- a/src/api/java/mekanism/api/datamaps/chemical/attribute/HeatedCoolant.java
+++ b/src/api/java/mekanism/api/datamaps/chemical/attribute/HeatedCoolant.java
@@ -54,12 +54,12 @@ public record HeatedCoolant(Holder<?> otherVariant, double thermalEnthalpy, doub
           Codec.doubleRange(Double.MIN_VALUE, MAX_COOLANT_TEMP).optionalFieldOf(SerializationConstants.TEMPERATURE, BASE_COOLANT_TEMP).forGetter(HeatedCoolant::temperature)
     ).apply(instance, HeatedCoolant::new));
 
-    public HeatedCoolant(Holder<Chemical> otherVariant, double thermalEnthalpy) {
+    public HeatedCoolant(Holder<?> otherVariant, double thermalEnthalpy) {
         this(otherVariant, thermalEnthalpy, BASE_COOLING_EFFICIENCY, BASE_COOLANT_TEMP);
     }
 
     public HeatedCoolant {
-        IChemicalCoolant.validateCoolantParams(otherChemical(), thermalEnthalpy, conductivity);
+        IChemicalCoolant.validateCoolantParams(otherVariant, thermalEnthalpy, conductivity);
         if (temperature <= 0 || temperature > MAX_COOLANT_TEMP) {
             throw new IllegalArgumentException("Coolant attributes must have a temperature greater than zero and at most " + MAX_COOLANT_TEMP + "! Temperature: " + temperature);
         }

--- a/src/api/java/mekanism/api/datamaps/chemical/attribute/IChemicalCoolant.java
+++ b/src/api/java/mekanism/api/datamaps/chemical/attribute/IChemicalCoolant.java
@@ -38,9 +38,22 @@ public sealed interface IChemicalCoolant extends IChemicalAttribute permits Cool
     double conductivity();
 
     /**
-     * Gets the other chemical this coolant transforms into after it undergoes a temperature change.
+     * Gets the other substance this coolant transforms into after it undergoes a temperature change.
      */
-    Holder<Chemical> otherVariant();
+    Holder<?> otherVariant();
+
+    /**
+     * Tries to obtain the other variant as a chemical.
+     *
+     * @throws UnsupportedOperationException if the variant was not a chemical.
+     */
+    default Holder<Chemical> otherChemical() {
+        if (otherVariant().value() instanceof Chemical) {
+            //noinspection unchecked
+            return (Holder<Chemical>) otherVariant();
+        }
+        throw new UnsupportedOperationException("Substance is not a chemical");
+    }
 
     @Override
     default void collectTooltips(TooltipContext context, List<Component> tooltips, TooltipFlag tooltipFlag) {
@@ -53,7 +66,7 @@ public sealed interface IChemicalCoolant extends IChemicalAttribute permits Cool
     static <COOLANT extends IChemicalCoolant> Products.P3<Mu<COOLANT>, Holder<Chemical>, Double, Double> createBaseCodec(RecordCodecBuilder.Instance<COOLANT> instance,
           String otherFormName, double defaultConductivity) {
         return instance.group(
-              ChemicalStack.CHEMICAL_NON_EMPTY_HOLDER_CODEC.fieldOf(otherFormName).forGetter(IChemicalCoolant::otherVariant),
+              ChemicalStack.CHEMICAL_NON_EMPTY_HOLDER_CODEC.fieldOf(otherFormName).forGetter(IChemicalCoolant::otherChemical),
               Codec.doubleRange(Double.MIN_VALUE, Double.MAX_VALUE).fieldOf(SerializationConstants.THERMAL_ENTHALPY).forGetter(IChemicalCoolant::thermalEnthalpy),
               Codec.doubleRange(Double.MIN_VALUE, 1).optionalFieldOf(SerializationConstants.CONDUCTIVITY, defaultConductivity).forGetter(IChemicalCoolant::conductivity)
         );

--- a/src/api/java/mekanism/api/datamaps/chemical/attribute/IChemicalCoolant.java
+++ b/src/api/java/mekanism/api/datamaps/chemical/attribute/IChemicalCoolant.java
@@ -32,12 +32,6 @@ import net.neoforged.neoforge.fluids.FluidStack;
 public sealed interface IChemicalCoolant extends IChemicalAttribute permits CooledCoolant, HeatedCoolant {
     //TODO - 1.22: Rename this to `ICoolant`, and maybe move it to a more generic package than `chemical.attribute`
 
-    enum CoolantType {
-        FLUID,
-        CHEMICAL,
-        UNKNOWN
-    }
-
     /**
      * Gets the thermal enthalpy of this coolant. Thermal Enthalpy defines how much energy one mB of the chemical can store.
      */
@@ -53,20 +47,6 @@ public sealed interface IChemicalCoolant extends IChemicalAttribute permits Cool
      * Gets the other substance this coolant transforms into after it undergoes a temperature change.
      */
     Holder<?> otherVariant();
-
-    /**
-     * Determines the type of the other variant. Convenient for switches.
-     */
-    default CoolantType otherType() {
-        final Object other = otherVariant().value();
-        if (other instanceof Fluid) {
-            return CoolantType.FLUID;
-        }
-        if (other instanceof Chemical) {
-            return CoolantType.CHEMICAL;
-        }
-        return CoolantType.UNKNOWN;
-    }
 
     /**
      * Tries to obtain the other variant as a fluid.

--- a/src/api/java/mekanism/api/datamaps/chemical/attribute/IChemicalCoolant.java
+++ b/src/api/java/mekanism/api/datamaps/chemical/attribute/IChemicalCoolant.java
@@ -38,18 +38,18 @@ public sealed interface IChemicalCoolant extends IChemicalAttribute permits Cool
 
         static HolderType forHolder(Holder<?> holder) {
             final ResourceKey<?> key = holder.getKey();
-            //Prioritize checking the value over the key
-            if (holder.isBound() || key == null) {
+            //Prioritize checking the key over the value
+            if (key != null) {
+                if (key.isFor(Registries.FLUID)) {
+                    return FLUID;
+                } else if (key.isFor(MekanismAPI.CHEMICAL_REGISTRY_NAME)) {
+                    return CHEMICAL;
+                }
+            } else if (holder.isBound()) {
                 final Object value = holder.value();
                 if (value instanceof Fluid) {
                     return FLUID;
                 } else if (value instanceof Chemical) {
-                    return CHEMICAL;
-                }
-            } else {
-                if (key.isFor(Registries.FLUID)) {
-                    return FLUID;
-                } else if (key.isFor(MekanismAPI.CHEMICAL_REGISTRY_NAME)) {
                     return CHEMICAL;
                 }
             }
@@ -115,6 +115,8 @@ public sealed interface IChemicalCoolant extends IChemicalAttribute permits Cool
         case CHEMICAL -> DataResult.success(Either.right((Holder<Chemical>) holder));
     });
 
+    //TODO - 1.22: remove backcompat
+    @Deprecated(forRemoval = true, since = "10.7.13")
     Codec<Holder<?>> FLUID_OR_CHEMICAL_LEGACY = Codec.withAlternative(FLUID_OR_CHEMICAL, ChemicalStack.CHEMICAL_NON_EMPTY_HOLDER_CODEC);
 
     @Override
@@ -144,9 +146,8 @@ public sealed interface IChemicalCoolant extends IChemicalAttribute permits Cool
      * @throws IllegalArgumentException If thermal enthalpy or conductivity are invalid values.
      */
     static void validateCoolantParams(Holder<?> otherVariant, double thermalEnthalpy, double conductivity) {
-        //noinspection unchecked,rawtypes
-        if (otherVariant.is((ResourceKey) MekanismAPI.EMPTY_CHEMICAL_KEY)) {
-            throw new IllegalArgumentException("Coolants cannot have an empty chemical variant");
+        if (MekanismAPI.isEmptyKey(otherVariant)) {
+            throw new IllegalArgumentException("Coolants cannot have an empty variant");
         }
         if (thermalEnthalpy <= 0) {
             throw new IllegalArgumentException("Coolant must have a thermal enthalpy greater than zero! Thermal Enthalpy: " + thermalEnthalpy);

--- a/src/api/java/mekanism/api/datamaps/chemical/attribute/IChemicalCoolant.java
+++ b/src/api/java/mekanism/api/datamaps/chemical/attribute/IChemicalCoolant.java
@@ -109,19 +109,22 @@ public sealed interface IChemicalCoolant extends IChemicalAttribute permits Cool
     /**
      * Validates that the parameters are valid as values in coolants.
      *
-     * @param otherVariant Must not represent the empty chemical.
+     * @param otherVariant    Must not represent the empty chemical.
      * @param thermalEnthalpy Must be greater than zero.
      * @param conductivity    This value should be greater than zero, and at most one.
      *
      * @throws IllegalArgumentException If thermal enthalpy or conductivity are invalid values.
      */
-    static void validateCoolantParams(Holder<Chemical> otherVariant, double thermalEnthalpy, double conductivity) {
-        if (otherVariant.is(MekanismAPI.EMPTY_CHEMICAL_KEY)) {
-            throw new IllegalArgumentException("Coolants can not be made that point to the empty chemical");
-        } else if (thermalEnthalpy <= 0) {
-            throw new IllegalArgumentException("Coolant attributes must have a thermal enthalpy greater than zero! Thermal Enthalpy: " + thermalEnthalpy);
-        } else if (conductivity <= 0 || conductivity > 1) {
-            throw new IllegalArgumentException("Coolant attributes must have a conductivity greater than zero and at most one! Conductivity: " + conductivity);
+    static void validateCoolantParams(Holder<?> otherVariant, double thermalEnthalpy, double conductivity) {
+        //noinspection unchecked
+        if (otherVariant.value() instanceof Chemical && ((Holder<Chemical>) otherVariant).is(MekanismAPI.EMPTY_CHEMICAL_KEY)) {
+            throw new IllegalArgumentException("Coolants cannot have an empty chemical variant");
+        }
+        if (thermalEnthalpy <= 0) {
+            throw new IllegalArgumentException("Coolant must have a thermal enthalpy greater than zero! Thermal Enthalpy: " + thermalEnthalpy);
+        }
+        if (conductivity <= 0 || conductivity > 1) {
+            throw new IllegalArgumentException("Coolant must have a conductivity greater than zero and at most one! Conductivity: " + conductivity);
         }
     }
 }

--- a/src/api/java/mekanism/api/datamaps/chemical/attribute/IChemicalCoolant.java
+++ b/src/api/java/mekanism/api/datamaps/chemical/attribute/IChemicalCoolant.java
@@ -32,6 +32,43 @@ import net.neoforged.neoforge.fluids.FluidStack;
 public sealed interface IChemicalCoolant extends IChemicalAttribute permits CooledCoolant, HeatedCoolant {
     //TODO - 1.22: Rename this to `ICoolant`, and maybe move it to a more generic package than `chemical.attribute`
 
+    enum HolderType {
+        FLUID,
+        CHEMICAL;
+
+        static HolderType forHolder(Holder<?> holder) {
+            final ResourceKey<?> key = holder.getKey();
+            //Prioritize checking the value over the key
+            if (holder.isBound() || key == null) {
+                final Object value = holder.value();
+                if (value instanceof Fluid) {
+                    return FLUID;
+                } else if (value instanceof Chemical) {
+                    return CHEMICAL;
+                }
+            } else {
+                if (key.isFor(Registries.FLUID)) {
+                    return FLUID;
+                } else if (key.isFor(MekanismAPI.CHEMICAL_REGISTRY_NAME)) {
+                    return CHEMICAL;
+                }
+            }
+            throw new IllegalArgumentException("Holder isn't for fluids or chemicals");
+        }
+    }
+
+    /**
+     * Gets the other substance this coolant transforms into after it undergoes a temperature change.
+     */
+    Holder<?> otherVariant();
+
+    /**
+     * Gets the representative type of the other variant.
+     *
+     * @apiNote When getting the variant as a specific type (e.g.: {@link #otherFluid()} or {@link #otherChemical()}), use this to check beforehand, or risk an exception.
+     */
+    HolderType otherType();
+
     /**
      * Gets the thermal enthalpy of this coolant. Thermal Enthalpy defines how much energy one mB of the chemical can store.
      */
@@ -44,21 +81,16 @@ public sealed interface IChemicalCoolant extends IChemicalAttribute permits Cool
     double conductivity();
 
     /**
-     * Gets the other substance this coolant transforms into after it undergoes a temperature change.
-     */
-    Holder<?> otherVariant();
-
-    /**
      * Tries to obtain the other variant as a fluid.
      *
      * @throws UnsupportedOperationException if the variant was not a fluid.
      */
     default Holder<Fluid> otherFluid() {
-        if (otherVariant().getKey().isFor(Registries.FLUID)) {
-            //noinspection unchecked
-            return (Holder<Fluid>) otherVariant();
+        if (otherType() != HolderType.FLUID) {
+            throw new UnsupportedOperationException("Variant is not a fluid");
         }
-        throw new UnsupportedOperationException("Variant is not a fluid");
+        //noinspection unchecked
+        return (Holder<Fluid>) otherVariant();
     }
 
     /**
@@ -67,27 +99,23 @@ public sealed interface IChemicalCoolant extends IChemicalAttribute permits Cool
      * @throws UnsupportedOperationException if the variant was not a chemical.
      */
     default Holder<Chemical> otherChemical() {
-        if (otherVariant().getKey().isFor(MekanismAPI.CHEMICAL_REGISTRY_NAME)) {
-            //noinspection unchecked
-            return (Holder<Chemical>) otherVariant();
+        if (otherType() != HolderType.CHEMICAL) {
+            throw new UnsupportedOperationException("Variant is not a chemical");
         }
-        throw new UnsupportedOperationException("Variant is not a chemical");
+        //noinspection unchecked
+        return (Holder<Chemical>) otherVariant();
     }
 
+    @SuppressWarnings("unchecked")
     Codec<Holder<?>> FLUID_OR_CHEMICAL = Codec.xor(
           FluidStack.FLUID_NON_EMPTY_CODEC.fieldOf(SerializationConstants.FLUID).codec(),
           ChemicalStack.CHEMICAL_NON_EMPTY_HOLDER_CODEC.fieldOf(SerializationConstants.CHEMICAL).codec()
-    ).flatComapMap(Either::unwrap, holder -> {
-        if (holder.getKey().isFor(Registries.FLUID)) {
-            //noinspection unchecked
-            return DataResult.success(Either.left((Holder<Fluid>) holder));
-        }
-        if (holder.getKey().isFor(MekanismAPI.CHEMICAL_REGISTRY_NAME)) {
-            //noinspection unchecked
-            return DataResult.success(Either.right((Holder<Chemical>) holder));
-        }
-        return DataResult.error(() -> "Holder holds neither a fluid nor a chemical");
+    ).flatComapMap(Either::unwrap, holder -> switch (HolderType.forHolder(holder)) {
+        case FLUID -> DataResult.success(Either.left((Holder<Fluid>) holder));
+        case CHEMICAL -> DataResult.success(Either.right((Holder<Chemical>) holder));
     });
+
+    Codec<Holder<?>> FLUID_OR_CHEMICAL_LEGACY = Codec.withAlternative(FLUID_OR_CHEMICAL, ChemicalStack.CHEMICAL_NON_EMPTY_HOLDER_CODEC);
 
     @Override
     default void collectTooltips(TooltipContext context, List<Component> tooltips, TooltipFlag tooltipFlag) {
@@ -100,7 +128,7 @@ public sealed interface IChemicalCoolant extends IChemicalAttribute permits Cool
     static <COOLANT extends IChemicalCoolant> Products.P3<Mu<COOLANT>, Holder<?>, Double, Double> createBaseCodec(RecordCodecBuilder.Instance<COOLANT> instance,
           String otherFormName, double defaultConductivity) {
         return instance.group(
-              FLUID_OR_CHEMICAL.fieldOf(otherFormName).forGetter(IChemicalCoolant::otherVariant),
+              FLUID_OR_CHEMICAL_LEGACY.fieldOf(otherFormName).forGetter(IChemicalCoolant::otherVariant),
               Codec.doubleRange(Double.MIN_VALUE, Double.MAX_VALUE).fieldOf(SerializationConstants.THERMAL_ENTHALPY).forGetter(IChemicalCoolant::thermalEnthalpy),
               Codec.doubleRange(Double.MIN_VALUE, 1).optionalFieldOf(SerializationConstants.CONDUCTIVITY, defaultConductivity).forGetter(IChemicalCoolant::conductivity)
         );

--- a/src/api/java/mekanism/api/datamaps/chemical/attribute/IChemicalCoolant.java
+++ b/src/api/java/mekanism/api/datamaps/chemical/attribute/IChemicalCoolant.java
@@ -1,7 +1,9 @@
 package mekanism.api.datamaps.chemical.attribute;
 
 import com.mojang.datafixers.Products;
+import com.mojang.datafixers.util.Either;
 import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import com.mojang.serialization.codecs.RecordCodecBuilder.Mu;
 import java.util.List;
@@ -18,6 +20,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.Item.TooltipContext;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.material.Fluid;
+import net.neoforged.neoforge.fluids.FluidStack;
 
 /**
  * Represents the base information that coolants keep track of.
@@ -89,6 +92,21 @@ public sealed interface IChemicalCoolant extends IChemicalAttribute permits Cool
         throw new UnsupportedOperationException("Variant is not a chemical");
     }
 
+    Codec<Holder<?>> FLUID_OR_CHEMICAL = Codec.xor(
+          FluidStack.FLUID_NON_EMPTY_CODEC.fieldOf(SerializationConstants.FLUID).codec(),
+          ChemicalStack.CHEMICAL_NON_EMPTY_HOLDER_CODEC.fieldOf(SerializationConstants.CHEMICAL).codec()
+    ).flatComapMap(Either::unwrap, holder -> {
+        if (holder.value() instanceof Fluid) {
+            //noinspection unchecked
+            return DataResult.success(Either.left((Holder<Fluid>) holder));
+        }
+        if (holder.value() instanceof Chemical) {
+            //noinspection unchecked
+            return DataResult.success(Either.right((Holder<Chemical>) holder));
+        }
+        return DataResult.error(() -> "Holder holds neither a fluid nor a chemical");
+    });
+
     @Override
     default void collectTooltips(TooltipContext context, List<Component> tooltips, TooltipFlag tooltipFlag) {
         ITooltipHelper tooltipHelper = ITooltipHelper.INSTANCE;
@@ -97,10 +115,10 @@ public sealed interface IChemicalCoolant extends IChemicalAttribute permits Cool
               tooltipHelper.getEnergyPerMBDisplayShort(MathUtils.clampToLong(thermalEnthalpy()))));
     }
 
-    static <COOLANT extends IChemicalCoolant> Products.P3<Mu<COOLANT>, Holder<Chemical>, Double, Double> createBaseCodec(RecordCodecBuilder.Instance<COOLANT> instance,
+    static <COOLANT extends IChemicalCoolant> Products.P3<Mu<COOLANT>, Holder<?>, Double, Double> createBaseCodec(RecordCodecBuilder.Instance<COOLANT> instance,
           String otherFormName, double defaultConductivity) {
         return instance.group(
-              ChemicalStack.CHEMICAL_NON_EMPTY_HOLDER_CODEC.fieldOf(otherFormName).forGetter(IChemicalCoolant::otherChemical),
+              FLUID_OR_CHEMICAL.fieldOf(otherFormName).forGetter(IChemicalCoolant::otherVariant),
               Codec.doubleRange(Double.MIN_VALUE, Double.MAX_VALUE).fieldOf(SerializationConstants.THERMAL_ENTHALPY).forGetter(IChemicalCoolant::thermalEnthalpy),
               Codec.doubleRange(Double.MIN_VALUE, 1).optionalFieldOf(SerializationConstants.CONDUCTIVITY, defaultConductivity).forGetter(IChemicalCoolant::conductivity)
         );

--- a/src/api/java/mekanism/api/datamaps/chemical/attribute/IChemicalCoolant.java
+++ b/src/api/java/mekanism/api/datamaps/chemical/attribute/IChemicalCoolant.java
@@ -17,6 +17,7 @@ import net.minecraft.core.Holder;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.Item.TooltipContext;
 import net.minecraft.world.item.TooltipFlag;
+import net.minecraft.world.level.material.Fluid;
 
 /**
  * Represents the base information that coolants keep track of.
@@ -24,7 +25,13 @@ import net.minecraft.world.item.TooltipFlag;
  * @since 10.7.11
  */
 public sealed interface IChemicalCoolant extends IChemicalAttribute permits CooledCoolant, HeatedCoolant {
-    //TODO - 1.22: Do we want to allow applying coolants to fluids so that we can define water directly that way?
+    //TODO - 1.22: Rename this to `ICoolant`, and maybe move it to a more generic package than `chemical.attribute`
+
+    enum CoolantType {
+        FLUID,
+        CHEMICAL,
+        UNKNOWN
+    }
 
     /**
      * Gets the thermal enthalpy of this coolant. Thermal Enthalpy defines how much energy one mB of the chemical can store.
@@ -43,6 +50,33 @@ public sealed interface IChemicalCoolant extends IChemicalAttribute permits Cool
     Holder<?> otherVariant();
 
     /**
+     * Determines the type of the other variant. Convenient for switches.
+     */
+    default CoolantType otherType() {
+        final Object other = otherVariant().value();
+        if (other instanceof Fluid) {
+            return CoolantType.FLUID;
+        }
+        if (other instanceof Chemical) {
+            return CoolantType.CHEMICAL;
+        }
+        return CoolantType.UNKNOWN;
+    }
+
+    /**
+     * Tries to obtain the other variant as a fluid.
+     *
+     * @throws UnsupportedOperationException if the variant was not a fluid.
+     */
+    default Holder<Fluid> otherFluid() {
+        if (otherVariant().value() instanceof Fluid) {
+            //noinspection unchecked
+            return (Holder<Fluid>) otherVariant();
+        }
+        throw new UnsupportedOperationException("Variant is not a fluid");
+    }
+
+    /**
      * Tries to obtain the other variant as a chemical.
      *
      * @throws UnsupportedOperationException if the variant was not a chemical.
@@ -52,7 +86,7 @@ public sealed interface IChemicalCoolant extends IChemicalAttribute permits Cool
             //noinspection unchecked
             return (Holder<Chemical>) otherVariant();
         }
-        throw new UnsupportedOperationException("Substance is not a chemical");
+        throw new UnsupportedOperationException("Variant is not a chemical");
     }
 
     @Override

--- a/src/api/java/mekanism/api/datamaps/chemical/attribute/IChemicalCoolant.java
+++ b/src/api/java/mekanism/api/datamaps/chemical/attribute/IChemicalCoolant.java
@@ -16,7 +16,9 @@ import mekanism.api.text.APILang;
 import mekanism.api.text.EnumColor;
 import mekanism.api.text.ITooltipHelper;
 import net.minecraft.core.Holder;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.item.Item.TooltipContext;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.material.Fluid;
@@ -72,7 +74,7 @@ public sealed interface IChemicalCoolant extends IChemicalAttribute permits Cool
      * @throws UnsupportedOperationException if the variant was not a fluid.
      */
     default Holder<Fluid> otherFluid() {
-        if (otherVariant().value() instanceof Fluid) {
+        if (otherVariant().getKey().isFor(Registries.FLUID)) {
             //noinspection unchecked
             return (Holder<Fluid>) otherVariant();
         }
@@ -85,7 +87,7 @@ public sealed interface IChemicalCoolant extends IChemicalAttribute permits Cool
      * @throws UnsupportedOperationException if the variant was not a chemical.
      */
     default Holder<Chemical> otherChemical() {
-        if (otherVariant().value() instanceof Chemical) {
+        if (otherVariant().getKey().isFor(MekanismAPI.CHEMICAL_REGISTRY_NAME)) {
             //noinspection unchecked
             return (Holder<Chemical>) otherVariant();
         }
@@ -96,11 +98,11 @@ public sealed interface IChemicalCoolant extends IChemicalAttribute permits Cool
           FluidStack.FLUID_NON_EMPTY_CODEC.fieldOf(SerializationConstants.FLUID).codec(),
           ChemicalStack.CHEMICAL_NON_EMPTY_HOLDER_CODEC.fieldOf(SerializationConstants.CHEMICAL).codec()
     ).flatComapMap(Either::unwrap, holder -> {
-        if (holder.value() instanceof Fluid) {
+        if (holder.getKey().isFor(Registries.FLUID)) {
             //noinspection unchecked
             return DataResult.success(Either.left((Holder<Fluid>) holder));
         }
-        if (holder.value() instanceof Chemical) {
+        if (holder.getKey().isFor(MekanismAPI.CHEMICAL_REGISTRY_NAME)) {
             //noinspection unchecked
             return DataResult.success(Either.right((Holder<Chemical>) holder));
         }
@@ -134,8 +136,8 @@ public sealed interface IChemicalCoolant extends IChemicalAttribute permits Cool
      * @throws IllegalArgumentException If thermal enthalpy or conductivity are invalid values.
      */
     static void validateCoolantParams(Holder<?> otherVariant, double thermalEnthalpy, double conductivity) {
-        //noinspection unchecked
-        if (otherVariant.value() instanceof Chemical && ((Holder<Chemical>) otherVariant).is(MekanismAPI.EMPTY_CHEMICAL_KEY)) {
+        //noinspection unchecked,rawtypes
+        if (otherVariant.is((ResourceKey) MekanismAPI.EMPTY_CHEMICAL_KEY)) {
             throw new IllegalArgumentException("Coolants cannot have an empty chemical variant");
         }
         if (thermalEnthalpy <= 0) {

--- a/src/datagen/generated/mekanism/.cache/e0d3d0b8d9c807675613821fa865a35f707cd83f
+++ b/src/datagen/generated/mekanism/.cache/e0d3d0b8d9c807675613821fa865a35f707cd83f
@@ -1,8 +1,8 @@
-// 1.21.1	2025-03-06T13:10:32.206377	Data Maps
+// 1.21.1	2025-04-03T19:31:37.4954674	Data Maps
 2369e18ed66a732f8af62dbe659f48964d72c206 data/mekanism/data_maps/damage_type/mekasuit_absorption.json
-0a40506077d2677d3eb3a91081a43e1275ce1022 data/mekanism/data_maps/mekanism/chemical/chemical_attribute_cooled_coolant.json
+a88e9ee19ebcd69b2c12de7a1147b9a93a55545b data/mekanism/data_maps/mekanism/chemical/chemical_attribute_cooled_coolant.json
 b65cd7a865b066288664199fc4ea0d9c9570e350 data/mekanism/data_maps/mekanism/chemical/chemical_attribute_fuel.json
-67894a75ea7d42c8bc62c01da8ddf54388acd32a data/mekanism/data_maps/mekanism/chemical/chemical_attribute_heated_coolant.json
+b77ab7d3d805a9cc5027c062cac3bcc34c5cd60f data/mekanism/data_maps/mekanism/chemical/chemical_attribute_heated_coolant.json
 28278d9876869f23e3b1a6f98cdfebccc8de9299 data/mekanism/data_maps/mekanism/chemical/chemical_attribute_radioactivity.json
 ef87b2bf8e136bbe95f7ceab869684b93147974b data/mekanism/data_maps/mekanism/chemical/chemical_solid_tag.json
 5ad5f28bab5d31e92cbbf10d2cca56ed6e45683d data/neoforge/data_maps/game_event/vibration_frequencies.json

--- a/src/datagen/generated/mekanism/data/mekanism/data_maps/mekanism/chemical/chemical_attribute_cooled_coolant.json
+++ b/src/datagen/generated/mekanism/data/mekanism/data_maps/mekanism/chemical/chemical_attribute_cooled_coolant.json
@@ -1,7 +1,9 @@
 {
   "values": {
     "mekanism:sodium": {
-      "hot_variant": "mekanism:superheated_sodium",
+      "hot_variant": {
+        "chemical": "mekanism:superheated_sodium"
+      },
       "thermal_enthalpy": 5.0
     }
   }

--- a/src/datagen/generated/mekanism/data/mekanism/data_maps/mekanism/chemical/chemical_attribute_heated_coolant.json
+++ b/src/datagen/generated/mekanism/data/mekanism/data_maps/mekanism/chemical/chemical_attribute_heated_coolant.json
@@ -1,7 +1,9 @@
 {
   "values": {
     "mekanism:superheated_sodium": {
-      "cool_variant": "mekanism:sodium",
+      "cool_variant": {
+        "chemical": "mekanism:sodium"
+      },
       "thermal_enthalpy": 5.0
     }
   }

--- a/src/generators/java/mekanism/generators/client/recipe_viewer/recipe/FissionRecipeViewerRecipe.java
+++ b/src/generators/java/mekanism/generators/client/recipe_viewer/recipe/FissionRecipeViewerRecipe.java
@@ -68,7 +68,7 @@ public record FissionRecipeViewerRecipe(ResourceLocation id, @Nullable ChemicalS
                   RecipeViewerUtils.synthetic(key.location(), "fission", MekanismGenerators.MODID),
                   IngredientCreatorAccess.chemicalStack().fromHolder(MekanismAPI.CHEMICAL_REGISTRY.getHolderOrThrow(key), amount),
                   IngredientCreatorAccess.chemicalStack().fromHolder(MekanismChemicals.FISSILE_FUEL, 1),
-                  coolant.heat(amount), MekanismChemicals.NUCLEAR_WASTE.asStack(1)
+                  new ChemicalStack(coolant.otherChemical(), amount), MekanismChemicals.NUCLEAR_WASTE.asStack(1)
             ));
         }
         //TODO - 1.22: Remove this handling of legacy attributes

--- a/src/generators/java/mekanism/generators/common/content/fission/FissionReactorMultiblockData.java
+++ b/src/generators/java/mekanism/generators/common/content/fission/FissionReactorMultiblockData.java
@@ -449,7 +449,7 @@ public class FissionReactorMultiblockData extends MultiblockData implements IVal
                     lastBoilRate = clampCoolantHeated(caseCoolantHeat / coolantType.thermalEnthalpy(), chemicalCoolantTank.getStored());
                     if (lastBoilRate > 0) {
                         MekanismUtils.logMismatchedStackSize(chemicalCoolantTank.shrinkStack(lastBoilRate, Action.EXECUTE), lastBoilRate);
-                        heatedCoolantTank.insert(coolantType.heat(lastBoilRate), Action.EXECUTE, AutomationType.INTERNAL);
+                        heatedCoolantTank.insert(new ChemicalStack(coolantType.otherChemical(), lastBoilRate), Action.EXECUTE, AutomationType.INTERNAL);
                         caseCoolantHeat = lastBoilRate * coolantType.thermalEnthalpy();
                         heatCapacitor.handleHeat(-caseCoolantHeat);
                     }

--- a/src/main/java/mekanism/client/recipe_viewer/emi/recipe/BoilerEmiRecipe.java
+++ b/src/main/java/mekanism/client/recipe_viewer/emi/recipe/BoilerEmiRecipe.java
@@ -3,7 +3,11 @@ package mekanism.client.recipe_viewer.emi.recipe;
 import dev.emi.emi.api.widget.WidgetHolder;
 import java.util.Collections;
 import java.util.List;
+import mekanism.api.chemical.ChemicalStack;
 import mekanism.api.math.MathUtils;
+import mekanism.api.recipes.ingredients.ChemicalStackIngredient;
+import mekanism.api.recipes.ingredients.FluidStackIngredient;
+import mekanism.api.recipes.ingredients.InputIngredient;
 import mekanism.api.text.EnumColor;
 import mekanism.client.gui.element.GuiInnerScreen;
 import mekanism.client.gui.element.gauge.GaugeType;
@@ -16,6 +20,7 @@ import mekanism.common.util.MekanismUtils;
 import mekanism.common.util.UnitDisplayUtils.TemperatureUnit;
 import mekanism.common.util.text.TextUtils;
 import net.minecraft.resources.ResourceLocation;
+import net.neoforged.neoforge.fluids.FluidStack;
 
 public class BoilerEmiRecipe extends MekanismEmiRecipe<BoilerRecipeViewerRecipe> {
 
@@ -23,12 +28,22 @@ public class BoilerEmiRecipe extends MekanismEmiRecipe<BoilerRecipeViewerRecipe>
         super(category, id, recipe);
         addInputDefinition(recipe.water());
         addChemicalOutputDefinition(List.of(recipe.steam()));
-        if (recipe.superHeatedCoolant() == null) {
+        if (recipe.heatedCoolant() == null) {
             addEmptyInput();
             addOutputDefinition(Collections.emptyList());
         } else {
-            addInputDefinition(recipe.superHeatedCoolant());
-            addChemicalOutputDefinition(List.of(recipe.cooledCoolant()));
+            final InputIngredient<?> heatedCoolant = recipe.heatedCoolant();
+            switch (heatedCoolant) {
+                case FluidStackIngredient fluid -> addInputDefinition(fluid);
+                case ChemicalStackIngredient chemical -> addInputDefinition(chemical);
+                default -> throw new IllegalStateException("Bad heated coolant: expected fluid or chemical, got " + heatedCoolant);
+            }
+            final Object cooledCoolant = recipe.cooledCoolant();
+            switch (cooledCoolant) {
+                case FluidStack fluid -> addFluidOutputDefinition(List.of(fluid));
+                case ChemicalStack chemical -> addChemicalOutputDefinition(List.of(chemical));
+                default -> throw new IllegalStateException("Bad cooled coolant: expected fluid or chemical, got " + cooledCoolant);
+            }
         }
     }
 

--- a/src/main/java/mekanism/client/recipe_viewer/jei/machine/BoilerRecipeCategory.java
+++ b/src/main/java/mekanism/client/recipe_viewer/jei/machine/BoilerRecipeCategory.java
@@ -3,8 +3,12 @@ package mekanism.client.recipe_viewer.jei.machine;
 import com.mojang.serialization.Codec;
 import java.util.Collections;
 import java.util.List;
+import mekanism.api.chemical.ChemicalStack;
 import mekanism.api.heat.HeatAPI;
 import mekanism.api.math.MathUtils;
+import mekanism.api.recipes.ingredients.ChemicalStackIngredient;
+import mekanism.api.recipes.ingredients.FluidStackIngredient;
+import mekanism.api.recipes.ingredients.InputIngredient;
 import mekanism.api.text.EnumColor;
 import mekanism.client.gui.element.GuiInnerScreen;
 import mekanism.client.gui.element.gauge.GaugeType;
@@ -27,6 +31,7 @@ import mezz.jei.api.recipe.IRecipeManager;
 import mezz.jei.api.recipe.RecipeIngredientRole;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.resources.ResourceLocation;
+import net.neoforged.neoforge.fluids.FluidStack;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -74,7 +79,7 @@ public class BoilerRecipeCategory extends BaseRecipeCategory<BoilerRecipeViewerR
     @Override
     protected void renderElements(BoilerRecipeViewerRecipe recipe, IRecipeSlotsView recipeSlotView, GuiGraphics guiGraphics, int x, int y) {
         super.renderElements(recipe, recipeSlotView, guiGraphics, x, y);
-        if (recipe.superHeatedCoolant() == null) {
+        if (recipe.heatedCoolant() == null) {
             superHeatedCoolantTank.drawBarOverlay(guiGraphics);
             cooledCoolantTank.drawBarOverlay(guiGraphics);
         }
@@ -95,12 +100,23 @@ public class BoilerRecipeCategory extends BaseRecipeCategory<BoilerRecipeViewerR
     @Override
     public void setRecipe(@NotNull IRecipeLayoutBuilder builder, BoilerRecipeViewerRecipe recipe, @NotNull IFocusGroup focusGroup) {
         initFluid(builder, RecipeIngredientRole.INPUT, waterTank, recipe.water().getRepresentations());
-        if (recipe.superHeatedCoolant() == null) {
+        if (recipe.heatedCoolant() == null) {
             initChemical(builder, RecipeIngredientRole.OUTPUT, steamTank, Collections.singletonList(recipe.steam()));
         } else {
-            initChemical(builder, RecipeIngredientRole.INPUT, superHeatedCoolantTank, recipe.superHeatedCoolant().getRepresentations());
+            final InputIngredient<?> heatedCoolant = recipe.heatedCoolant();
+            switch (heatedCoolant) {
+                case FluidStackIngredient fluid -> initFluid(builder, RecipeIngredientRole.INPUT, superHeatedCoolantTank, fluid.getRepresentations());
+                case ChemicalStackIngredient chemical -> initChemical(builder, RecipeIngredientRole.INPUT, superHeatedCoolantTank, chemical.getRepresentations());
+                default -> throw new IllegalStateException("Bad heated coolant: expected fluid or chemical, got " + heatedCoolant);
+            }
             initChemical(builder, RecipeIngredientRole.OUTPUT, steamTank, Collections.singletonList(recipe.steam()));
-            initChemical(builder, RecipeIngredientRole.OUTPUT, cooledCoolantTank, Collections.singletonList(recipe.cooledCoolant()));
+            final Object cooledCoolant = recipe.cooledCoolant();
+            switch (cooledCoolant) {
+                case FluidStack fluid -> initFluid(builder, RecipeIngredientRole.OUTPUT, cooledCoolantTank, Collections.singletonList(fluid));
+                case ChemicalStack chemical -> initChemical(builder, RecipeIngredientRole.OUTPUT, cooledCoolantTank, Collections.singletonList(chemical));
+                default -> throw new IllegalStateException("Bad cooled coolant: expected fluid or chemical, got " + cooledCoolant);
+            }
+
         }
     }
 }

--- a/src/main/java/mekanism/client/recipe_viewer/recipe/BoilerRecipeViewerRecipe.java
+++ b/src/main/java/mekanism/client/recipe_viewer/recipe/BoilerRecipeViewerRecipe.java
@@ -1,11 +1,13 @@
 package mekanism.client.recipe_viewer.recipe;
 
+import com.mojang.datafixers.util.Either;
 import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.Map.Entry;
 import mekanism.api.MekanismAPI;
 import mekanism.api.SerializationConstants;
 import mekanism.api.chemical.Chemical;
@@ -15,6 +17,7 @@ import mekanism.api.datamaps.IMekanismDataMapTypes;
 import mekanism.api.datamaps.chemical.attribute.HeatedCoolant;
 import mekanism.api.recipes.ingredients.ChemicalStackIngredient;
 import mekanism.api.recipes.ingredients.FluidStackIngredient;
+import mekanism.api.recipes.ingredients.InputIngredient;
 import mekanism.api.recipes.ingredients.creator.IngredientCreatorAccess;
 import mekanism.client.recipe_viewer.RecipeViewerUtils;
 import mekanism.client.recipe_viewer.emi.INamedRVRecipe;
@@ -23,24 +26,40 @@ import mekanism.common.config.MekanismConfig;
 import mekanism.common.content.boiler.BoilerMultiblockData;
 import mekanism.common.registries.MekanismChemicals;
 import mekanism.common.util.HeatUtils;
+import mekanism.common.util.MekCodecs;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.FluidTags;
 import org.jetbrains.annotations.Nullable;
 
-public record BoilerRecipeViewerRecipe(ResourceLocation id, @Nullable ChemicalStackIngredient superHeatedCoolant, FluidStackIngredient water, ChemicalStack steam,
-                                       ChemicalStack cooledCoolant, double temperature) implements INamedRVRecipe {
+public record BoilerRecipeViewerRecipe(
+      ResourceLocation id,
+      @Nullable InputIngredient<?> heatedCoolant, //Either FluidStackIngredient | ChemicalStackIngredient
+      FluidStackIngredient water,
+      ChemicalStack steam,
+      Object cooledCoolant, //Either FluidStack | ChemicalStack
+      double temperature) implements INamedRVRecipe {
+
+    public static final MapCodec<InputIngredient<?>> FLUID_OR_CHEMICAL_INGREDIENT = MekCodecs.alternativeElement(
+          FluidStackIngredient.CODEC.fieldOf(SerializationConstants.FLUID_INPUT),
+          ChemicalStackIngredient.CODEC.optionalFieldOf(SerializationConstants.CHEMICAL_INPUT, null),
+          ingredient -> switch (ingredient) {
+              case FluidStackIngredient fluid -> DataResult.success(Either.left(fluid));
+              case ChemicalStackIngredient chemical -> DataResult.success(Either.right(chemical));
+              case null -> DataResult.success(Either.right(null)); //Relay null to the codec with .optionalFieldOf()
+              default -> DataResult.error(() -> "Bad ingredient: expected fluid or chemical, got " + ingredient);
+          }
+    );
 
     private static final int WATER_AMOUNT = 1;
     public static final Codec<BoilerRecipeViewerRecipe> CODEC = RecordCodecBuilder.create(instance -> instance.group(
           ResourceLocation.CODEC.fieldOf(SerializationConstants.ID).forGetter(BoilerRecipeViewerRecipe::id),
-          ChemicalStackIngredient.CODEC.optionalFieldOf(SerializationConstants.CHEMICAL_INPUT).forGetter(recipe -> Optional.ofNullable(recipe.superHeatedCoolant())),
+          FLUID_OR_CHEMICAL_INGREDIENT.forGetter(BoilerRecipeViewerRecipe::heatedCoolant),
           FluidStackIngredient.CODEC.optionalFieldOf(SerializationConstants.FLUID_INPUT, IngredientCreatorAccess.fluid().from(FluidTags.WATER, WATER_AMOUNT)).forGetter(BoilerRecipeViewerRecipe::water),
           ChemicalStack.CODEC.optionalFieldOf(SerializationConstants.MAIN_OUTPUT, MekanismChemicals.STEAM.asStack(WATER_AMOUNT)).forGetter(BoilerRecipeViewerRecipe::steam),
-          ChemicalStack.CODEC.optionalFieldOf(SerializationConstants.SECONDARY_OUTPUT, ChemicalStack.EMPTY).forGetter(BoilerRecipeViewerRecipe::cooledCoolant),
+          MekCodecs.FLUID_OR_CHEMICAL_STACK_LEGACY.optionalFieldOf(SerializationConstants.SECONDARY_OUTPUT, ChemicalStack.EMPTY).forGetter(BoilerRecipeViewerRecipe::cooledCoolant),
           Codec.DOUBLE.optionalFieldOf(SerializationConstants.TEMPERATURE, HeatUtils.BASE_BOIL_TEMP).forGetter(BoilerRecipeViewerRecipe::temperature)
-    ).apply(instance, (id, superHeatedCoolant, water, steam, cooledCoolant, temperature) ->
-          new BoilerRecipeViewerRecipe(id, superHeatedCoolant.orElse(null), water, steam, cooledCoolant, temperature)));
+    ).apply(instance, BoilerRecipeViewerRecipe::new));
 
     @SuppressWarnings("removal")
     public static List<BoilerRecipeViewerRecipe> getBoilerRecipes() {
@@ -57,7 +76,7 @@ public record BoilerRecipeViewerRecipe(ResourceLocation id, @Nullable ChemicalSt
               HeatUtils.BASE_BOIL_TEMP + waterToSteamHeatNecessary / (BoilerMultiblockData.CASING_HEAT_CAPACITY * MekanismConfig.general.boilerWaterConductivity.get())
         ));
         //Add recipes for all heated coolants
-        for (Map.Entry<ResourceKey<Chemical>, HeatedCoolant> entry : MekanismAPI.CHEMICAL_REGISTRY.getDataMap(IMekanismDataMapTypes.INSTANCE.heatedChemicalCoolant()).entrySet()) {
+        for (Entry<ResourceKey<Chemical>, HeatedCoolant> entry : MekanismAPI.CHEMICAL_REGISTRY.getDataMap(IMekanismDataMapTypes.INSTANCE.heatedChemicalCoolant()).entrySet()) {
             ResourceKey<Chemical> key = entry.getKey();
             HeatedCoolant coolant = entry.getValue();
             //Amount of coolant that is actually used to

--- a/src/main/java/mekanism/client/recipe_viewer/recipe/BoilerRecipeViewerRecipe.java
+++ b/src/main/java/mekanism/client/recipe_viewer/recipe/BoilerRecipeViewerRecipe.java
@@ -65,7 +65,7 @@ public record BoilerRecipeViewerRecipe(ResourceLocation id, @Nullable ChemicalSt
             recipes.add(new BoilerRecipeViewerRecipe(
                   RecipeViewerUtils.synthetic(key.location(), "boiler", Mekanism.MODID),
                   IngredientCreatorAccess.chemicalStack().fromHolder(MekanismAPI.CHEMICAL_REGISTRY.getHolderOrThrow(key), coolantAmount), water,
-                  steam, coolant.cool(coolantAmount),
+                  steam, new ChemicalStack(coolant.otherChemical(), coolantAmount),
                   HeatUtils.BASE_BOIL_TEMP
             ));
         }

--- a/src/main/java/mekanism/common/content/boiler/BoilerMultiblockData.java
+++ b/src/main/java/mekanism/common/content/boiler/BoilerMultiblockData.java
@@ -182,7 +182,7 @@ public class BoilerMultiblockData extends MultiblockData implements IValveHandle
             if (coolantType != null) {
                 double portionToCool = coolantType.conductivity() * superheatedCoolantTank.getStored();
                 long toCool = Math.round(portionToCool * (1 - heatCapacitor.getTemperature() / coolantType.temperature()));
-                ChemicalStack cooledCoolant = coolantType.cool(toCool);
+                ChemicalStack cooledCoolant = new ChemicalStack(coolantType.otherChemical(), toCool);
                 long amountCooled = toCool - cooledCoolantTank.insert(cooledCoolant, Action.EXECUTE, AutomationType.INTERNAL).getAmount();
                 if (amountCooled > 0) {
                     double heatEnergy = amountCooled * coolantType.thermalEnthalpy();

--- a/src/main/java/mekanism/common/integration/lookingat/jade/JadeTooltipRenderer.java
+++ b/src/main/java/mekanism/common/integration/lookingat/jade/JadeTooltipRenderer.java
@@ -5,15 +5,10 @@ import com.mojang.serialization.Codec;
 import com.mojang.serialization.DataResult;
 import com.mojang.serialization.MapCodec;
 import java.util.Optional;
-import java.util.function.Function;
 import mekanism.api.SerializationConstants;
 import mekanism.client.render.IFancyFontRenderer.TextAlignment;
-import mekanism.common.integration.lookingat.ChemicalElement;
-import mekanism.common.integration.lookingat.EnergyElement;
-import mekanism.common.integration.lookingat.FluidElement;
-import mekanism.common.integration.lookingat.ILookingAtElement;
-import mekanism.common.integration.lookingat.LookingAtElement;
-import mekanism.common.integration.lookingat.TextElement;
+import mekanism.common.integration.lookingat.*;
+import mekanism.common.util.MekCodecs;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
@@ -36,13 +31,7 @@ public class JadeTooltipRenderer<ACCESSOR extends Accessor<?>> implements ICompo
 
     static final JadeTooltipRenderer<?> INSTANCE = new JadeTooltipRenderer<>();
 
-    private static <B, L extends B, R extends B> MapCodec<B> alternativeElement(MapCodec<L> leftBase, MapCodec<R> rightBase,
-          final Function<? super B, ? extends DataResult<? extends Either<L, R>>> from) {
-        MapCodec<Either<L, R>> base = Codec.mapEither(leftBase, rightBase);
-        return Codec.of(base.flatComap(from), base.map(Either::unwrap), () -> base + "[flatComapMapped]");
-    }
-
-    private static final MapCodec<ILookingAtElement> FLUID_OR_CHEMICAL_CODEC = alternativeElement(
+    private static final MapCodec<ILookingAtElement> FLUID_OR_CHEMICAL_CODEC = MekCodecs.alternativeElement(
           FluidElement.CODEC,
           ChemicalElement.CODEC,
           (ILookingAtElement element) -> switch (element) {
@@ -51,7 +40,7 @@ public class JadeTooltipRenderer<ACCESSOR extends Accessor<?>> implements ICompo
               default -> DataResult.error(() -> "Unknown Element Type, expected either fluid or chemical");
           }
     );
-    private static final MapCodec<ILookingAtElement> ENERGY_OR_TEXT_CODEC = alternativeElement(
+    private static final MapCodec<ILookingAtElement> ENERGY_OR_TEXT_CODEC = MekCodecs.alternativeElement(
           EnergyElement.CODEC,
           TextElement.CODEC,
           (ILookingAtElement element) -> switch (element) {

--- a/src/main/java/mekanism/common/util/MekCodecs.java
+++ b/src/main/java/mekanism/common/util/MekCodecs.java
@@ -1,11 +1,16 @@
 package mekanism.common.util;
 
+import com.mojang.datafixers.util.Either;
 import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
 import com.mojang.serialization.MapCodec;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.function.Function;
+import mekanism.api.SerializationConstants;
+import mekanism.api.chemical.ChemicalStack;
 import mekanism.common.integration.computer.MethodRestriction;
-import net.minecraft.util.ExtraCodecs;
+import net.neoforged.neoforge.fluids.FluidStack;
 
 public class MekCodecs {
 
@@ -18,7 +23,26 @@ public class MekCodecs {
         }
     });
 
+    public static final Codec<Object> FLUID_OR_CHEMICAL_STACK = Codec.xor(
+          FluidStack.CODEC.fieldOf(SerializationConstants.FLUID).codec(),
+          ChemicalStack.CODEC.fieldOf(SerializationConstants.CHEMICAL).codec()
+    ).flatComapMap(Either::unwrap, stack -> switch (stack) {
+        case FluidStack fluid -> DataResult.success(Either.left(fluid));
+        case ChemicalStack chemical -> DataResult.success(Either.right(chemical));
+        default -> DataResult.error(() -> "Bad stack: expected fluid or chemical, got " + stack);
+    });
+
+    //TODO - 1.22: remove backcompat
+    @Deprecated(forRemoval = true, since = "10.7.13")
+    public static final Codec<Object> FLUID_OR_CHEMICAL_STACK_LEGACY = Codec.withAlternative(FLUID_OR_CHEMICAL_STACK, ChemicalStack.CODEC);
+
     public static MapCodec<Class<?>[]> optionalClassArrayCodec(String fieldName) {
         return CLASS_TO_STRING_CODEC.listOf().optionalFieldOf(fieldName, Collections.emptyList()).xmap(cl -> cl.toArray(new Class[0]), Arrays::asList);
+    }
+
+    public static <B, L extends B, R extends B> MapCodec<B> alternativeElement(MapCodec<L> leftBase, MapCodec<R> rightBase,
+                                                                               final Function<? super B, ? extends DataResult<? extends Either<L, R>>> from) {
+        MapCodec<Either<L, R>> base = Codec.mapEither(leftBase, rightBase);
+        return Codec.of(base.flatComap(from), base.map(Either::unwrap), () -> base + "[flatComapMapped]");
     }
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add getter to `IChemicalAttribute` for  a `Holder<?>` and a helper for a `Holder<Chemical>`
- Update `CooledCoolant` and `HeatedCoolant` to reflect these changes