### PR TITLE
fix(crash): logistical transporter accessing invalid cache on player join

### DIFF
--- a/src/main/java/mekanism/common/content/network/transmitter/LogisticalTransporterBase.java
+++ b/src/main/java/mekanism/common/content/network/transmitter/LogisticalTransporterBase.java
@@ -72,7 +72,10 @@ public abstract class LogisticalTransporterBase extends Transmitter<IItemHandler
     private IItemHandler getCapForSide(Direction logisticalSide) {
         BlockCapabilityCache<IItemHandler, Direction> cache = capabilityCache.get(logisticalSide);
         if (cache == null) {
-            cache = Capabilities.ITEM.createCache((ServerLevel) getLevel(), getBlockPos().relative(logisticalSide), logisticalSide.getOpposite(), this::isValid);
+            cache = Capabilities.ITEM.createCache((ServerLevel) getLevel(), getBlockPos().relative(logisticalSide), logisticalSide.getOpposite(), this::isValid, () -> {
+                // It's possible this will run before the put() call, and this will silently fail.
+                capabilityCache.remove(logisticalSide);
+            });
             capabilityCache.put(logisticalSide, cache);
         }
         return cache.getCapability();
@@ -83,7 +86,10 @@ public abstract class LogisticalTransporterBase extends Transmitter<IItemHandler
         EnumMap<Direction, BlockCapabilityCache<IItemHandler, Direction>> sideCache = fallbackHandlerCache.computeIfAbsent(pos, k -> new EnumMap<>(Direction.class));
         BlockCapabilityCache<IItemHandler, Direction> cache = sideCache.get(handlerSide);
         if (cache == null) {
-            cache = Capabilities.ITEM.createCache((ServerLevel) getLevel(), BlockPos.of(pos), handlerSide, this::isValid);
+            cache = Capabilities.ITEM.createCache((ServerLevel) getLevel(), BlockPos.of(pos), handlerSide, this::isValid, () -> {
+                // It's possible this will run before the put() call, and this will silently fail.
+                capabilityCache.remove(handlerSide);
+            });
             sideCache.put(handlerSide, cache);
         }
         return cache.getCapability();


### PR DESCRIPTION
## Changes proposed in this pull request:

I get this crash when loading into the game, which seems to suggest that the
cache being pulled is invalid.

This is playing with the FTB Evolution modpack.

https://pste.ch/akonajiruv

**Warning:** I don't know if this is the right approach to fixing the bug. It
seems like there is still a race condition here where the cache can get
invalidated before it is put into the Map. It's probable that there's another
change that needs to be made somewhere else.

