### PR TITLE
Multiblock content loss patching, forcing sync on saveAdditional

### DIFF
--- a/src/main/java/mekanism/common/tile/prefab/TileEntityMultiblock.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityMultiblock.java
@@ -312,8 +312,23 @@ public abstract class TileEntityMultiblock<T extends MultiblockData> extends Til
         }
     }
 
+    // test method to fix last-tick-lost-contents issue
+    private void forceSyncCaches()
+    {
+        T multiblock = getMultiblock();
+        if (isMaster() && multiblock.isFormed()) {
+            getManager().handleDirtyMultiblock(multiblock);
+        }
+    }
+
     @Override
     public void saveAdditional(@NotNull CompoundTag nbtTags, @NotNull HolderLookup.Provider provider) {
+
+        // this currently seems to work alright at fixing the last-tick-loss issue, but needs testing if theres any side effects
+        // the reason being that on the very last tick of the server when it closes, the caches can be out of date
+        forceSyncCaches();
+
+        // continue as normal
         super.saveAdditional(nbtTags, provider);
         if (cachedID != null) {
             //Note: We don't bother validating here the cache still exists as it is irrelevant and unused until attempting to form the multiblock

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityMultiblock.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityMultiblock.java
@@ -312,7 +312,6 @@ public abstract class TileEntityMultiblock<T extends MultiblockData> extends Til
         }
     }
 
-    // test method to fix last-tick-lost-contents issue
     private void forceSyncCaches()
     {
         T multiblock = getMultiblock();
@@ -324,8 +323,8 @@ public abstract class TileEntityMultiblock<T extends MultiblockData> extends Til
     @Override
     public void saveAdditional(@NotNull CompoundTag nbtTags, @NotNull HolderLookup.Provider provider) {
 
-        // this currently seems to work alright at fixing the last-tick-loss issue, but needs testing if theres any side effects
-        // the reason being that on the very last tick of the server when it closes, the caches can be out of date
+        // force sync the caches since they tend to be one tick out of date,
+        // due to how multiblocks and tube networks can tick in different orders both within mekanism and other mods
         forceSyncCaches();
 
         // continue as normal


### PR DESCRIPTION
rather simple patch that has been working reliably, just force sync the cache when NBT write is needed.

However it should be noted that if you check the multiblock data file while the game is paused but the world is still open, the data will still show as if its out of date, but this is just a side effect of how ticks are ordered between multiblocks and tube networks while the server is still open. If you close the server normally the data file should contain the final contents that were finished being inserted on the final tick during shutdown.
