### PR TITLE
Open up some available parameters and proxy capabilities

### DIFF
--- a/src/main/java/mekanism/common/capabilities/Capabilities.java
+++ b/src/main/java/mekanism/common/capabilities/Capabilities.java
@@ -105,8 +105,8 @@ public class Capabilities {
             TileEntityBoundingBlock.proxyCapability(event, capability);
         }
         //Note: Common caps we may eventually want to proxy but currently have no use for doing so
-        /*TileEntityBoundingBlock.proxyCapability(event, FluidHandler.BLOCK);
-        TileEntityBoundingBlock.proxyCapability(event, CHEMICAL_HANDLER.block());
-        TileEntityBoundingBlock.proxyCapability(event, HEAT_HANDLER.block());*/
+        TileEntityBoundingBlock.proxyCapability(event, FluidHandler.BLOCK);
+        TileEntityBoundingBlock.proxyCapability(event, CHEMICAL.block());
+        TileEntityBoundingBlock.proxyCapability(event, HEAT);
     }
 }

--- a/src/main/java/mekanism/common/tile/base/TileEntityMekanism.java
+++ b/src/main/java/mekanism/common/tile/base/TileEntityMekanism.java
@@ -224,18 +224,18 @@ public abstract class TileEntityMekanism extends CapabilityTileEntity implements
 
     //Variables for handling IMekanismChemicalHandler
     @Nullable
-    private final ChemicalHandlerManager chemicalHandlerManager;
+    protected final ChemicalHandlerManager chemicalHandlerManager;
     private float radiationScale;
     //End variables IMekanismChemicalHandler
 
     //Variables for handling IMekanismFluidHandler
     @Nullable
-    private final FluidHandlerManager fluidHandlerManager;
+    protected final FluidHandlerManager fluidHandlerManager;
     //End variables IMekanismFluidHandler
 
     //Variables for handling IMekanismStrictEnergyHandler
     @Nullable
-    private final EnergyHandlerManager energyHandlerManager;
+    protected final EnergyHandlerManager energyHandlerManager;
     private final LastEnergyTracker lastEnergyTracker = new LastEnergyTracker();
     //End variables IMekanismStrictEnergyHandler
 


### PR DESCRIPTION
## Changes proposed in this pull request:
I want to add some large machines (like digital miner) in my mod, but parameters such as chemicalHandler Manager and fluidHandler Manager are private and I cannot use them. If you can change it to protected, I can develop based on TileEntityMekanism.

In addition, I have also enabled some proxy capabilities, although I can also add them, it may be more convenient if you can build this feature in.