### PR TITLE
Fix NullPointerException in SoundHandler's TileTickableSound

### DIFF
--- a/src/main/java/mekanism/client/sound/SoundHandler.java
+++ b/src/main/java/mekanism/client/sound/SoundHandler.java
@@ -314,6 +314,9 @@ public class SoundHandler {
         @Override
         public void tick() {
             // Every configured interval, see if we need to adjust muffling
+            if (Minecraft.getInstance().level == null) {
+                 return;
+                }
             Level level = Minecraft.getInstance().level;
             if (!MekanismUtils.isTickingNormally(level)) {
                 //Mute it similar to how the minecart sound handling is


### PR DESCRIPTION
## Changes proposed in this pull request:
**Fix NullPointerException in SoundHandler's TileTickableSound**

This PR fixes a NullPointerException that occurs when TileTickableSound.tick() tries to access level.getGameTime() on a null level reference.

**Changes Made:**

Added null check for the level field in TileTickableSound.tick()
Implemented proper handling when the level is null (either stopping the sound or skipping the tick)

**Impact:**

Prevents client crashes when sound handling encounters null world references

```
java.lang.NullPointerException: Cannot invoke "net.minecraft.world.level.Level.getGameTime()" because "level" is null
	at TRANSFORMER/mekanism@10.7.14/mekanism.client.sound.SoundHandler$TileTickableSound.tick(SoundHandler.java:321) ~[%5BM%5D%5B1.21.1%5D%5B通用机械%5D%20Mekanism-1.21.1-10.7.14.79.jar%23422!/:10.7.14] {re:classloading}
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.client.sounds.SoundEngine.tickNonPaused(SoundEngine.java:241) ~[client-1.21.1-20240808.144430-srg.jar%23342!/:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:dynamic_fps-common.mixins.json:SoundEngineMixin from mod dynamic_fps,pl:mixin:APP:immersiveengineering.mixins.json:coremods.client.SoundEngineMixin from mod immersiveengineering,pl:mixin:A,pl:runtimedistcleaner:A}
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.client.sounds.SoundEngine.tick(SoundEngine.java:225) ~[client-1.21.1-20240808.144430-srg.jar%23342!/:?] {re:mixin,pl:accesstransformer:B,pl:runtimedistcleaner:A,re:classloading,pl:accesstransformer:B,pl:mixin:APP:dynamic_fps-common.mixins.json:SoundEngineMixin from mod dynamic_fps,pl:mixin:APP:immersiveengineering.mixins.json:coremods.client.SoundEngineMixin from mod immersiveengineering,pl:mixin:A,pl:runtimedistcleaner:A}
	at TRANSFORMER/minecraft@1.21.1/net.minecraft.client.sounds.SoundManager.tick(SoundManager.java:283) ~[client-1.21.1-20240808.144430-srg.jar%23342!/:?] {re:classloading,pl:accesstransformer:B}
```