### PR TITLE
Fixed bug that some Multiblock machines unnecessarily recheck their structure when they get redstone updates via `onNeighborChange` if Alternate Current is installed.

### DIFF
--- a/src/main/java/mekanism/common/tile/prefab/TileEntityInternalMultiblock.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityInternalMultiblock.java
@@ -69,9 +69,9 @@ public class TileEntityInternalMultiblock extends TileEntityMekanism implements 
         //If the neighbor change happened to a block outside a multiblock, and it isn't a block that could be part of the multiblock
         //Note: This is necessary to eliminate unnecessary structure recheck
         // caused by redstone optimization mods like Alternate Current reporting the different neighborPos from Vanilla implementation.
-        long dX = Math.abs((long)neighborPos.getX() - worldPosition.getX());
-        long dY = Math.abs((long)neighborPos.getY() - worldPosition.getY());
-        long dZ = Math.abs((long)neighborPos.getZ() - worldPosition.getZ());
+        int dX = Math.abs(neighborPos.getX() - worldPosition.getX());
+        int dY = Math.abs(neighborPos.getY() - worldPosition.getY());
+        int dZ = Math.abs(neighborPos.getZ() - worldPosition.getZ());
         if (Math.max(Math.max(dX, dY), dZ) > 1) return;
         //And we are not already an internal part of the structure, or we are changing an internal part to air
         // then we mark the structure as needing to be re-validated

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityInternalMultiblock.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityInternalMultiblock.java
@@ -4,11 +4,9 @@ import java.util.Objects;
 import java.util.UUID;
 import mekanism.api.SerializationConstants;
 import mekanism.common.lib.multiblock.IInternalMultiblock;
-import mekanism.common.lib.multiblock.IMultiblockBase;
 import mekanism.common.lib.multiblock.MultiblockData;
 import mekanism.common.tile.base.TileEntityMekanism;
 import mekanism.common.util.NBTUtils;
-import mekanism.common.util.WorldUtils;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.HolderLookup;
@@ -71,7 +69,10 @@ public class TileEntityInternalMultiblock extends TileEntityMekanism implements 
         //If the neighbor change happened to a block outside a multiblock, and it isn't a block that could be part of the multiblock
         //Note: This is necessary to eliminate unnecessary structure recheck
         // caused by redstone optimization mods like Alternate Current reporting the different neighborPos from Vanilla implementation.
-        if (!(WorldUtils.getTileEntity(level, neighborPos) instanceof IMultiblockBase)) return;
+        long dX = Math.abs((long)neighborPos.getX() - worldPosition.getX());
+        long dY = Math.abs((long)neighborPos.getY() - worldPosition.getY());
+        long dZ = Math.abs((long)neighborPos.getZ() - worldPosition.getZ());
+        if (Math.max(Math.max(dX, dY), dZ) > 1) return;
         //And we are not already an internal part of the structure, or we are changing an internal part to air
         // then we mark the structure as needing to be re-validated
         //Note: This isn't a super accurate check as if a node gets replaced by command or mod with say dirt

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityInternalMultiblock.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityInternalMultiblock.java
@@ -4,9 +4,11 @@ import java.util.Objects;
 import java.util.UUID;
 import mekanism.api.SerializationConstants;
 import mekanism.common.lib.multiblock.IInternalMultiblock;
+import mekanism.common.lib.multiblock.IMultiblockBase;
 import mekanism.common.lib.multiblock.MultiblockData;
 import mekanism.common.tile.base.TileEntityMekanism;
 import mekanism.common.util.NBTUtils;
+import mekanism.common.util.WorldUtils;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.HolderLookup;
@@ -63,16 +65,18 @@ public class TileEntityInternalMultiblock extends TileEntityMekanism implements 
         super.onNeighborChange(block, neighborPos);
         //TODO - V11: Make this properly support changing blocks inside the structure when they aren't touching any part of the multiblocks
         //Note: We handle when an internal multiblock is removed that isn't touching anything in BlockMekanism#onRemove
-        if (!isRemote() && multiblock != null) {
-            //If the neighbor change happened to a block inside a multiblock, and it isn't a block that is part of the multiblock
-            if (level.isEmptyBlock(neighborPos) || !multiblock.isKnownLocation(neighborPos)) {
-                //And we are not already an internal part of the structure, or we are changing an internal part to air
-                // then we mark the structure as needing to be re-validated
-                //Note: This isn't a super accurate check as if a node gets replaced by command or mod with say dirt
-                // it won't know to invalidate it but oh well. (See java docs on internalLocations for more caveats)
-                multiblock.recheckStructure = true;
-            }
-        }
+        if (level == null || multiblock == null || isRemote()) return;
+        //If the neighbor change happened to a block inside a multiblock, and it isn't a block that is part of the multiblock
+        if (!level.isEmptyBlock(neighborPos) && multiblock.isKnownLocation(neighborPos)) return;
+        //If the neighbor change happened to a block outside a multiblock, and it isn't a block that could be part of the multiblock
+        //Note: This is necessary to eliminate unnecessary structure recheck
+        // caused by redstone optimization mods like Alternate Current reporting the different neighborPos from Vanilla implementation.
+        if (!(WorldUtils.getTileEntity(level, neighborPos) instanceof IMultiblockBase)) return;
+        //And we are not already an internal part of the structure, or we are changing an internal part to air
+        // then we mark the structure as needing to be re-validated
+        //Note: This isn't a super accurate check as if a node gets replaced by command or mod with say dirt
+        // it won't know to invalidate it but oh well. (See java docs on internalLocations for more caveats)
+        multiblock.recheckStructure = true;
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityInternalMultiblock.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityInternalMultiblock.java
@@ -61,23 +61,25 @@ public class TileEntityInternalMultiblock extends TileEntityMekanism implements 
     @Override
     public void onNeighborChange(Block block, BlockPos neighborPos) {
         super.onNeighborChange(block, neighborPos);
-        //TODO - V11: Make this properly support changing blocks inside the structure when they aren't touching any part of the multiblocks
-        //Note: We handle when an internal multiblock is removed that isn't touching anything in BlockMekanism#onRemove
-        if (level == null || multiblock == null || isRemote()) return;
-        //If the neighbor change happened to a block inside a multiblock, and it isn't a block that is part of the multiblock
-        if (!level.isEmptyBlock(neighborPos) && multiblock.isKnownLocation(neighborPos)) return;
-        //If the neighbor change happened to a block outside a multiblock, and it isn't a block that could be part of the multiblock
+        //Check if the neighborPos is really a neighbor of this block
         //Note: This is necessary to eliminate unnecessary structure recheck
         // caused by redstone optimization mods like Alternate Current reporting the different neighborPos from Vanilla implementation.
-        int dX = Math.abs(neighborPos.getX() - worldPosition.getX());
-        int dY = Math.abs(neighborPos.getY() - worldPosition.getY());
-        int dZ = Math.abs(neighborPos.getZ() - worldPosition.getZ());
-        if (((dX | dY | dZ) >>> 1) > 0) return;
-        //And we are not already an internal part of the structure, or we are changing an internal part to air
-        // then we mark the structure as needing to be re-validated
-        //Note: This isn't a super accurate check as if a node gets replaced by command or mod with say dirt
-        // it won't know to invalidate it but oh well. (See java docs on internalLocations for more caveats)
-        multiblock.recheckStructure = true;
+        boolean fX = Integer.toUnsignedLong(Math.abs(neighborPos.getX() - worldPosition.getX())) > 1;
+        boolean fY = Integer.toUnsignedLong(Math.abs(neighborPos.getY() - worldPosition.getY())) > 1;
+        boolean fZ = Integer.toUnsignedLong(Math.abs(neighborPos.getZ() - worldPosition.getZ())) > 1;
+        if (fX | fY | fZ) return;
+        //TODO - V11: Make this properly support changing blocks inside the structure when they aren't touching any part of the multiblocks
+        //Note: We handle when an internal multiblock is removed that isn't touching anything in BlockMekanism#onRemove
+        if (level != null && multiblock != null && !isRemote()) {
+            //If the neighbor change happened to a block inside a multiblock, and it isn't a block that is part of the multiblock
+            if (level.isEmptyBlock(neighborPos) || !multiblock.isKnownLocation(neighborPos)) {
+                //And we are not already an internal part of the structure, or we are changing an internal part to air
+                // then we mark the structure as needing to be re-validated
+                //Note: This isn't a super accurate check as if a node gets replaced by command or mod with say dirt
+                // it won't know to invalidate it but oh well. (See java docs on internalLocations for more caveats)
+                multiblock.recheckStructure = true;
+            }
+        }
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityInternalMultiblock.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityInternalMultiblock.java
@@ -64,10 +64,10 @@ public class TileEntityInternalMultiblock extends TileEntityMekanism implements 
         //Check if the neighborPos is really a neighbor of this block
         //Note: This is necessary to eliminate unnecessary structure recheck
         // caused by redstone optimization mods like Alternate Current reporting the different neighborPos from Vanilla implementation.
-        boolean fX = Integer.toUnsignedLong(Math.abs(neighborPos.getX() - worldPosition.getX())) > 1;
-        boolean fY = Integer.toUnsignedLong(Math.abs(neighborPos.getY() - worldPosition.getY())) > 1;
-        boolean fZ = Integer.toUnsignedLong(Math.abs(neighborPos.getZ() - worldPosition.getZ())) > 1;
-        if (fX | fY | fZ) return;
+        long dX = Integer.toUnsignedLong(Math.abs(neighborPos.getX() - worldPosition.getX()));
+        long dY = Integer.toUnsignedLong(Math.abs(neighborPos.getY() - worldPosition.getY()));
+        long dZ = Integer.toUnsignedLong(Math.abs(neighborPos.getZ() - worldPosition.getZ()));
+        if ((dX + dY + dZ) > 1) return;
         //TODO - V11: Make this properly support changing blocks inside the structure when they aren't touching any part of the multiblocks
         //Note: We handle when an internal multiblock is removed that isn't touching anything in BlockMekanism#onRemove
         if (level != null && multiblock != null && !isRemote()) {

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityInternalMultiblock.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityInternalMultiblock.java
@@ -72,7 +72,7 @@ public class TileEntityInternalMultiblock extends TileEntityMekanism implements 
         int dX = Math.abs(neighborPos.getX() - worldPosition.getX());
         int dY = Math.abs(neighborPos.getY() - worldPosition.getY());
         int dZ = Math.abs(neighborPos.getZ() - worldPosition.getZ());
-        if (Math.max(Math.max(dX, dY), dZ) > 1) return;
+        if (((dX | dY | dZ) >>> 1) > 0) return;
         //And we are not already an internal part of the structure, or we are changing an internal part to air
         // then we mark the structure as needing to be re-validated
         //Note: This isn't a super accurate check as if a node gets replaced by command or mod with say dirt


### PR DESCRIPTION
## Changes proposed in this pull request:

<img width="3840" height="2036" alt="Redstone Wire on top of the Reactor Glass" src="https://github.com/user-attachments/assets/ab41d458-5027-430d-8515-3207f83278e0" />

When the Redstone Wire on top of the Reactor Glass gets updated, `TileEntityInternalMultiblock` beneath the `mekanismgenerators:reactor_glass` (in this case the `TileEntityControlRodAssembly`) receives `onNeighborChange(Block block, BlockPos neighborPos)` with `block` set to `Block{minecraft:redstone_wire}`.  
If [Alternate Current](https://modrinth.com/mod/alternate-current) is not present, `neighborPos` will be the position of the `mekanismgenerators:reactor_glass` in this case.  
However, if it is present, `neighborPos` will be the position of the `minecraft:redstone_wire`, which is right above the `mekanismgenerators:reactor_glass` in this case.  
This causes the `multiblock.isKnownLocation(neighborPos)` return `false`, thus setting `multiblock.recheckStructure` to `true`, ultimately triggering the multiblock structure recheck.  

<img width="3840" height="2036" alt="Redstone Wire connected to the Fission Reactor Logic Adapter on top of the Reactor Glass" src="https://github.com/user-attachments/assets/7b917a42-e80b-4939-839e-b136c9bd1923" />
<img width="3840" height="2036" alt="Configuration of Fission Reactor Logic Adapter (Insufficient Fuel)" src="https://github.com/user-attachments/assets/2256dacc-b126-47b6-94c0-f00e265e3074" />

This setup above makes it even worse. The Redstone mode of Fission Reactor Logic Adapter is set to Insufficient Fuel here, and the reactor has no fuel this time. Redstone Wire connects the Logic Adapter and the Reactor Glass on top of the Control Rod Assembly.  
This setup causes infinite multiblock structure recheck like in the video below if Alternate Current is present.

https://github.com/user-attachments/assets/9435b5ba-fb16-4bd8-b4c5-7a30ca8997b2

This fix checks if the touching block can be a part of multiblock structure at all, reducing unnecessary multiblock structure rechecks caused by redstone updates even if the Alternate Current is present.