### PR TITLE
Fix Dynamic Valve HashMap leak: Use instanceof in FluidRenderData.equals

### DIFF
--- a/src/main/java/mekanism/client/render/data/FluidRenderData.java
+++ b/src/main/java/mekanism/client/render/data/FluidRenderData.java
@@ -55,7 +55,7 @@ public class FluidRenderData extends RenderData {
         } else if (data == null) {
             return false;
         }
-        return data instanceof FluidRenderData && equalsCommonFluid(data);
+        return data.getClass() == FluidRenderData.class && equalsCommonFluid(data);
     }
 
     protected boolean equalsCommonFluid(Object data) {

--- a/src/main/java/mekanism/client/render/data/FluidRenderData.java
+++ b/src/main/java/mekanism/client/render/data/FluidRenderData.java
@@ -55,7 +55,7 @@ public class FluidRenderData extends RenderData {
         } else if (data == null) {
             return false;
         }
-        return data.getClass() == FluidRenderData.class && equalsCommonFluid(data);
+        return data.getClass() == getClass() && equalsCommonFluid(data);
     }
 
     protected boolean equalsCommonFluid(Object data) {

--- a/src/main/java/mekanism/client/render/data/FluidRenderData.java
+++ b/src/main/java/mekanism/client/render/data/FluidRenderData.java
@@ -55,7 +55,7 @@ public class FluidRenderData extends RenderData {
         } else if (data == null) {
             return false;
         }
-        return data.getClass() == FluidRenderData.class && equalsCommonFluid(data);
+        return data instanceof FluidRenderData && equalsCommonFluid(data);
     }
 
     protected boolean equalsCommonFluid(Object data) {

--- a/src/main/java/mekanism/client/render/data/ValveRenderData.java
+++ b/src/main/java/mekanism/client/render/data/ValveRenderData.java
@@ -1,5 +1,7 @@
 package mekanism.client.render.data;
 
+import org.jetbrains.annotations.Nullable;
+
 import mekanism.api.annotations.NothingNullByDefault;
 import mekanism.common.lib.multiblock.IValveHandler.ValveData;
 import net.minecraft.core.BlockPos;
@@ -30,8 +32,16 @@ public class ValveRenderData extends FluidRenderData {
     }
 
     @Override
-    public boolean equals(Object data) {
-        return data instanceof ValveRenderData other && super.equals(data) && side == other.side && valveFluidHeight == other.valveFluidHeight;
+    public boolean equals(@Nullable Object data) {
+        if (data == this) {
+            return true;
+        } else if (data == null) {
+            return false;
+        }
+        return data.getClass() == getClass() &&
+            super.equals(data) &&
+            side == ((ValveRenderData) data).side &&
+            valveFluidHeight == ((ValveRenderData) data).valveFluidHeight;
     }
 
     @Override


### PR DESCRIPTION
Currently, each frame a Dynamic Valve is being rendered a new instance of a `Float2ObjectMap<Model3D>` is created and stored in `ModelRenderer.cachedValveFluids`. Although the code is written to use `computeIfAbsent`, the equality check for `ValveRenderData` always returns `false`, because its superclass, `FluidRenderData`, tests for exact class equality. By changing this check to an `instanceof` we can allow the `super.equals()` to succeed, preventing the map from growing infinitely and allowing the cache to function as intended.

Because the map can grow to quite a few objects, the lookup and insertion time can increase drastically, severely hurting performance in long play sessions. I've seen `ModelRenderer.getValveModel` take up to 80% of CPU time when profiled (recorded via Spark's client profiler). In the amount of time its taken to write the description of this PR, VisualVM's heap dump displays over 80k instances of `ValveRenderData` from looking at a single Dynamic Tank slowly filling with water on a test world:
<img width="508" height="284" alt="image" src="https://github.com/user-attachments/assets/ffd59a9c-70fd-4606-8466-1a8402d33912" />

After updating the `equals` implementation:

<img width="526" height="310" alt="image" src="https://github.com/user-attachments/assets/a64e7d7f-e836-41e5-8525-6d4230f93009" />

The count continues to stay fixed at 1 even when letting run for a long time - cache is working :)
