### PR TITLE
Add getEnergyUnit computercraft helper method

### DIFF
--- a/src/main/java/mekanism/common/integration/computer/ComputerEnergyHelper.java
+++ b/src/main/java/mekanism/common/integration/computer/ComputerEnergyHelper.java
@@ -6,6 +6,11 @@ import mekanism.common.util.UnitDisplayUtils.EnergyUnit;
 
 public class ComputerEnergyHelper {
 
+    @ComputerMethod(methodDescription = "Return the Current Configured Energy Unit")
+    public static String getEnergyUnit() {
+        return EnergyUnit.getConfigured().getTabName(); //used tab name as it is constant between languages
+    }
+
     @ComputerMethod(methodDescription = "Convert Mekanism Joules to Forge Energy")
     public static long joulesToFE(long joules) throws ComputerException {
         return convert(EnergyUnit.FORGE_ENERGY, joules, true);


### PR DESCRIPTION
## Changes proposed in this pull request:
Adds a new `getEnergyUnit` computercraft method to the `mekanismEnergyHelper` global to allow users to get the currently configured energy unit.

This is useful in certain scenarios where users would want to dynamically handle energy unit conversions. 

Example:
```lua
function getEnergy (matrix)
    if mekanismEnergyHelper.getEnergyUnit() == "fe" then
        return mekanismEnergyHelper.joulesToFE(matrix.getLastInput())
    end
    
    return matrix.getLastInput()
end
```