### PR TITLE
Add green rear port to Isotopic Centrifuge

### DIFF
--- a/src/main/java/mekanism/common/content/blocktype/BlockShapes.java
+++ b/src/main/java/mekanism/common/content/blocktype/BlockShapes.java
@@ -692,8 +692,10 @@ public final class BlockShapes {
               box(4, 30, 4, 6, 32, 6), // node1
               box(5, 30, 10, 6, 32, 11), // node2
               box(6, 30, 6, 10, 31, 10), // coil
-              box(4, 4, 0, 12, 12, 1), // port
-              box(5, 5, 1, 11, 11, 3), // port_connector
+              box(4, 4, 0, 12, 12, 1), // port_front
+              box(5, 5, 1, 11, 11, 3), // port_connector_front
+              box(4, 4, 15, 12, 12, 16), // port_back
+              box(5, 5, 13, 11, 11, 15), // port_connector_back
               box(6, 18, 7, 7, 25, 8), // random_shape1
               box(6, 17, 7, 9, 18, 8), // random_shape2
               box(8, 15, 7, 9, 17, 8) // random_shape3

--- a/src/main/resources/assets/mekanism/models/block/isotopic_centrifuge.json
+++ b/src/main/resources/assets/mekanism/models/block/isotopic_centrifuge.json
@@ -330,7 +330,7 @@
 					}
 				},
 				{
-					"name": "port",
+					"name": "port_front",
 					"from": [4, 4, 0],
 					"to": [12, 12, 1],
 					"faces": {
@@ -343,7 +343,7 @@
 					}
 				},
 				{
-					"name": "port_led",
+					"name": "port_led_front",
 					"from": [4, 4, 0],
 					"to": [12, 12, 0],
 					"faces": {
@@ -355,7 +355,7 @@
 					}
 				},
 				{
-					"name": "port_connector",
+					"name": "port_connector_front",
 					"from": [5, 5, 1],
 					"to": [11, 11, 3],
 					"faces": {
@@ -363,6 +363,42 @@
 						"west": {"uv": [9, 1, 11, 7], "texture": "#1"},
 						"up": {"uv": [9, 1, 15, 3], "texture": "#1"},
 						"down": {"uv": [9, 1, 15, 3], "texture": "#1"}
+					}
+				},
+				{
+					"name": "port_back",
+					"from": [4, 4, 15],
+					"to": [12, 12, 16],
+					"faces": {
+						"north": {"uv": [0, 8, 8, 16], "texture": "#1"},
+						"east": {"uv": [7, 0, 8, 8], "texture": "#1"},
+						"south": {"uv": [0, 0, 8, 8], "texture": "#1", "cullface": "south"},
+						"west": {"uv": [0, 0, 1, 8], "texture": "#1"},
+						"up": {"uv": [0, 0, 8, 1], "rotation": 180, "texture": "#1"},
+						"down": {"uv": [0, 7, 8, 8], "rotation": 180, "texture": "#1"}
+					}
+				},
+				{
+					"name": "port_led_back",
+					"from": [4, 4, 16],
+					"to": [12, 12, 16],
+					"faces": {
+						"south": {"uv": [8, 8, 16, 16], "texture": "#2", "cullface": "south"}
+					},
+					"neoforge_data": {
+						"block_light": 15,
+						"sky_light": 15
+					}
+				},
+				{
+					"name": "port_connector_back",
+					"from": [5, 5, 13],
+					"to": [11, 11, 15],
+					"faces": {
+						"east": {"uv": [9, 1, 11, 7], "texture": "#1"},
+						"west": {"uv": [13, 1, 15, 7], "texture": "#1"},
+						"up": {"uv": [9, 1, 15, 3], "rotation": 180, "texture": "#1"},
+						"down": {"uv": [9, 1, 15, 3], "rotation": 180, "texture": "#1"}
 					}
 				},
 				{


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add a green port to the rear of the Isotopic Centrifuge (opposite the existing port)
- Update the BlockShapes definition to include the new port

Fixes mekanism/Mekanism-Feature-Requests#802

## Screeenshots:

<img width="427" height="240" src="https://github.com/user-attachments/assets/dcb039fd-3c67-4463-a7da-4eedfe0aba44" />
<img width="427" height="240" src="https://github.com/user-attachments/assets/62e6e254-5f17-49c2-90ff-b5a6cdd52dc4" />