### PR TITLE
Add a default method to determine whether the machine needs to be configured by the Configurator

### DIFF
--- a/src/main/java/mekanism/client/render/RenderTickHandler.java
+++ b/src/main/java/mekanism/client/render/RenderTickHandler.java
@@ -475,7 +475,7 @@ public class RenderTickHandler {
             if (state.isConfigurating()) {
                 TransmissionType type = Objects.requireNonNull(state.getTransmission(), "Configurating state requires transmission type");
                 BlockEntity tile = WorldUtils.getTileEntity(world, pos);
-                if (tile instanceof ISideConfiguration configurable) {
+                if (tile instanceof ISideConfiguration configurable && configurable.needConfig()) {
                     TileComponentConfig config = configurable.getConfig();
                     if (config.supports(type)) {
                         Direction face = rayTraceResult.getDirection();

--- a/src/main/java/mekanism/common/item/ItemConfigurator.java
+++ b/src/main/java/mekanism/common/item/ItemConfigurator.java
@@ -127,7 +127,7 @@ public class ItemConfigurator extends Item implements IRadialModeItem<Configurat
             ConfiguratorMode mode = getMode(stack);
             if (mode.isConfigurating()) { //Configurate
                 TransmissionType transmissionType = Objects.requireNonNull(mode.getTransmission(), "Configurating state requires transmission type");
-                if (tile instanceof ISideConfiguration config && config.getConfig().supports(transmissionType)) {
+                if (tile instanceof ISideConfiguration config && config.getConfig().supports(transmissionType) && config.needConfig()) {
                     ConfigInfo info = config.getConfig().getConfig(transmissionType);
                     if (info != null) {
                         RelativeSide relativeSide = RelativeSide.fromDirections(config.getDirection(), side);

--- a/src/main/java/mekanism/common/tile/interfaces/ISideConfiguration.java
+++ b/src/main/java/mekanism/common/tile/interfaces/ISideConfiguration.java
@@ -1,6 +1,7 @@
 package mekanism.common.tile.interfaces;
 
 import java.util.List;
+
 import mekanism.api.chemical.IChemicalTank;
 import mekanism.api.fluid.IExtendedFluidTank;
 import mekanism.api.inventory.IInventorySlot;
@@ -40,6 +41,13 @@ public interface ISideConfiguration {
      * @return this machine's ejector
      */
     TileComponentEjector getEjector();
+
+    /**
+     * Determine whether the machine needs to be adjusted by the Configurator
+     */
+    default boolean needConfig() {
+        return true;
+    }
 
     @Nullable
     default DataType getActiveDataType(Object container) {


### PR DESCRIPTION
…figured by the Configurator

## Changes proposed in this pull request:

Added a default method to the ISideConfiguration interface that can be used to determine whether the machine needs to be configured by the Configurator.

I added a large machine(like miner), but it has a recipe. So it had to be configured by the Configurator, but large machines have offset their I/O, so this feature is not needed at this time.

Thanks

