### PR TITLE
Fix transporter item box color rendering

### DIFF
--- a/src/main/java/mekanism/client/model/ModelTransporterBox.java
+++ b/src/main/java/mekanism/client/model/ModelTransporterBox.java
@@ -49,6 +49,6 @@ public class ModelTransporterBox extends MekanismJavaModel {
 
     @Override
     public void renderToBuffer(@NotNull PoseStack matrix, @NotNull VertexConsumer vertexBuilder, int light, int overlayLight, int color) {
-        box.render(matrix, vertexBuilder, light, overlayLight, 0xFFFFFFFF);
+        box.render(matrix, vertexBuilder, light, overlayLight, color);
     }
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
Closes #8502 
In this PR, I am fixing an issue with the Logistical Transporter’s traveling item overlay ("transporter box") always rendered using a grey tint instead of the sorter-assigned color.

The root cause was that ModelTransporterBox#renderToBuffer ignored the color parameter passed from the renderer and instead hardcoded the tint to 0xFFFFFFFF. This was causing all transporter boxes to appear identical with a light gray box color regardless of the filter color actually being used.

I tested the solution in a dev environment and everything was working correctly after the fix. 