### PR TITLE
Modify source method to handle mace incompatible with Mekanism Tools

### DIFF
--- a/src/main/java/mekanism/common/registration/impl/MekanismDamageType.java
+++ b/src/main/java/mekanism/common/registration/impl/MekanismDamageType.java
@@ -50,12 +50,12 @@ public record MekanismDamageType(ResourceKey<DamageType> key, float exhaustion, 
         return new DamageSource(holder(registryAccess), position);
     }
 
-    public DamageSource source(Level level, @Nullable Entity directEntity, @Nullable Entity causingEntity) {
+    public DamageSource source(RegistryAccess registryAccess @Nullable Entity directEntity, @Nullable Entity causingEntity) {
         if (directEntity instanceof Player player && player.getMainHandItem().is(Items.MACE)) {
             // Return null or throw, so the weapon code falls back to vanilla
             return null;
         }
-        return new DamageSource(holder(level.registryAccess()), directEntity, causingEntity);
+        return new DamageSource(holder(registryAccess), directEntity, causingEntity);
     }
 
     private Holder<DamageType> holder(RegistryAccess registryAccess) {

--- a/src/main/java/mekanism/common/registration/impl/MekanismDamageType.java
+++ b/src/main/java/mekanism/common/registration/impl/MekanismDamageType.java
@@ -50,8 +50,12 @@ public record MekanismDamageType(ResourceKey<DamageType> key, float exhaustion, 
         return new DamageSource(holder(registryAccess), position);
     }
 
-    public DamageSource source(RegistryAccess registryAccess, @Nullable Entity directEntity, @Nullable Entity causingEntity) {
-        return new DamageSource(holder(registryAccess), directEntity, causingEntity);
+    public DamageSource source(Level level, @Nullable Entity directEntity, @Nullable Entity causingEntity) {
+        if (directEntity instanceof Player player && player.getMainHandItem().is(Items.MACE)) {
+            // Return null or throw, so the weapon code falls back to vanilla
+            return null;
+        }
+        return new DamageSource(holder(level.registryAccess()), directEntity, causingEntity);
     }
 
     private Holder<DamageType> holder(RegistryAccess registryAccess) {


### PR DESCRIPTION
 ## Changes proposed in this pull request:
Updated source method to prevent maces from breaking. Due to it overriding existing classes with Mekanism Tools the mace broke, the  small fix

if (directEntity instanceof Player player && player.getMainHandItem().is(Items.MACE)) {
            return null;
        }
        
        returns null to prevent anything happening if it is a mace.
Mekanism-1.21.x\src\main\java\mekanism\common\registration\impl\MekanismDamageType.java