### PR TITLE
Minor network cleanups and bit-shift speed upgrade baseline

### DIFF
--- a/src/main/java/mekanism/common/lib/transmitter/DynamicBufferedNetwork.java
+++ b/src/main/java/mekanism/common/lib/transmitter/DynamicBufferedNetwork.java
@@ -130,7 +130,7 @@ public abstract class DynamicBufferedNetwork<ACCEPTOR, NETWORK extends DynamicBu
         long sum = 0;
         for (TRANSMITTER transmitter : getTransmitters()) {
             long transmitterCapacity = transmitter.getCapacity();
-            if (transmitterCapacity > Long.MAX_VALUE - capacity) {
+            if (transmitterCapacity > Long.MAX_VALUE - sum) {
                 //Ensure we don't overflow
                 sum = Long.MAX_VALUE;
                 break;

--- a/src/main/java/mekanism/common/lib/transmitter/DynamicNetwork.java
+++ b/src/main/java/mekanism/common/lib/transmitter/DynamicNetwork.java
@@ -151,7 +151,6 @@ public abstract class DynamicNetwork<ACCEPTOR, NETWORK extends DynamicNetwork<AC
         for (ObjectIterator<Long2ObjectMap.Entry<TRANSMITTER>> iterator = Long2ObjectMaps.fastIterator(net.positionedTransmitters); iterator.hasNext(); ) {
             Long2ObjectMap.Entry<TRANSMITTER> entry = iterator.next();
             TRANSMITTER transmitter = entry.getValue();
-            positionedTransmitters.put(entry.getLongKey(), transmitter);
             if (transmitter.setTransmitterNetwork(getNetwork(), false)) {
                 transmittersToUpdate.add(transmitter);
             }

--- a/src/main/java/mekanism/common/lib/transmitter/acceptor/NetworkAcceptorCache.java
+++ b/src/main/java/mekanism/common/lib/transmitter/acceptor/NetworkAcceptorCache.java
@@ -102,7 +102,11 @@ public class NetworkAcceptorCache<ACCEPTOR> {
 
     public int getAcceptorCount() {
         //Count multiple connections to the same position as multiple acceptors
-        return cachedAcceptors.values().stream().mapToInt(Map::size).sum();
+        int count = 0;
+        for (Map<Direction, ACCEPTOR> sides : cachedAcceptors.values()) {
+            count += sides.size();
+        }
+        return count;
     }
 
     public boolean hasAcceptor(BlockPos acceptorPos) {
@@ -115,7 +119,6 @@ public class NetworkAcceptorCache<ACCEPTOR> {
     }
 
     public Set<Direction> getAcceptorDirections(long pos) {
-        //TODO: Do this better?
-        return cachedAcceptors.get(pos).keySet();
+        return cachedAcceptors.getOrDefault(pos, Collections.emptyMap()).keySet();
     }
 }

--- a/src/main/java/mekanism/common/tile/machine/TileEntityChemicalInfuser.java
+++ b/src/main/java/mekanism/common/tile/machine/TileEntityChemicalInfuser.java
@@ -208,7 +208,7 @@ public class TileEntityChemicalInfuser extends TileEntityRecipeMachine<ChemicalC
     public void recalculateUpgrades(Upgrade upgrade) {
         super.recalculateUpgrades(upgrade);
         if (upgrade == Upgrade.SPEED) {
-            baselineMaxOperations = (int) Math.pow(2, upgradeComponent.getUpgrades(Upgrade.SPEED));
+            baselineMaxOperations = 1 << upgradeComponent.getUpgrades(Upgrade.SPEED);
         }
     }
 

--- a/src/main/java/mekanism/common/tile/machine/TileEntityChemicalWasher.java
+++ b/src/main/java/mekanism/common/tile/machine/TileEntityChemicalWasher.java
@@ -205,7 +205,7 @@ public class TileEntityChemicalWasher extends TileEntityRecipeMachine<FluidChemi
     public void recalculateUpgrades(Upgrade upgrade) {
         super.recalculateUpgrades(upgrade);
         if (upgrade == Upgrade.SPEED) {
-            baselineMaxOperations = (int) Math.pow(2, upgradeComponent.getUpgrades(Upgrade.SPEED));
+            baselineMaxOperations = 1 << upgradeComponent.getUpgrades(Upgrade.SPEED);
         }
     }
 

--- a/src/main/java/mekanism/common/tile/machine/TileEntityElectrolyticSeparator.java
+++ b/src/main/java/mekanism/common/tile/machine/TileEntityElectrolyticSeparator.java
@@ -308,9 +308,9 @@ public class TileEntityElectrolyticSeparator extends TileEntityRecipeMachine<Ele
     public void recalculateUpgrades(Upgrade upgrade) {
         super.recalculateUpgrades(upgrade);
         if (upgrade == Upgrade.SPEED) {
-            double speed = Math.pow(2, upgradeComponent.getUpgrades(Upgrade.SPEED));
-            baselineMaxOperations = (int) speed;
-            dumpRate = (long) (BASE_DUMP_RATE * speed);
+            int speed = 1 << upgradeComponent.getUpgrades(Upgrade.SPEED);
+            baselineMaxOperations = speed;
+            dumpRate = (long) BASE_DUMP_RATE * speed;
         }
     }
 

--- a/src/main/java/mekanism/common/tile/machine/TileEntityIsotopicCentrifuge.java
+++ b/src/main/java/mekanism/common/tile/machine/TileEntityIsotopicCentrifuge.java
@@ -183,7 +183,7 @@ public class TileEntityIsotopicCentrifuge extends TileEntityRecipeMachine<Chemic
     public void recalculateUpgrades(Upgrade upgrade) {
         super.recalculateUpgrades(upgrade);
         if (upgrade == Upgrade.SPEED) {
-            baselineMaxOperations = (int) Math.pow(2, upgradeComponent.getUpgrades(Upgrade.SPEED));
+            baselineMaxOperations = 1 << upgradeComponent.getUpgrades(Upgrade.SPEED);
         }
     }
 

--- a/src/main/java/mekanism/common/tile/machine/TileEntityPigmentMixer.java
+++ b/src/main/java/mekanism/common/tile/machine/TileEntityPigmentMixer.java
@@ -215,7 +215,7 @@ public class TileEntityPigmentMixer extends TileEntityRecipeMachine<ChemicalChem
     public void recalculateUpgrades(Upgrade upgrade) {
         super.recalculateUpgrades(upgrade);
         if (upgrade == Upgrade.SPEED) {
-            baselineMaxOperations = (int) Math.pow(2, upgradeComponent.getUpgrades(Upgrade.SPEED));
+            baselineMaxOperations = 1 << upgradeComponent.getUpgrades(Upgrade.SPEED);
         }
     }
 

--- a/src/main/java/mekanism/common/tile/machine/TileEntityRotaryCondensentrator.java
+++ b/src/main/java/mekanism/common/tile/machine/TileEntityRotaryCondensentrator.java
@@ -302,7 +302,7 @@ public class TileEntityRotaryCondensentrator extends TileEntityRecipeMachine<Rot
     public void recalculateUpgrades(Upgrade upgrade) {
         super.recalculateUpgrades(upgrade);
         if (upgrade == Upgrade.SPEED) {
-            baselineMaxOperations = (int) Math.pow(2, upgradeComponent.getUpgrades(Upgrade.SPEED));
+            baselineMaxOperations = 1 << upgradeComponent.getUpgrades(Upgrade.SPEED);
         }
     }
 


### PR DESCRIPTION
A handful of small changes I noticed while reading through the transmitter code.

- `DynamicBufferedNetwork#updateCapacity` was checking `Long.MAX_VALUE - capacity` (the stale field) against each transmitter's capacity, rather than `Long.MAX_VALUE - sum` (the running total it's building). Minor bug — the guard could trip on the wrong value when the previous capacity was high.
- `NetworkAcceptorCache#getAcceptorDirections` would NPE if the position wasn't cached (the `//TODO: Do this better?` right above it was the nudge). Swapped it for the same `getOrDefault(..., emptyMap())` pattern `getCachedAcceptor` uses three lines up. Also replaced the `stream().mapToInt(Map::size).sum()` in `getAcceptorCount` with a plain loop since it's hit from the network update path.
- `DynamicNetwork#adoptTransmittersAndAcceptorsFrom` was doing `positionedTransmitters.putAll(net.positionedTransmitters)` and then doing a `put()` per entry inside the following loop. The `put()` is redundant; the loop still needs to walk each transmitter for `setTransmitterNetwork`.
- Six machines (`TileEntityRotaryCondensentrator`, `TileEntityChemicalInfuser`, `TileEntityChemicalWasher`, `TileEntityIsotopicCentrifuge`, `TileEntityPigmentMixer`, `TileEntityElectrolyticSeparator`) compute `baselineMaxOperations = (int) Math.pow(2, speedUpgrades)`. Speed upgrades cap at 8, so this always fits in an int — replaced with `1 << speedUpgrades`.

Nothing behavioural should change. Tests and runtime behaviour were not exercised beyond reading the code, so happy to split any of these out if you'd rather take them separately.