### PR TITLE
Miscellaneous defensive/perf fixes

### DIFF
--- a/src/main/java/mekanism/common/content/network/HeatNetwork.java
+++ b/src/main/java/mekanism/common/content/network/HeatNetwork.java
@@ -47,6 +47,10 @@ public class HeatNetwork extends DynamicNetwork<IHeatHandler, HeatNetwork, Therm
     @Override
     public void onUpdate() {
         super.onUpdate();
+        int size = transmittersSize();
+        if (size == 0) {
+            return;
+        }
         double newSumTemp = 0, newHeatLost = 0, newHeatTransferred = 0;
         for (ThermodynamicConductor transmitter : getTransmitters()) {
             HeatTransfer transfer = transmitter.simulate();
@@ -62,7 +66,7 @@ public class HeatNetwork extends DynamicNetwork<IHeatHandler, HeatNetwork, Therm
         }
         heatLost = newHeatLost;
         heatTransferred = newHeatTransferred;
-        meanTemp = newSumTemp / transmittersSize();
+        meanTemp = newSumTemp / size;
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/factory/TileEntityFactory.java
+++ b/src/main/java/mekanism/common/tile/factory/TileEntityFactory.java
@@ -472,7 +472,7 @@ public abstract class TileEntityFactory<RECIPE extends MekanismRecipe<?>> extend
             getEnergyContainer().setEnergy(data.energyContainer.getEnergy());
             sorting = data.sorting;
             energySlot.deserializeNBT(provider, data.energySlot.serializeNBT(provider));
-            System.arraycopy(data.progress, 0, progress, 0, data.progress.length);
+            System.arraycopy(data.progress, 0, progress, 0, Math.min(data.progress.length, progress.length));
             for (int i = 0; i < data.inputSlots.size(); i++) {
                 //Copy the stack using NBT so that if it is not actually valid due to a reload we don't crash
                 inputSlots.get(i).deserializeNBT(provider, data.inputSlots.get(i).serializeNBT(provider));

--- a/src/main/java/mekanism/common/tile/machine/TileEntityDigitalMiner.java
+++ b/src/main/java/mekanism/common/tile/machine/TileEntityDigitalMiner.java
@@ -14,7 +14,6 @@ import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -212,8 +211,17 @@ public class TileEntityDigitalMiner extends TileEntityMekanism implements IChunk
 
     private void closeInvalidScreens() {
         if (getActive() && !playersUsing.isEmpty()) {
-            for (Player player : new HashSet<>(playersUsing)) {
+            List<Player> toClose = null;
+            for (Player player : playersUsing) {
                 if (player.containerMenu instanceof DigitalMinerConfigContainer) {
+                    if (toClose == null) {
+                        toClose = new ArrayList<>(2);
+                    }
+                    toClose.add(player);
+                }
+            }
+            if (toClose != null) {
+                for (Player player : toClose) {
                     player.closeContainer();
                 }
             }


### PR DESCRIPTION
A small batch of independent fixes noticed while reading through the code. Each one is in its own commit.

**HeatNetwork** — `onUpdate` divided by `transmittersSize()` unconditionally. If the network is ever ticked with zero transmitters (e.g. during teardown), that's `0.0 / 0 = NaN` for the double, which then sticks around in `meanTemp` and leaks into `getStoredInfo`'s display. Early-return when the network is empty.

**TileEntityFactory** — in `parseUpgradeData`, `System.arraycopy(data.progress, 0, progress, 0, data.progress.length)` uses the source length unconditionally. If you parse upgrade data from a higher-tier factory into a lower-tier one, `data.progress.length > progress.length` and the copy AIOOBEs. Clamp with `Math.min(data.progress.length, progress.length)`.

**TileEntityDigitalMiner** — `closeInvalidScreens` runs every tick while the miner is active and has viewers, and the `new HashSet<>(playersUsing)` snapshot was allocated every single tick regardless of whether anyone actually had the config GUI open (which is the uncommon path). Walk the set directly, only allocate a small buffer if we actually find someone to close. Same CME protection — just zero allocation in the common case.

---

**Please test before merging to main.** I didn't run these in a dev environment — I've only read the code and traced the logic. They look right to me but they touch persistence (the factory upgrade path specifically) and a hot tick method, so a round on a dev branch before hitting `1.21.x` would be much appreciated. I'm happy to split any of them into separate PRs if that makes CI bisection easier.