### PR TITLE
deprecate `MekanismJEI.shouldLoad()` (unnecessary since EMI 1.1.11)

### DIFF
--- a/src/generators/java/mekanism/generators/client/recipe_viewer/jei/GeneratorsJEI.java
+++ b/src/generators/java/mekanism/generators/client/recipe_viewer/jei/GeneratorsJEI.java
@@ -34,26 +34,18 @@ public class GeneratorsJEI implements IModPlugin {
 
     @Override
     public void registerItemSubtypes(@NotNull ISubtypeRegistration registry) {
-        if (MekanismJEI.shouldLoad()) {
-            MekanismJEI.registerItemSubtypes(registry, GeneratorsItems.ITEMS.getEntries());
-            MekanismJEI.registerItemSubtypes(registry, GeneratorsBlocks.BLOCKS.getSecondaryEntries());
-        }
+        MekanismJEI.registerItemSubtypes(registry, GeneratorsItems.ITEMS.getEntries());
+        MekanismJEI.registerItemSubtypes(registry, GeneratorsBlocks.BLOCKS.getSecondaryEntries());
     }
 
     @Override
     public void registerCategories(@NotNull IRecipeCategoryRegistration registry) {
-        if (!MekanismJEI.shouldLoad()) {
-            return;
-        }
         IGuiHelper guiHelper = registry.getJeiHelpers().getGuiHelper();
         registry.addRecipeCategories(new FissionReactorRecipeCategory(guiHelper, GeneratorsRVRecipeType.FISSION));
     }
 
     @Override
     public void registerRecipeCatalysts(@NotNull IRecipeCatalystRegistration registry) {
-        if (!MekanismJEI.shouldLoad()) {
-            return;
-        }
         CatalystRegistryHelper.register(registry, GeneratorsRVRecipeType.FISSION);
     }
 
@@ -64,9 +56,6 @@ public class GeneratorsJEI implements IModPlugin {
 
     @Override
     public void registerRecipes(@NotNull IRecipeRegistration registry) {
-        if (!MekanismJEI.shouldLoad()) {
-            return;
-        }
         RecipeRegistryHelper.register(registry, GeneratorsRVRecipeType.FISSION, FissionRecipeViewerRecipe.getFissionRecipes());
     }
 }

--- a/src/main/java/mekanism/client/recipe_viewer/jei/MekanismJEI.java
+++ b/src/main/java/mekanism/client/recipe_viewer/jei/MekanismJEI.java
@@ -88,9 +88,10 @@ public class MekanismJEI implements IModPlugin {
     private static final ISubtypeInterpreter<ItemStack> MEKANISM_DATA_INTERPRETER = new MekanismSubtypeInterpreter();
     private static final Map<IRecipeViewerRecipeType<?>, RecipeType<?>> recipeTypeInstanceCache = new HashMap<>();
 
+    // in case any addons still call this
+    @Deprecated(forRemoval = true)
     public static boolean shouldLoad() {
-        //Skip handling if both EMI and JEI are loaded as otherwise some things behave strangely
-        return !Mekanism.hooks.emi.isLoaded();
+        return true;
     }
 
     public static RecipeType<?> genericRecipeType(IRecipeViewerRecipeType<?> recipeType) {
@@ -142,10 +143,8 @@ public class MekanismJEI implements IModPlugin {
 
     @Override
     public void registerItemSubtypes(ISubtypeRegistration registry) {
-        if (shouldLoad()) {
-            registerItemSubtypes(registry, MekanismItems.ITEMS.getEntries());
-            registerItemSubtypes(registry, MekanismBlocks.BLOCKS.getSecondaryEntries());
-        }
+        registerItemSubtypes(registry, MekanismItems.ITEMS.getEntries());
+        registerItemSubtypes(registry, MekanismBlocks.BLOCKS.getSecondaryEntries());
     }
 
     @Override
@@ -165,9 +164,6 @@ public class MekanismJEI implements IModPlugin {
 
     @Override
     public void registerCategories(IRecipeCategoryRegistration registry) {
-        if (!shouldLoad()) {
-            return;
-        }
         IGuiHelper guiHelper = registry.getJeiHelpers().getGuiHelper();
 
         registry.addRecipeCategories(new ChemicalCrystallizerRecipeCategory(guiHelper, RecipeViewerRecipeType.CRYSTALLIZING));
@@ -217,9 +213,6 @@ public class MekanismJEI implements IModPlugin {
 
     @Override
     public void registerGuiHandlers(IGuiHandlerRegistration registry) {
-        if (!shouldLoad()) {
-            return;
-        }
         registry.addRecipeClickArea(GuiRobitRepair.class, 102, 48, 22, 15, RecipeTypes.ANVIL);
         registry.addGenericGuiContainerHandler(GuiMekanism.class, new JeiGuiElementHandler(registry.getJeiHelpers().getIngredientManager()));
         registry.addGhostIngredientHandler(GuiMekanism.class, new JeiGhostIngredientHandler<>());
@@ -232,9 +225,6 @@ public class MekanismJEI implements IModPlugin {
 
     @Override
     public void registerRecipes(IRecipeRegistration registry) {
-        if (!shouldLoad()) {
-            return;
-        }
         RecipeRegistryHelper.register(registry, RecipeViewerRecipeType.SMELTING, MekanismRecipeType.SMELTING);
         RecipeRegistryHelper.register(registry, RecipeViewerRecipeType.ENRICHING, MekanismRecipeType.ENRICHING);
         RecipeRegistryHelper.register(registry, RecipeViewerRecipeType.CRUSHING, MekanismRecipeType.CRUSHING);
@@ -274,9 +264,6 @@ public class MekanismJEI implements IModPlugin {
 
     @Override
     public void registerRecipeCatalysts(IRecipeCatalystRegistration registry) {
-        if (!shouldLoad()) {
-            return;
-        }
         //TODO: Eventually we may want to look into trying to make output definitions be invisibly added to categories, and then
         // have the output get calculated in draw, except it would also need to override getTooltip related stuff which won't be
         // super straightforward.
@@ -297,9 +284,6 @@ public class MekanismJEI implements IModPlugin {
 
     @Override
     public void registerRecipeTransferHandlers(IRecipeTransferRegistration registry) {
-        if (!shouldLoad()) {
-            return;
-        }
         IRecipeTransferHandlerHelper transferHelper = registry.getTransferHelper();
         IStackHelper stackHelper = registry.getJeiHelpers().getStackHelper();
         registry.addRecipeTransferHandler(CraftingRobitContainer.class, MekanismContainerTypes.CRAFTING_ROBIT.get(), RecipeTypes.CRAFTING, 1, 9, 10, 36);

--- a/src/tools/java/mekanism/tools/client/recipe_viewer/jei/ToolsJEI.java
+++ b/src/tools/java/mekanism/tools/client/recipe_viewer/jei/ToolsJEI.java
@@ -36,20 +36,18 @@ public class ToolsJEI implements IModPlugin {
 
     @Override
     public void registerRecipes(@NotNull IRecipeRegistration registry) {
-        if (MekanismJEI.shouldLoad()) {
-            //Add the Anvil repair recipes to JEI for all the different tools and armors in Mekanism Tools
-            for (Holder<Item> toolsItem : ToolsItems.ITEMS.getEntries()) {
-                RecipeRegistryHelper.addAnvilRecipes(registry, toolsItem, item -> {
-                    if (item instanceof ItemMekanismShield shieldItem) {
-                        return shieldItem.getRepairMaterial().getItems();
-                    } else if (item instanceof ArmorItem armorItem) {
-                        return armorItem.getMaterial().value().repairIngredient().get().getItems();
-                    } else if (item instanceof TieredItem tieredItem) {
-                        return tieredItem.getTier().getRepairIngredient().getItems();
-                    }
-                    return null;
-                });
-            }
+        //Add the Anvil repair recipes to JEI for all the different tools and armors in Mekanism Tools
+        for (Holder<Item> toolsItem : ToolsItems.ITEMS.getEntries()) {
+            RecipeRegistryHelper.addAnvilRecipes(registry, toolsItem, item -> {
+                if (item instanceof ItemMekanismShield shieldItem) {
+                    return shieldItem.getRepairMaterial().getItems();
+                } else if (item instanceof ArmorItem armorItem) {
+                    return armorItem.getMaterial().value().repairIngredient().get().getItems();
+                } else if (item instanceof TieredItem tieredItem) {
+                    return tieredItem.getTier().getRepairIngredient().getItems();
+                }
+                return null;
+            });
         }
     }
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Deprecate `MekanismJEI.shouldLoad()`
  - Method marked `@Deprecated(forRemoval = true)`
  - All usages within Mekanism removed
  - Method now always returns `true` in case any addons still use it

This should cause no issues with JEMI as of EMI 1.1.11, as that version implements a mixin which prevents JEI from loading plugins from mods which also provide an EMI plugin.

Doing this allows me to add better compatibility in TMRV for several Mekanism addons which provide a JEI plugin, but do not provide an EMI plugin. These addons almost always have a hard dependency on the Mekanism JEI plugin, which is not loading.

The latest TMRV update partially loads JEI plugins with EMI replacements with very effective compatibility improvements. However, I had to use a cross-mod mixin targeting Mekanism to achieve this. I don't like cross-mod mixins, and doing this should _hopefully_ make users less likely to report bugs to Mekanism.

I of course take full responsibility for any bugs caused by this partial loading hack, but in my testing on Craftoria and ATM10, all this change appears to do is significantly reduce the number of errors while loading TMRV.