### PR TITLE
Port cleanup: JEI bump, item models, renderer fixes, and bolt rendering

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ jade_id=7938398
 jade_version_modrinth=26.0.9+neoforge
 #Maven (unofficial)
 jade_version=mc26.1-NeoForge-26.0.10
-jei_version=29.6.0.30
+jei_version=29.6.2.31
 json_things_version=0.18.5
 wthit_version=19.0.1
 

--- a/src/generators/java/mekanism/generators/client/GeneratorsClientRegistration.java
+++ b/src/generators/java/mekanism/generators/client/GeneratorsClientRegistration.java
@@ -57,14 +57,6 @@ public class GeneratorsClientRegistration {
 
     @SubscribeEvent
     public static void init(FMLClientSetupEvent event) {
-        //TODO - 26.1 fluid models
-        /*event.enqueueWork(() -> {
-            //Set fluids to a translucent render layer
-            for (Holder<Fluid> fluid : GeneratorsFluids.FLUIDS.getFluidEntries()) {
-                ItemBlockRenderTypes.setRenderLayer(fluid.value(), RenderType.translucent());
-            }
-        });*/
-
         //TODO - 26.1 Models
         // adv solar gen requires to be translated up 1 block, so handle the model separately
         /*ClientRegistration.addCustomModel(GeneratorsBlocks.ADVANCED_SOLAR_GENERATOR, (orig, evt) -> new TransformedBakedModel<Void>(orig,

--- a/src/generators/java/mekanism/generators/client/GeneratorsClientRegistration.java
+++ b/src/generators/java/mekanism/generators/client/GeneratorsClientRegistration.java
@@ -42,10 +42,14 @@ import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.fml.event.lifecycle.FMLClientSetupEvent;
+import mekanism.generators.client.model.FuelAssemblyModel;
+import mekanism.generators.client.render.item.RenderAdvancedSolarItem;
 import net.neoforged.neoforge.client.event.AddClientReloadListenersEvent;
 import net.neoforged.neoforge.client.event.EntityRenderersEvent;
+import net.neoforged.neoforge.client.event.RegisterBlockStateModels;
 import net.neoforged.neoforge.client.event.RegisterFluidModelsEvent;
 import net.neoforged.neoforge.client.event.RegisterMenuScreensEvent;
+import net.neoforged.neoforge.client.event.RegisterSpecialModelRendererEvent;
 import net.neoforged.neoforge.client.event.TextureAtlasStitchedEvent;
 import net.neoforged.neoforge.client.extensions.common.RegisterClientExtensionsEvent;
 
@@ -57,14 +61,6 @@ public class GeneratorsClientRegistration {
 
     @SubscribeEvent
     public static void init(FMLClientSetupEvent event) {
-        //TODO - 26.1 Models
-        // adv solar gen requires to be translated up 1 block, so handle the model separately
-        /*ClientRegistration.addCustomModel(GeneratorsBlocks.ADVANCED_SOLAR_GENERATOR, (orig, evt) -> new TransformedBakedModel<Void>(orig,
-              QuadTransformation.translate(0, 1, 0)));*/
-        //TODO: Eventually make use of these custom model wrappers
-        //ClientRegistration.addCustomModel(GeneratorsBlocks.FISSION_FUEL_ASSEMBLY, (orig, evt) -> new FuelAssemblyBakedModel(orig, 0.75));
-        //ClientRegistration.addCustomModel(GeneratorsBlocks.CONTROL_ROD_ASSEMBLY, (orig, evt) -> new FuelAssemblyBakedModel(orig, 0.375));
-
         IModuleHelper moduleHelper = IModuleHelper.INSTANCE;
         moduleHelper.addMekaSuitModuleModels(MekanismGenerators.rl("models/entity/mekasuit_modules.obj"));
         moduleHelper.addMekaSuitModuleModelSpec("solar_helmet", GeneratorsModules.SOLAR_RECHARGING_UNIT, EquipmentSlot.HEAD);
@@ -121,6 +117,16 @@ public class GeneratorsClientRegistration {
     @SubscribeEvent
     public static void fluidModels(RegisterFluidModelsEvent event) {
         ClientRegistrationUtil.registerFluidModels(event, GeneratorsFluids.FLUIDS);
+    }
+
+    @SubscribeEvent
+    public static void registerModels(RegisterBlockStateModels event) {
+        event.registerModel(FuelAssemblyModel.Unbaked.ID, FuelAssemblyModel.Unbaked.MAP_CODEC);
+    }
+
+    @SubscribeEvent
+    public static void registerSpecialRenderer(RegisterSpecialModelRendererEvent event) {
+        event.register(MekanismGenerators.rl("advanced_solar"), RenderAdvancedSolarItem.Unbaked.MAP_CODEC);
     }
 
     @SubscribeEvent

--- a/src/generators/java/mekanism/generators/client/model/FuelAssemblyModel.java
+++ b/src/generators/java/mekanism/generators/client/model/FuelAssemblyModel.java
@@ -1,0 +1,97 @@
+package mekanism.generators.client.model;
+
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import java.util.List;
+import mekanism.api.annotations.NothingNullByDefault;
+import mekanism.generators.common.MekanismGenerators;
+import mekanism.generators.common.tile.fission.TileEntityFissionAssembly;
+import net.minecraft.client.renderer.block.BlockAndTintGetter;
+import net.minecraft.client.renderer.block.dispatch.BlockStateModelPart;
+import net.minecraft.client.renderer.block.dispatch.ModelState;
+import net.minecraft.client.renderer.block.dispatch.Variant;
+import net.minecraft.client.resources.model.ModelBaker;
+import net.minecraft.client.resources.model.ResolvedModel;
+import net.minecraft.client.resources.model.SimpleModelWrapper;
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.Identifier;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.neoforge.client.model.DynamicBlockStateModel;
+import net.neoforged.neoforge.client.model.block.CustomUnbakedBlockStateModel;
+import net.neoforged.neoforge.model.data.ModelData;
+
+/**
+ * 26.1 DynamicBlockStateModel for Fission Fuel/Control Rod Assembly.
+ * <p>
+ * When the assembly is part of an active fission multiblock ({@link TileEntityFissionAssembly#GLOWING} is present
+ * in {@link ModelData}), an emissive translucent glow overlay is appended to the base model parts.
+ * <p>
+ * This replaces the legacy {@code FuelAssemblyBakedModel} which relied on {@code ModifyBakingResult}.
+ */
+@NothingNullByDefault
+public class FuelAssemblyModel implements DynamicBlockStateModel {
+
+    private final BlockStateModelPart basePart;
+    private final BlockStateModelPart glowPart;
+
+    public FuelAssemblyModel(BlockStateModelPart basePart, BlockStateModelPart glowPart) {
+        this.basePart = basePart;
+        this.glowPart = glowPart;
+    }
+
+    @Override
+    public void collectParts(BlockAndTintGetter level, BlockPos pos, BlockState state, RandomSource random, List<BlockStateModelPart> parts) {
+        parts.add(basePart);
+        ModelData modelData = level.getModelData(pos);
+        if (modelData.has(TileEntityFissionAssembly.GLOWING)) {
+            parts.add(glowPart);
+        }
+    }
+
+    @Override
+    public net.minecraft.client.resources.model.sprite.Material.Baked particleMaterial() {
+        return basePart.particleMaterial();
+    }
+
+    @net.minecraft.client.resources.model.geometry.BakedQuad.MaterialFlags
+    @Override
+    public int materialFlags() {
+        return basePart.materialFlags() | glowPart.materialFlags();
+    }
+
+    public record Unbaked(Identifier baseModel, Identifier glowModel, Variant.SimpleModelState state) implements CustomUnbakedBlockStateModel {
+
+        public static final Identifier ID = MekanismGenerators.rl("fuel_assembly");
+        public static final MapCodec<Unbaked> MAP_CODEC = RecordCodecBuilder.mapCodec(in -> in.group(
+              Identifier.CODEC.fieldOf("base_model").forGetter(Unbaked::baseModel),
+              Identifier.CODEC.fieldOf("glow_model").forGetter(Unbaked::glowModel),
+              Variant.SimpleModelState.MAP_CODEC.forGetter(Unbaked::state)
+        ).apply(in, Unbaked::new));
+
+        @Override
+        public MapCodec<? extends CustomUnbakedBlockStateModel> codec() {
+            return MAP_CODEC;
+        }
+
+        @Override
+        public FuelAssemblyModel bake(ModelBaker baker) {
+            ModelState modelState = state.asModelState();
+            return new FuelAssemblyModel(
+                  bakePart(baker, modelState, baseModel),
+                  bakePart(baker, modelState, glowModel)
+            );
+        }
+
+        private static BlockStateModelPart bakePart(ModelBaker baker, ModelState modelState, Identifier identifier) {
+            ResolvedModel model = baker.getModel(identifier);
+            return SimpleModelWrapper.bake(baker, model, modelState);
+        }
+
+        @Override
+        public void resolveDependencies(Resolver resolver) {
+            resolver.markDependency(baseModel);
+            resolver.markDependency(glowModel);
+        }
+    }
+}

--- a/src/generators/java/mekanism/generators/client/render/item/RenderAdvancedSolarItem.java
+++ b/src/generators/java/mekanism/generators/client/render/item/RenderAdvancedSolarItem.java
@@ -1,0 +1,73 @@
+package mekanism.generators.client.render.item;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.serialization.MapCodec;
+import net.minecraft.client.Minecraft;
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.client.renderer.SubmitNodeCollector;
+import net.minecraft.client.renderer.block.BlockModelRenderState;
+import net.minecraft.client.renderer.special.SpecialModelRenderer;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.state.BlockState;
+import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * 26.1 SpecialModelRenderer for Advanced Solar Generator item.
+ * <p>
+ * Applies a {@code translate(0, 1, 0)} offset to the block model before submission,
+ * matching the legacy {@code TransformedBakedModel} offset that was removed with
+ * {@code ModifyBakingResult}.
+ */
+@NullMarked
+public class RenderAdvancedSolarItem implements SpecialModelRenderer<RenderAdvancedSolarItem.SolarState> {
+
+    public RenderAdvancedSolarItem() {
+    }
+
+    @Override
+    public void submit(@Nullable SolarState state, PoseStack poseStack, SubmitNodeCollector submitNodeCollector, int lightCoords, int overlayCoords, boolean hasFoil, int outlineColor) {
+        if (state == null) {
+            return;
+        }
+        // Apply the legacy +1 Y offset that used to come from TransformedBakedModel
+        poseStack.pushPose();
+        poseStack.translate(0, 1, 0);
+        state.blockModelRenderState.submit(poseStack, submitNodeCollector, lightCoords, overlayCoords, outlineColor);
+        poseStack.popPose();
+    }
+
+    @Override
+    public void getExtents(java.util.function.Consumer<org.joml.Vector3fc> output) {
+        // Let the block model extents drive this
+    }
+
+    @Nullable
+    @Override
+    public SolarState extractArgument(ItemStack stack) {
+        BlockState blockState = ((BlockItem) stack.getItem()).getBlock().defaultBlockState();
+        BlockModelRenderState blockModel = new BlockModelRenderState();
+        Minecraft.getInstance().getBlockModelResolver().update(blockModel, blockState, mekanism.client.ModelUtil.BLOCK_DISPLAY_NO_CONTEXT);
+        return new SolarState(blockModel);
+    }
+
+    public record SolarState(BlockModelRenderState blockModelRenderState) {
+    }
+
+    public static class Unbaked implements SpecialModelRenderer.Unbaked<SolarState> {
+
+        public static final Unbaked INSTANCE = new Unbaked();
+        public static final MapCodec<Unbaked> MAP_CODEC = MapCodec.unit(INSTANCE);
+
+        @Override
+        @Nullable
+        public SpecialModelRenderer<SolarState> bake(net.minecraft.client.renderer.special.SpecialModelRenderer.BakingContext context) {
+            return new RenderAdvancedSolarItem();
+        }
+
+        @Override
+        public MapCodec<? extends SpecialModelRenderer.Unbaked<SolarState>> type() {
+            return MAP_CODEC;
+        }
+    }
+}

--- a/src/generators/resources/assets/mekanismgenerators/blockstates/control_rod_assembly.json
+++ b/src/generators/resources/assets/mekanismgenerators/blockstates/control_rod_assembly.json
@@ -1,7 +1,10 @@
 {
   "variants": {
     "": {
-      "model": "mekanismgenerators:block/fission/control_rod_assembly"
+      "type": "mekanismgenerators:fuel_assembly",
+      "base_model": "mekanismgenerators:block/fission/control_rod_assembly",
+      "glow_model": "mekanismgenerators:block/fission/fuel_assembly_glow",
+      "state": {}
     }
   }
 }

--- a/src/generators/resources/assets/mekanismgenerators/blockstates/fission_fuel_assembly.json
+++ b/src/generators/resources/assets/mekanismgenerators/blockstates/fission_fuel_assembly.json
@@ -1,7 +1,10 @@
 {
   "variants": {
     "": {
-      "model": "mekanismgenerators:block/fission/fuel_assembly"
+      "type": "mekanismgenerators:fuel_assembly",
+      "base_model": "mekanismgenerators:block/fission/fuel_assembly",
+      "glow_model": "mekanismgenerators:block/fission/fuel_assembly_glow",
+      "state": {}
     }
   }
 }

--- a/src/generators/resources/assets/mekanismgenerators/models/block/fission/fuel_assembly_glow.json
+++ b/src/generators/resources/assets/mekanismgenerators/models/block/fission/fuel_assembly_glow.json
@@ -1,0 +1,41 @@
+{
+	"credit": "Mekanism glow overlay",
+	"textures": {
+		"glow": "mekanism:block/overlay/overlay_white"
+	},
+	"render_type": "minecraft:translucent",
+	"elements": [
+		{
+			"name": "glow_north",
+			"from": [0.5, 0.5, 0.5],
+			"to": [15.5, 15.5, 0.6],
+			"faces": {
+				"north": {"uv": [0, 0, 16, 16], "texture": "#glow"}
+			}
+		},
+		{
+			"name": "glow_south",
+			"from": [0.5, 0.5, 15.4],
+			"to": [15.5, 15.5, 15.5],
+			"faces": {
+				"south": {"uv": [0, 0, 16, 16], "texture": "#glow"}
+			}
+		},
+		{
+			"name": "glow_east",
+			"from": [15.4, 0.5, 0.5],
+			"to": [15.5, 15.5, 15.5],
+			"faces": {
+				"east": {"uv": [0, 0, 16, 16], "texture": "#glow"}
+			}
+		},
+		{
+			"name": "glow_west",
+			"from": [0.5, 0.5, 0.5],
+			"to": [0.6, 15.5, 15.5],
+			"faces": {
+				"west": {"uv": [0, 0, 16, 16], "texture": "#glow"}
+			}
+		}
+	]
+}

--- a/src/generators/resources/assets/mekanismgenerators/models/item/advanced_solar_generator.json
+++ b/src/generators/resources/assets/mekanismgenerators/models/item/advanced_solar_generator.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanismgenerators:block/advanced_solar_generator"
+}

--- a/src/generators/resources/assets/mekanismgenerators/models/item/advanced_solar_generator.json
+++ b/src/generators/resources/assets/mekanismgenerators/models/item/advanced_solar_generator.json
@@ -1,3 +1,5 @@
 {
-  "parent": "mekanismgenerators:block/advanced_solar_generator"
+  "model": {
+    "type": "mekanismgenerators:advanced_solar"
+  }
 }

--- a/src/generators/resources/assets/mekanismgenerators/models/item/bio_generator.json
+++ b/src/generators/resources/assets/mekanismgenerators/models/item/bio_generator.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanismgenerators:block/bio_generator"
+}

--- a/src/generators/resources/assets/mekanismgenerators/models/item/control_rod_assembly.json
+++ b/src/generators/resources/assets/mekanismgenerators/models/item/control_rod_assembly.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanismgenerators:block/fission/control_rod_assembly"
+}

--- a/src/generators/resources/assets/mekanismgenerators/models/item/electromagnetic_coil.json
+++ b/src/generators/resources/assets/mekanismgenerators/models/item/electromagnetic_coil.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanismgenerators:block/electromagnetic_coil"
+}

--- a/src/generators/resources/assets/mekanismgenerators/models/item/fission_fuel_assembly.json
+++ b/src/generators/resources/assets/mekanismgenerators/models/item/fission_fuel_assembly.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanismgenerators:block/fission/fuel_assembly"
+}

--- a/src/generators/resources/assets/mekanismgenerators/models/item/fission_reactor_casing.json
+++ b/src/generators/resources/assets/mekanismgenerators/models/item/fission_reactor_casing.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanismgenerators:block/fission/casing"
+}

--- a/src/generators/resources/assets/mekanismgenerators/models/item/fission_reactor_logic_adapter.json
+++ b/src/generators/resources/assets/mekanismgenerators/models/item/fission_reactor_logic_adapter.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanismgenerators:block/fission/logic_adapter"
+}

--- a/src/generators/resources/assets/mekanismgenerators/models/item/fission_reactor_port.json
+++ b/src/generators/resources/assets/mekanismgenerators/models/item/fission_reactor_port.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanismgenerators:block/fission/port_input"
+}

--- a/src/generators/resources/assets/mekanismgenerators/models/item/fusion_reactor_controller.json
+++ b/src/generators/resources/assets/mekanismgenerators/models/item/fusion_reactor_controller.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanismgenerators:block/fusion/controller"
+}

--- a/src/generators/resources/assets/mekanismgenerators/models/item/fusion_reactor_frame.json
+++ b/src/generators/resources/assets/mekanismgenerators/models/item/fusion_reactor_frame.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanismgenerators:block/fusion/frame"
+}

--- a/src/generators/resources/assets/mekanismgenerators/models/item/fusion_reactor_logic_adapter.json
+++ b/src/generators/resources/assets/mekanismgenerators/models/item/fusion_reactor_logic_adapter.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanismgenerators:block/fusion/logic_adapter"
+}

--- a/src/generators/resources/assets/mekanismgenerators/models/item/fusion_reactor_port.json
+++ b/src/generators/resources/assets/mekanismgenerators/models/item/fusion_reactor_port.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanismgenerators:block/fusion/port"
+}

--- a/src/generators/resources/assets/mekanismgenerators/models/item/gas_burning_generator.json
+++ b/src/generators/resources/assets/mekanismgenerators/models/item/gas_burning_generator.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanismgenerators:block/gas_burning_generator"
+}

--- a/src/generators/resources/assets/mekanismgenerators/models/item/heat_generator.json
+++ b/src/generators/resources/assets/mekanismgenerators/models/item/heat_generator.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanismgenerators:block/heat_generator"
+}

--- a/src/generators/resources/assets/mekanismgenerators/models/item/laser_focus_matrix.json
+++ b/src/generators/resources/assets/mekanismgenerators/models/item/laser_focus_matrix.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanismgenerators:block/fusion/laser_focus_matrix"
+}

--- a/src/generators/resources/assets/mekanismgenerators/models/item/reactor_glass.json
+++ b/src/generators/resources/assets/mekanismgenerators/models/item/reactor_glass.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanismgenerators:block/reactor_glass"
+}

--- a/src/generators/resources/assets/mekanismgenerators/models/item/rotational_complex.json
+++ b/src/generators/resources/assets/mekanismgenerators/models/item/rotational_complex.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanismgenerators:block/rotational_complex"
+}

--- a/src/generators/resources/assets/mekanismgenerators/models/item/saturating_condenser.json
+++ b/src/generators/resources/assets/mekanismgenerators/models/item/saturating_condenser.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanismgenerators:block/saturating_condenser"
+}

--- a/src/generators/resources/assets/mekanismgenerators/models/item/turbine_casing.json
+++ b/src/generators/resources/assets/mekanismgenerators/models/item/turbine_casing.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanismgenerators:block/turbine/casing"
+}

--- a/src/generators/resources/assets/mekanismgenerators/models/item/turbine_rotor.json
+++ b/src/generators/resources/assets/mekanismgenerators/models/item/turbine_rotor.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanismgenerators:block/turbine/rotor"
+}

--- a/src/generators/resources/assets/mekanismgenerators/models/item/turbine_valve.json
+++ b/src/generators/resources/assets/mekanismgenerators/models/item/turbine_valve.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanismgenerators:block/turbine/valve"
+}

--- a/src/generators/resources/assets/mekanismgenerators/models/item/turbine_vent.json
+++ b/src/generators/resources/assets/mekanismgenerators/models/item/turbine_vent.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanismgenerators:block/turbine/vent"
+}

--- a/src/main/java/mekanism/client/gui/machine/GuiAntiprotonicNucleosynthesizer.java
+++ b/src/main/java/mekanism/client/gui/machine/GuiAntiprotonicNucleosynthesizer.java
@@ -80,17 +80,16 @@ public class GuiAntiprotonicNucleosynthesizer extends GuiConfigurableTile<TileEn
         screen.drawScrollingString(guiGraphics, MekanismLang.PROCESS_RATE.translate(TextUtils.getPercent(tile.getProcessRate())), 0,
               screen.getHeight() - font().lineHeight - 2, TextAlignment.CENTER, screenTextColor(), 2, false);
         super.drawForegroundText(guiGraphics, mouseX, mouseY);
-        //TODO - 26.1: gui rendering
-        //PoseStack pose = guiGraphics.pose();
-        //pose.pushPose();
-        //pose.translate(0, 0, 100);
-        ////TODO - 26.1: I think it is this?
-        ////guiGraphics.submitGuiElementRenderState();
-        //MultiBufferSource.BufferSource renderer = guiGraphics.bufferSource();
-        //float partialTicks = MekanismRenderer.getPartialTick();
-        //bolt.update(this, boltSupplier.get(), partialTicks);
-        //bolt.render(gameTime, partialTicks, pose, renderer);
-        //renderer.endBatch(MekanismRenderType.MEK_LIGHTNING);
-        //pose.popPose();
+        //TODO - 26.1: GuiGraphics.pose() now returns Matrix3x2fStack (2D only), and GuiGraphicsExtractor
+        // no longer exposes bufferSource(). GUI custom 3D rendering needs architectural rework.
+        /*PoseStack pose = guiGraphics.pose();
+        pose.pushPose();
+        pose.translate(0, 0, 100);
+        MultiBufferSource.BufferSource renderer = guiGraphics.bufferSource();
+        float partialTicks = MekanismRenderer.getPartialTick();
+        bolt.update(this, boltSupplier.get(), partialTicks);
+        bolt.render(Minecraft.getInstance().level.getGameTime(), partialTicks, pose, renderer);
+        renderer.endBatch(MekanismRenderType.MEK_LIGHTNING);
+        pose.popPose();*/
     }
 }

--- a/src/main/java/mekanism/client/gui/tooltip/MultiLineTooltip.java
+++ b/src/main/java/mekanism/client/gui/tooltip/MultiLineTooltip.java
@@ -8,7 +8,6 @@ import net.minecraft.network.chat.contents.PlainTextContents.LiteralContents;
 
 class MultiLineTooltip {
 
-    //TODO - 26.1: test this works
     static Tooltip create(List<Component> message) {
         MutableComponent parent = MutableComponent.create(new LiteralContents(""));
         for (Component component : message) {

--- a/src/main/java/mekanism/client/render/LateEffectQueue.java
+++ b/src/main/java/mekanism/client/render/LateEffectQueue.java
@@ -1,0 +1,50 @@
+package mekanism.client.render;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import java.util.ArrayList;
+import java.util.List;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.state.level.CameraRenderState;
+
+/**
+ * Cola de efectos visuales tardíos (late effects) para el frame actual.
+ * <p>
+ * Tile entity renderers y otros sistemas de renderizado pueden encolar lambdas aquí durante
+ * {@code extractRenderState()} o {@code submit()}, y {@link RenderTickHandler} las drenará
+ * en {@code RenderLevelStageEvent.AfterTranslucentParticles} donde se dispone de
+ * {@link MultiBufferSource.BufferSource} y {@link CameraRenderState}.
+ * <p>
+ * Esto desacopla FX transparentes/libres del pipeline de geometría estable de 26.1.
+ */
+public class LateEffectQueue {
+
+    private static final List<LateEffect> effects = new ArrayList<>();
+
+    public static void add(LateEffect effect) {
+        effects.add(effect);
+    }
+
+    public static boolean hasEffects() {
+        return !effects.isEmpty();
+    }
+
+    public static void renderAndClear(PoseStack poseStack, MultiBufferSource.BufferSource bufferSource,
+          CameraRenderState camera, long gameTime, float partialTick) {
+        if (effects.isEmpty()) {
+            return;
+        }
+        // Copy to avoid concurrent modification if a nested effect adds more
+        List<LateEffect> toRender = new ArrayList<>(effects);
+        effects.clear();
+        for (LateEffect effect : toRender) {
+            effect.render(poseStack, bufferSource, camera, gameTime, partialTick);
+        }
+    }
+
+    @FunctionalInterface
+    public interface LateEffect {
+
+        void render(PoseStack poseStack, MultiBufferSource.BufferSource bufferSource,
+              CameraRenderState camera, long gameTime, float partialTick);
+    }
+}

--- a/src/main/java/mekanism/client/render/RenderTickHandler.java
+++ b/src/main/java/mekanism/client/render/RenderTickHandler.java
@@ -172,6 +172,7 @@ public class RenderTickHandler {
         }
         if (LateEffectQueue.hasEffects()) {
             LateEffectQueue.renderAndClear(event.getPoseStack(), renderer, levelState.cameraRenderState, levelState.gameTime, MekanismRenderer.getPartialTick());
+            renderer.endBatch();
         }
     }
 

--- a/src/main/java/mekanism/client/render/RenderTickHandler.java
+++ b/src/main/java/mekanism/client/render/RenderTickHandler.java
@@ -162,14 +162,13 @@ public class RenderTickHandler {
         }
     }
 
-    @SubscribeEvent//TODO - 26.1 is this a correct replacement?
+    @SubscribeEvent
     public void renderWorldAfterParticles(RenderLevelStageEvent.AfterTranslucentParticles event) {
         if (boltRenderer.hasBoltsToRender()) {
-            //TODO - 26.1: Figure out if this is still valid as the buffer
-            /*MultiBufferSource.BufferSource renderer = minecraft.renderBuffers().bufferSource();
+            MultiBufferSource.BufferSource renderer = minecraft.renderBuffers().bufferSource();
             LevelRenderState levelState = event.getLevelRenderState();
             boltRenderer.render(levelState.gameTime, MekanismRenderer.getPartialTick(), event.getPoseStack(), renderer, levelState.cameraRenderState.pos);
-            renderer.endBatch(MekanismRenderType.MEK_LIGHTNING);*/
+            renderer.endBatch(MekanismRenderType.MEK_LIGHTNING);
         }
     }
 
@@ -191,7 +190,7 @@ public class RenderTickHandler {
             PlayerModel model = renderer.getModel();
             AvatarRenderState renderState = renderer.createRenderState();
             renderer.extractRenderState(player, renderState, MekanismRenderer.getPartialTick());
-            //TODO - 26.1 model.setAllVisible(true);
+            //TODO - 26.1: PlayerModel no longer has setAllVisible, visibility is controlled via render state
             //Note: We just want it to act as empty even if there is a map as it looks a lot better
             boolean rightHand = event.getArm() == HumanoidArm.RIGHT;
             if (rightHand) {

--- a/src/main/java/mekanism/client/render/RenderTickHandler.java
+++ b/src/main/java/mekanism/client/render/RenderTickHandler.java
@@ -164,11 +164,14 @@ public class RenderTickHandler {
 
     @SubscribeEvent
     public void renderWorldAfterParticles(RenderLevelStageEvent.AfterTranslucentParticles event) {
+        MultiBufferSource.BufferSource renderer = minecraft.renderBuffers().bufferSource();
+        LevelRenderState levelState = event.getLevelRenderState();
         if (boltRenderer.hasBoltsToRender()) {
-            MultiBufferSource.BufferSource renderer = minecraft.renderBuffers().bufferSource();
-            LevelRenderState levelState = event.getLevelRenderState();
             boltRenderer.render(levelState.gameTime, MekanismRenderer.getPartialTick(), event.getPoseStack(), renderer, levelState.cameraRenderState.pos);
             renderer.endBatch(MekanismRenderType.MEK_LIGHTNING);
+        }
+        if (LateEffectQueue.hasEffects()) {
+            LateEffectQueue.renderAndClear(event.getPoseStack(), renderer, levelState.cameraRenderState, levelState.gameTime, MekanismRenderer.getPartialTick());
         }
     }
 

--- a/src/main/java/mekanism/client/render/lib/effect/BoltRenderer.java
+++ b/src/main/java/mekanism/client/render/lib/effect/BoltRenderer.java
@@ -8,6 +8,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import mekanism.client.render.MekanismRenderType;
 import mekanism.common.lib.effect.BoltEffect;
 import mekanism.common.lib.effect.BoltEffect.BoltQuads;
 import mekanism.common.lib.effect.BoltEffect.FadeFunction.RenderBounds;
@@ -44,7 +45,7 @@ public class BoltRenderer {
     }
 
     public void render(long gameTime, float partialTicks, PoseStack matrixStack, MultiBufferSource bufferIn, @Nullable Vec3 cameraPos) {
-        VertexConsumer buffer = bufferIn.getBuffer(null/*MekanismRenderType.MEK_LIGHTNING*/);// TODO - 26.1: rendering.
+        VertexConsumer buffer = bufferIn.getBuffer(MekanismRenderType.MEK_LIGHTNING);
         Matrix4f matrix = matrixStack.last().pose();
         Timestamp timestamp = new Timestamp(gameTime, partialTicks);
         boolean refresh = timestamp.isPassed(refreshTimestamp, (1 / REFRESH_TIME));

--- a/src/main/java/mekanism/client/render/tileentity/RenderBin.java
+++ b/src/main/java/mekanism/client/render/tileentity/RenderBin.java
@@ -76,9 +76,7 @@ public class RenderBin extends MekanismTileEntityRenderer<TileEntityBin, BinRend
             if (blockState.isEmpty() || !blockState.get().canOcclude() || !blockState.get().isFaceSturdy(level, coverPos, state.facing.getOpposite())) {
                 //Calculate lighting based on the light at the block the bin is facing
                 state.lightCoords = LevelRenderer.getLightCoords(level, coverPos);
-                //TODO - 26.1: Evaluate the seed we are passing, and if we want to use this as the seed for transporters or if maybe we should be using zero here as well?
                 int seed = Ints.saturatedCast(state.blockPos.asLong());
-                //TODO - 26.1: Is this going to try and display a stack of items, or will it display a single one? If a stack we need to return a single sized item
                 this.itemModelResolver.updateForTopItem(state.item, binSlot.getRenderStack(), ItemDisplayContext.GUI, level, null, seed);
                 if (bin.getTier() == BinTier.CREATIVE) {
                     state.displayCount = MekanismLang.INFINITE.translateColored(EnumColor.WHITE);
@@ -86,8 +84,6 @@ public class RenderBin extends MekanismTileEntityRenderer<TileEntityBin, BinRend
                     state.displayCount = TextComponentUtil.build(binSlot.isLocked() ? EnumColor.AQUA : EnumColor.WHITE, binSlot.getCount());
                 }
             } else {
-                //TODO - 26.1: Re-evaluate how we want to do this. This just makes it so that we don't actually submit any rendering,
-                // but we should see if we can just put some of this stuff in the should render?
                 state.facing = null;
             }
         }
@@ -171,7 +167,7 @@ public class RenderBin extends MekanismTileEntityRenderer<TileEntityBin, BinRend
                       false,
                       DisplayMode.POLYGON_OFFSET,
                       state.lightCoords,
-                      0xFFFFFFFF,//TODO - 26.1: What color do we want to be using?
+                      0xFFFFFFFF,
                       0,
                       0
 

--- a/src/main/java/mekanism/client/render/tileentity/RenderEnergyCube.java
+++ b/src/main/java/mekanism/client/render/tileentity/RenderEnergyCube.java
@@ -60,7 +60,6 @@ public class RenderEnergyCube extends MekanismTileEntityRenderer<TileEntityEnerg
     public void extractRenderState(TileEntityEnergyCube cube, EnergyCubeRenderState state, float partialTick, Vec3 cameraPosition, @Nullable ModelFeatureRenderer.CrumblingOverlay breakProgress) {
         super.extractRenderState(cube, state, partialTick, cameraPosition, breakProgress);
         state.coreTint = cube.getTier().getBaseTier().getPackedColor(ARGB.as8BitChannel(cube.getEnergyScale()));
-        //TODO - 26.1: Do we want to use game time as a basis or some other value?
         state.ticks = cube.getLevel().getGameTime() + partialTick;
     }
 
@@ -76,12 +75,10 @@ public class RenderEnergyCube extends MekanismTileEntityRenderer<TileEntityEnerg
         nodeCollector.submitModelPart(
               this.energyCore,
               poseStack,
-              //TODO - 26.1: Figure out the render type
               ModelEnergyCore.RENDER_TYPE,
-              //TODO - 26.1: Do we want to be using the state's light level instead?
               LightCoordsUtil.FULL_BRIGHT,
               OverlayTexture.NO_OVERLAY,
-              null,//TODO - 26.1: Do we need to specify the texture or is doing so in the render type good enough?
+              null,
               state.coreTint,
               null//No break overlay for the core
         );

--- a/src/main/java/mekanism/client/render/tileentity/RenderEnergyCube.java
+++ b/src/main/java/mekanism/client/render/tileentity/RenderEnergyCube.java
@@ -4,6 +4,7 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Axis;
 import mekanism.api.annotations.NothingNullByDefault;
 import mekanism.client.model.ModelEnergyCore;
+import mekanism.client.render.LateEffectQueue;
 import mekanism.client.render.tileentity.RenderEnergyCube.EnergyCubeRenderState;
 import mekanism.common.Mekanism;
 import mekanism.common.base.ProfilerConstants;
@@ -22,6 +23,7 @@ import net.minecraft.client.renderer.blockentity.state.BlockEntityRenderState;
 import net.minecraft.client.renderer.feature.ModelFeatureRenderer;
 import net.minecraft.client.renderer.state.level.CameraRenderState;
 import net.minecraft.client.renderer.texture.OverlayTexture;
+import net.minecraft.core.BlockPos;
 import net.minecraft.util.ARGB;
 import net.minecraft.util.LightCoordsUtil;
 import net.minecraft.world.phys.Vec3;
@@ -65,24 +67,24 @@ public class RenderEnergyCube extends MekanismTileEntityRenderer<TileEntityEnerg
 
     @Override
     public void submit(EnergyCubeRenderState state, PoseStack poseStack, SubmitNodeCollector nodeCollector, CameraRenderState camera) {
-        float scaledTicks = 4 * state.ticks;
-        poseStack.pushPose();
-        poseStack.translate(0.5, 0.5, 0.5);
-        poseStack.scale(0.4F, 0.4F, 0.4F);
-        poseStack.translate(0, Math.sin(Math.toRadians(3 * state.ticks)) / 7, 0);
-        poseStack.mulPose(Axis.YP.rotationDegrees(scaledTicks));
-        poseStack.mulPose(coreVec.rotationDegrees(36F + scaledTicks));
-        nodeCollector.submitModelPart(
-              this.energyCore,
-              poseStack,
-              ModelEnergyCore.RENDER_TYPE,
-              LightCoordsUtil.FULL_BRIGHT,
-              OverlayTexture.NO_OVERLAY,
-              null,
-              state.coreTint,
-              null//No break overlay for the core
-        );
-        poseStack.popPose();
+        // Queue core as late FX: entityCutout via SubmitNodeCollector may not render correctly in 26.1 BER context.
+        // Using MultiBufferSource directly in AfterTranslucentParticles ensures the core is visible.
+        BlockPos pos = state.blockPos;
+        float ticks = state.ticks;
+        int tint = state.coreTint;
+        LateEffectQueue.add((fxPoseStack, bufferSource, fxCamera, gameTime, partialTicks) -> {
+            fxPoseStack.pushPose();
+            fxPoseStack.translate(pos.getX(), pos.getY(), pos.getZ());
+            float scaledTicks = 4 * ticks;
+            fxPoseStack.translate(0.5, 0.5, 0.5);
+            fxPoseStack.scale(0.4F, 0.4F, 0.4F);
+            fxPoseStack.translate(0, Math.sin(Math.toRadians(3 * ticks)) / 7, 0);
+            fxPoseStack.mulPose(Axis.YP.rotationDegrees(scaledTicks));
+            fxPoseStack.mulPose(coreVec.rotationDegrees(36F + scaledTicks));
+            var buffer = bufferSource.getBuffer(ModelEnergyCore.RENDER_TYPE);
+            energyCore.render(fxPoseStack, buffer, LightCoordsUtil.FULL_BRIGHT, OverlayTexture.NO_OVERLAY, tint);
+            fxPoseStack.popPose();
+        });
     }
 
     @Override

--- a/src/main/java/mekanism/client/render/tileentity/RenderIndustrialAlarm.java
+++ b/src/main/java/mekanism/client/render/tileentity/RenderIndustrialAlarm.java
@@ -64,7 +64,6 @@ public class RenderIndustrialAlarm extends MekanismTileEntityRenderer<TileEntity
           @Nullable ModelFeatureRenderer.CrumblingOverlay breakProgress) {
         super.extractRenderState(alarm, state, partialTick, cameraPosition, breakProgress);
         state.direction = alarm.getDirection();
-        //TODO - 26.1: Do we want to use game time as a basis or some other value?
         state.modelState.setRotation((alarm.getLevel().getGameTime() + partialTick) * ROTATE_SPEED % 360);
     }
 

--- a/src/main/java/mekanism/client/render/tileentity/RenderNutritionalLiquifier.java
+++ b/src/main/java/mekanism/client/render/tileentity/RenderNutritionalLiquifier.java
@@ -8,11 +8,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.WeakHashMap;
 import mekanism.api.annotations.NothingNullByDefault;
+import com.mojang.math.Axis;
+import mekanism.client.model.MekanismModelCache;
 import mekanism.client.render.MekanismRenderer;
 import mekanism.client.render.MekanismRenderer.FluidTextureType;
 import mekanism.client.render.ModelRenderer;
 import mekanism.client.render.RenderResizableCuboid;
 import mekanism.client.render.tileentity.RenderNutritionalLiquifier.LiquifierRenderState;
+import net.minecraft.client.renderer.block.BlockModelRenderState;
 import mekanism.common.base.ProfilerConstants;
 import mekanism.common.tile.machine.TileEntityNutritionalLiquifier;
 import net.minecraft.client.Camera;
@@ -96,26 +99,24 @@ public class RenderNutritionalLiquifier extends MekanismTileEntityRenderer<TileE
         if (state.stage != 0) {
             RenderResizableCuboid.renderCube(RenderResizableCuboid.SideRender.NOT_DOWN, 0.001F, 0.313F, 0.001F, 0.999F, 0.313F + 0.624F * (state.stage / (float) stages), 0.999F, poseStack, Sheets.translucentBlockSheet(), nodeCollector, state.pasteTint, state.lightCoords, OverlayTexture.NO_OVERLAY, RenderResizableCuboid.FaceDisplay.FRONT, camera.pos, Vec3.atLowerCornerOf(state.blockPos), state.pasteTexture);
         }
-        //TODO - 26.1: rendering
-        /*if (state.active) {
+        if (state.active) {
             //Render the blade at the correct rotation if we are active
             poseStack.pushPose();
             poseStack.translate(0.5, 0.5, 0.5);
             poseStack.mulPose(Axis.YP.rotationDegrees(state.bladeRotation));
             poseStack.translate(-0.5, -0.5, -0.5);
-            nodeCollector.submitModel(
-                  MekanismModelCache.INSTANCE.LIQUIFIER_BLADE.getBakedModel(),
-                  Unit.INSTANCE,
+            nodeCollector.submitBlockModel(
                   poseStack,
-                  Sheets.solidBlockSheet(),
+                  Sheets.cutoutBlockSheet(),
+                  MekanismModelCache.INSTANCE.LIQUIFIER_BLADE.getBakedModel(),
+                  BlockModelRenderState.EMPTY_TINTS,
                   state.lightCoords,
                   OverlayTexture.NO_OVERLAY,
-                  0,//No outline
-                  state.breakProgress
+                  0//No outline
             );
             poseStack.popPose();
         }
-        //Render the item and particle
+        //Render the item
         if (!state.item.isEmpty()) {
             poseStack.pushPose();
             poseStack.translate(0.5, 0.6, 0.5);
@@ -125,33 +126,12 @@ public class RenderNutritionalLiquifier extends MekanismTileEntityRenderer<TileE
             }
             state.item.submit(poseStack, nodeCollector, state.lightCoords, OverlayTexture.NO_OVERLAY, 0);
             poseStack.popPose();
-            if (state.active && Minecraft.getInstance().options.particles().get() != ParticleStatus.MINIMAL) {
-                //TODO - 26.1: Can this be transitioned to being a nodeCollector.submitParticleGroup call?
-                //Render eating particles
-                PseudoParticleData pseudoParticles = particles.computeIfAbsent(tile, t -> new PseudoParticleData());
-                if (isTickingNormally(tile)) {
-                    //Don't add particles if the game is paused
-                    if (pseudoParticles.lastTick != gameTime) {
-                        pseudoParticles.lastTick = gameTime;
-                        pseudoParticles.particles.removeIf(PseudoParticle::tick);
-                    }
-                    int rate = Minecraft.getInstance().options.particles().get() == ParticleStatus.DECREASED ? 10 : 3;
-                    if (gameTime % rate == 0) {
-                        pseudoParticles.particles.add(new PseudoParticle(state.item, tile.getLevel().random));
-                    }
-                }
-                //Render particles
-                VertexConsumer buffer = renderer.getBuffer(MekanismRenderType.NUTRITIONAL_PARTICLE);
-                poseStack.pushPose();
-                poseStack.translate(0.5, 0.55, 0.5);
-                Matrix4f matrix4f = poseStack.last().pose();
-                for (PseudoParticle particle : pseudoParticles.particles) {
-                    particle.render(matrix4f, buffer, partialTick, state.lightCoords);
-                }
-                poseStack.popPose();
-            } else {
-                particles.remove(tile);
-            }
+        }
+        //TODO - 26.1: Pseudo-particles are late FX that need MultiBufferSource.
+        // They should be transitioned to LateEffectQueue once NUTRITIONAL_PARTICLE render type is restored.
+        /*if (state.active && !state.item.isEmpty() && Minecraft.getInstance().options.particles().get() != ParticleStatus.MINIMAL) {
+            PseudoParticleData pseudoParticles = particles.computeIfAbsent(tile, t -> new PseudoParticleData());
+            ...
         }*/
     }
 

--- a/src/main/java/mekanism/client/render/tileentity/RenderPersonalChest.java
+++ b/src/main/java/mekanism/client/render/tileentity/RenderPersonalChest.java
@@ -23,38 +23,12 @@ public class RenderPersonalChest extends ChestRenderer<TileEntityPersonalChest> 
         super(context);
     }
 
-    //TODO - 26.1: Evaluate if we have to do anything or if it works fine even though it isn't a ChestBlockEntity
-    /*@Override
-    public void extractRenderState(TileEntityPersonalChest chest, ChestRenderState state, float partialTicks, Vec3 cameraPosition, ModelFeatureRenderer.@Nullable CrumblingOverlay breakProgress) {
-        super.extractRenderState(chest, state, partialTicks, cameraPosition, breakProgress);
-    }
-
-    @Override
-    protected void render(TileEntityPersonalChest tile, float partialTick, PoseStack matrix, MultiBufferSource renderer, int light, int overlayLight, ProfilerFiller profiler) {
-        matrix.pushPose();
-        if (!tile.isRemoved()) {
-            matrix.translate(0.5D, 0.5D, 0.5D);
-            matrix.mulPose(Axis.YP.rotationDegrees(-tile.getDirection().toYRot()));
-            matrix.translate(-0.5D, -0.5D, -0.5D);
-        }
-        float lidAngle = 1.0F - tile.getOpenNess(partialTick);
-        lidAngle = 1.0F - lidAngle * lidAngle * lidAngle;
-        VertexConsumer builder = renderer.getBuffer(RenderType.entityCutout(texture));
-        lid.xRot = -(lidAngle * Mth.HALF_PI);
-        lock.xRot = lid.xRot;
-        lid.render(matrix, builder, light, overlayLight);
-        lock.render(matrix, builder, light, overlayLight);
-        bottom.render(matrix, builder, light, overlayLight);
-        matrix.popPose();
-    }*/
-
     @Nullable
     @Override
     protected SpriteId getCustomSprite(TileEntityPersonalChest chest, ChestRenderState state) {
         return MATERIAL;
     }
 
-    //@Override//TODO - 26.1: Figure out if we need to setup profiling for this again?
     protected String getProfilerSection() {
         return ProfilerConstants.PERSONAL_CHEST;
     }

--- a/src/main/java/mekanism/client/render/tileentity/RenderPigmentMixer.java
+++ b/src/main/java/mekanism/client/render/tileentity/RenderPigmentMixer.java
@@ -14,8 +14,11 @@ import mekanism.client.render.tileentity.RenderPigmentMixer.PigmentMixerRenderSt
 import mekanism.common.base.ProfilerConstants;
 import mekanism.common.block.attribute.Attribute;
 import mekanism.common.tile.machine.TileEntityPigmentMixer;
+import net.minecraft.client.renderer.Sheets;
 import net.minecraft.client.renderer.SubmitNodeCollector;
+import net.minecraft.client.renderer.block.BlockModelRenderState;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
+import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.client.renderer.blockentity.state.BlockEntityRenderState;
 import net.minecraft.client.renderer.feature.ModelFeatureRenderer;
 import net.minecraft.client.renderer.state.level.CameraRenderState;
@@ -69,17 +72,15 @@ public class RenderPigmentMixer extends MekanismTileEntityRenderer<TileEntityPig
         poseStack.translate(shift, 0, shift);
         poseStack.mulPose(Axis.YN.rotationDegrees(state.rotation));
         poseStack.translate(-shift, 0, -shift);
-        //TODO - 26.1: rendering
-        /*nodeCollector.submitModel(
-              MekanismModelCache.INSTANCE.PIGMENT_MIXER_SHAFT.getBakedModel(),
-              Unit.INSTANCE,
+        nodeCollector.submitBlockModel(
               poseStack,
-              renderType,
+              Sheets.cutoutBlockSheet(),
+              MekanismModelCache.INSTANCE.PIGMENT_MIXER_SHAFT.getBakedModel(),
+              BlockModelRenderState.EMPTY_TINTS,
               state.lightCoords,
               OverlayTexture.NO_OVERLAY,
-              0,//TODO - 26.1: Test that this works as no outline, and if it doesn't fix all the other places we pass zero for the outline color
-              state.breakProgress
-        );*/
+              0//No outline
+        );
         poseStack.popPose();
     }
 

--- a/src/main/java/mekanism/client/render/tileentity/RenderSPS.java
+++ b/src/main/java/mekanism/client/render/tileentity/RenderSPS.java
@@ -1,10 +1,15 @@
 package mekanism.client.render.tileentity;
 
 import com.mojang.blaze3d.vertex.PoseStack;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import mekanism.api.annotations.NothingNullByDefault;
+import mekanism.client.render.LateEffectQueue;
+import mekanism.client.render.MekanismRenderType;
+import mekanism.client.render.lib.effect.BillboardingEffectRenderer;
 import mekanism.client.render.lib.effect.BoltRenderer;
 import mekanism.client.render.tileentity.RenderSPS.SPSRenderState;
 import mekanism.common.base.ProfilerConstants;
@@ -98,30 +103,50 @@ public class RenderSPS extends MultiblockTileEntityRenderer<SPSMultiblockData, T
         } else if (sps.orbitEffects.size() < targetEffectCount && rand.nextDouble() < 0.5) {
             sps.orbitEffects.add(new SPSOrbitEffect(multiblock, state.center));
         }
+
+        Vec3 blockPosVec = Vec3.atLowerCornerOf(pos);
+
+        // Queue bolts as late FX
+        if (bolts.hasBoltsToRender()) {
+            LateEffectQueue.add((poseStack, bufferSource, camera, gameTime, partialTicks) -> {
+                poseStack.pushPose();
+                poseStack.translate(-blockPosVec.x, -blockPosVec.y, -blockPosVec.z);
+                bolts.render(gameTime, partialTicks, poseStack, bufferSource);
+                poseStack.popPose();
+                bufferSource.endBatch(MekanismRenderType.MEK_LIGHTNING);
+            });
+        }
+
+        // Queue core billboard as late FX
+        if (state.processed > 0 && state.center != null) {
+            CORE.setPos(state.center);
+            CORE.setScale(state.lerpEnergy(MIN_SCALE, MAX_SCALE));
+            LateEffectQueue.add((poseStack, bufferSource, camera, gameTime, partialTicks) -> {
+                poseStack.pushPose();
+                poseStack.translate(-blockPosVec.x, -blockPosVec.y, -blockPosVec.z);
+                BillboardingEffectRenderer.render(CORE, camera, bufferSource, poseStack, (int) gameTime, partialTicks);
+                poseStack.popPose();
+            });
+        }
+
+        // Queue orbit billboards as late FX
+        List<SPSOrbitEffect> orbitSnapshot = new ArrayList<>(sps.orbitEffects);
+        if (!orbitSnapshot.isEmpty()) {
+            LateEffectQueue.add((poseStack, bufferSource, camera, gameTime, partialTicks) -> {
+                poseStack.pushPose();
+                poseStack.translate(-blockPosVec.x, -blockPosVec.y, -blockPosVec.z);
+                for (SPSOrbitEffect effect : orbitSnapshot) {
+                    BillboardingEffectRenderer.render(effect, camera, bufferSource, poseStack, (int) gameTime, partialTicks);
+                }
+                poseStack.popPose();
+            });
+        }
     }
 
     @Override
     public void submit(SPSRenderState state, PoseStack poseStack, SubmitNodeCollector nodeCollector, CameraRenderState camera) {
-        //TODO - 26.1: Figure out how to render these things, should they potentially use the CustomGeometryRenderer thing?
-        // I think the billboarding effects might be able to use a model part, which then might let them be ordered properly in terms of transparency
-        //bolts.render(partialTick, poseStack, renderer);
-
-        poseStack.pushPose();
-        //Because our center points are the center of the multiblock, we translate back to 0,0,0
-        //TODO - 26.1: Test this is the proper way to handle that we used to shift the billboarding effect renderer by the camera position
-        // when we were batching rendering of billboarding effects
-        poseStack.translate(-state.blockPos.getX(), -state.blockPos.getY(), -state.blockPos.getZ());
-
-        if (state.processed > 0 && state.center != null) {
-            CORE.setPos(state.center);
-            CORE.setScale(state.lerpEnergy(MIN_SCALE, MAX_SCALE));
-            //BillboardingEffectRenderer.render(CORE, camera, renderer, poseStack, renderTick, partialTick);
-        }
-
-        /*for (SPSOrbitEffect effect : sps.orbitEffects) {
-            BillboardingEffectRenderer.render(effect, camera, renderer, poseStack, renderTick, partialTick);
-        }*/
-        poseStack.popPose();
+        // Geometric FX (bolts + billboards) are rendered as late effects via LateEffectQueue
+        // in RenderTickHandler.renderWorldAfterParticles(). No submit-time geometry needed.
     }
 
     private static BoltEffect getBoltFromData(CoilData data, BlockPos pos, Vec3 center) {

--- a/src/main/java/mekanism/client/render/tileentity/RenderSPS.java
+++ b/src/main/java/mekanism/client/render/tileentity/RenderSPS.java
@@ -96,7 +96,6 @@ public class RenderSPS extends MultiblockTileEntityRenderer<SPSMultiblockData, T
         if (sps.orbitEffects.size() > targetEffectCount) {
             sps.orbitEffects.poll();
         } else if (sps.orbitEffects.size() < targetEffectCount && rand.nextDouble() < 0.5) {
-            //TODO - 26.1: Do we want to just use the level's random instead?
             sps.orbitEffects.add(new SPSOrbitEffect(multiblock, state.center));
         }
     }
@@ -114,13 +113,11 @@ public class RenderSPS extends MultiblockTileEntityRenderer<SPSMultiblockData, T
         poseStack.translate(-state.blockPos.getX(), -state.blockPos.getY(), -state.blockPos.getZ());
 
         if (state.processed > 0 && state.center != null) {
-            //TODO - 26.1: ProfilerConstants.SPS_CORE ?
             CORE.setPos(state.center);
             CORE.setScale(state.lerpEnergy(MIN_SCALE, MAX_SCALE));
             //BillboardingEffectRenderer.render(CORE, camera, renderer, poseStack, renderTick, partialTick);
         }
 
-        //TODO - 26.1: ProfilerConstants.SPS_ORBIT ?
         /*for (SPSOrbitEffect effect : sps.orbitEffects) {
             BillboardingEffectRenderer.render(effect, camera, renderer, poseStack, renderTick, partialTick);
         }*/

--- a/src/main/java/mekanism/client/render/transmitter/RenderPressurizedTube.java
+++ b/src/main/java/mekanism/client/render/transmitter/RenderPressurizedTube.java
@@ -4,15 +4,19 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import mekanism.api.MekanismAPI;
 import mekanism.api.annotations.NothingNullByDefault;
 import mekanism.client.render.MekanismRenderer;
+import mekanism.client.render.RenderResizableCuboid;
 import mekanism.client.render.transmitter.TransmitterRenderState.TubeRenderState;
 import mekanism.common.base.ProfilerConstants;
 import mekanism.common.content.network.ChemicalNetwork;
 import mekanism.common.content.network.transmitter.PressurizedTube;
 import mekanism.common.tile.transmitter.TileEntityPressurizedTube;
+import net.minecraft.client.renderer.Sheets;
 import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
 import net.minecraft.client.renderer.feature.ModelFeatureRenderer;
 import net.minecraft.client.renderer.state.level.CameraRenderState;
+import net.minecraft.client.renderer.texture.OverlayTexture;
+import net.minecraft.util.LightCoordsUtil;
 import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.Nullable;
 
@@ -43,14 +47,21 @@ public class RenderPressurizedTube extends RenderTransmitterBase<TileEntityPress
 
     @Override
     public void submit(TubeRenderState state, PoseStack poseStack, SubmitNodeCollector nodeCollector, CameraRenderState camera) {
-        //todo - 26.1: rendering
-        /*if (state.chemicalTexture != null) {
-            poseStack.pushPose();
-            poseStack.translate(0.5, 0.5, 0.5);
-            renderModel(state, poseStack, renderer.getBuffer(Sheets.translucentCullBlockSheet()), state.chemicalTint, state.currentScale,
-                  LightCoordsUtil.FULL_BRIGHT, OverlayTexture.NO_OVERLAY, state.chemicalTexture);
-            poseStack.popPose();
-        }*/
+        if (state.chemicalTexture == null || state.currentScale <= 0) {
+            return;
+        }
+        int color = MekanismRenderer.getColorARGB(state.chemicalTint, state.currentScale);
+        float min = 0.3F;
+        float max = 0.7F;
+        RenderResizableCuboid.renderCube(
+              RenderResizableCuboid.SideRender.ALL_FACES,
+              min, min, min, max, max, max,
+              poseStack, Sheets.translucentBlockSheet(), nodeCollector,
+              color, LightCoordsUtil.FULL_BRIGHT, OverlayTexture.NO_OVERLAY,
+              RenderResizableCuboid.FaceDisplay.FRONT,
+              camera.pos, Vec3.atLowerCornerOf(state.blockPos),
+              MekanismRenderer.getSinglePicker(state.chemicalTexture)
+        );
     }
 
     @Override

--- a/src/main/java/mekanism/client/render/transmitter/RenderPressurizedTube.java
+++ b/src/main/java/mekanism/client/render/transmitter/RenderPressurizedTube.java
@@ -58,7 +58,7 @@ public class RenderPressurizedTube extends RenderTransmitterBase<TileEntityPress
               min, min, min, max, max, max,
               poseStack, Sheets.translucentBlockSheet(), nodeCollector,
               color, LightCoordsUtil.FULL_BRIGHT, OverlayTexture.NO_OVERLAY,
-              RenderResizableCuboid.FaceDisplay.FRONT,
+              RenderResizableCuboid.FaceDisplay.BOTH,
               camera.pos, Vec3.atLowerCornerOf(state.blockPos),
               MekanismRenderer.getSinglePicker(state.chemicalTexture)
         );

--- a/src/main/java/mekanism/client/render/transmitter/RenderThermodynamicConductor.java
+++ b/src/main/java/mekanism/client/render/transmitter/RenderThermodynamicConductor.java
@@ -53,7 +53,7 @@ public class RenderThermodynamicConductor extends RenderTransmitterBase<TileEnti
               min, min, min, max, max, max,
               poseStack, Sheets.translucentBlockSheet(), nodeCollector,
               state.tempColor, LightCoordsUtil.FULL_BRIGHT, OverlayTexture.NO_OVERLAY,
-              RenderResizableCuboid.FaceDisplay.FRONT,
+              RenderResizableCuboid.FaceDisplay.BOTH,
               camera.pos, Vec3.atLowerCornerOf(state.blockPos),
               MekanismRenderer.getSinglePicker(MekanismRenderer.heatIcon)
         );

--- a/src/main/java/mekanism/client/render/transmitter/RenderThermodynamicConductor.java
+++ b/src/main/java/mekanism/client/render/transmitter/RenderThermodynamicConductor.java
@@ -2,15 +2,21 @@ package mekanism.client.render.transmitter;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import mekanism.api.annotations.NothingNullByDefault;
+import mekanism.client.render.MekanismRenderer;
+import mekanism.client.render.RenderResizableCuboid;
 import mekanism.client.render.transmitter.TransmitterRenderState.ConductorRenderState;
 import mekanism.common.base.ProfilerConstants;
 import mekanism.common.content.network.transmitter.ThermodynamicConductor;
 import mekanism.common.tile.transmitter.TileEntityThermodynamicConductor;
 import mekanism.common.util.HeatUtils;
+import net.minecraft.client.renderer.Sheets;
 import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
 import net.minecraft.client.renderer.feature.ModelFeatureRenderer;
 import net.minecraft.client.renderer.state.level.CameraRenderState;
+import net.minecraft.client.renderer.texture.OverlayTexture;
+import net.minecraft.util.ARGB;
+import net.minecraft.util.LightCoordsUtil;
 import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.Nullable;
 
@@ -36,23 +42,21 @@ public class RenderThermodynamicConductor extends RenderTransmitterBase<TileEnti
 
     @Override
     public void submit(ConductorRenderState state, PoseStack poseStack, SubmitNodeCollector nodeCollector, CameraRenderState camera) {
-        poseStack.pushPose();
-        poseStack.translate(0.5, 0.5, 0.5);
-        //TODO - 26.1: What submit do we want to be using
-        /*nodeCollector.submitModelPart(
-              this.model,
-              poseStack,
-              //TODO - 26.1: Is this the correct render type to be using? It used to be translucent cull
-              RenderTypes.entityTranslucent(MekanismRenderer.heatIcon.contents().name()),
-              //TODO - 26.1: I believe in the past we used LightTexture.FULL_BRIGHT for the model box, check which looks better state.lightCoords
-              LightCoordsUtil.FULL_BRIGHT,
-              OverlayTexture.NO_OVERLAY,
-              //TODO - 26.1: Do we need to pass the texture here as well, or not?
-              MekanismRenderer.heatIcon,
-              state.tempColor,
-              state.breakProgress//TODO - 26.1: Should we be rendering the crumbling overlay here?
-        );*/
-        poseStack.popPose();
+        float alpha = ARGB.alphaFloat(state.tempColor);
+        if (alpha <= 0) {
+            return;
+        }
+        float min = 0.3F;
+        float max = 0.7F;
+        RenderResizableCuboid.renderCube(
+              RenderResizableCuboid.SideRender.ALL_FACES,
+              min, min, min, max, max, max,
+              poseStack, Sheets.translucentBlockSheet(), nodeCollector,
+              state.tempColor, LightCoordsUtil.FULL_BRIGHT, OverlayTexture.NO_OVERLAY,
+              RenderResizableCuboid.FaceDisplay.FRONT,
+              camera.pos, Vec3.atLowerCornerOf(state.blockPos),
+              MekanismRenderer.getSinglePicker(MekanismRenderer.heatIcon)
+        );
     }
 
     @Override

--- a/src/main/java/mekanism/client/render/transmitter/RenderUniversalCable.java
+++ b/src/main/java/mekanism/client/render/transmitter/RenderUniversalCable.java
@@ -55,7 +55,7 @@ public class RenderUniversalCable extends RenderTransmitterBase<TileEntityUniver
               min, min, min, max, max, max,
               poseStack, Sheets.translucentBlockSheet(), nodeCollector,
               color, LightCoordsUtil.FULL_BRIGHT, OverlayTexture.NO_OVERLAY,
-              RenderResizableCuboid.FaceDisplay.FRONT,
+              RenderResizableCuboid.FaceDisplay.BOTH,
               camera.pos, Vec3.atLowerCornerOf(state.blockPos),
               MekanismRenderer.getSinglePicker(MekanismRenderer.energyIcon)
         );

--- a/src/main/java/mekanism/client/render/transmitter/RenderUniversalCable.java
+++ b/src/main/java/mekanism/client/render/transmitter/RenderUniversalCable.java
@@ -2,15 +2,20 @@ package mekanism.client.render.transmitter;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import mekanism.api.annotations.NothingNullByDefault;
+import mekanism.client.render.MekanismRenderer;
+import mekanism.client.render.RenderResizableCuboid;
 import mekanism.client.render.transmitter.TransmitterRenderState.CableRenderState;
 import mekanism.common.base.ProfilerConstants;
 import mekanism.common.content.network.EnergyNetwork;
 import mekanism.common.content.network.transmitter.UniversalCable;
 import mekanism.common.tile.transmitter.TileEntityUniversalCable;
+import net.minecraft.client.renderer.Sheets;
 import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
 import net.minecraft.client.renderer.feature.ModelFeatureRenderer;
 import net.minecraft.client.renderer.state.level.CameraRenderState;
+import net.minecraft.client.renderer.texture.OverlayTexture;
+import net.minecraft.util.LightCoordsUtil;
 import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.Nullable;
 
@@ -39,16 +44,21 @@ public class RenderUniversalCable extends RenderTransmitterBase<TileEntityUniver
 
     @Override
     public void submit(CableRenderState state, PoseStack poseStack, SubmitNodeCollector nodeCollector, CameraRenderState camera) {
-        //TODO - 26.1: What threshold do we want to cut this off at?
-        //todo - 26.1: rendering
-        /*if (state.currentScale > 0) {
-            poseStack.pushPose();
-            poseStack.translate(0.5, 0.5, 0.5);
-            renderModel(state, poseStack, renderer.getBuffer(Sheets.translucentCullBlockSheet()), 0xFFFFFF, state.currentScale, LightCoordsUtil.FULL_BRIGHT,
-                  OverlayTexture.NO_OVERLAY, MekanismRenderer.energyIcon);
-
-            poseStack.popPose();
-        }*/
+        if (state.currentScale <= 0) {
+            return;
+        }
+        int color = MekanismRenderer.getColorARGB(0xFFFFFF, state.currentScale);
+        float min = 0.3F;
+        float max = 0.7F;
+        RenderResizableCuboid.renderCube(
+              RenderResizableCuboid.SideRender.ALL_FACES,
+              min, min, min, max, max, max,
+              poseStack, Sheets.translucentBlockSheet(), nodeCollector,
+              color, LightCoordsUtil.FULL_BRIGHT, OverlayTexture.NO_OVERLAY,
+              RenderResizableCuboid.FaceDisplay.FRONT,
+              camera.pos, Vec3.atLowerCornerOf(state.blockPos),
+              MekanismRenderer.getSinglePicker(MekanismRenderer.energyIcon)
+        );
     }
 
     @Override

--- a/src/main/java/mekanism/common/recipe/lookup/cache/type/ItemInputCache.java
+++ b/src/main/java/mekanism/common/recipe/lookup/cache/type/ItemInputCache.java
@@ -27,13 +27,7 @@ public class ItemInputCache<RECIPE extends MekanismRecipe<?>> extends ComponentS
     }
 
     private boolean mapIngredient(RECIPE recipe, Ingredient input) {
-        if (input.isSimple()) {
-            //Simple ingredients don't actually check anything related to NBT,
-            // so we can add the items to our base/raw input cache directly
-            for (Holder<Item> item : input.getValues()) {
-                addInputCache(item.value(), recipe);
-            }
-        } else if (input.getCustomIngredient() instanceof CompoundIngredient(List<Ingredient> children)) {
+        if (input.getCustomIngredient() instanceof CompoundIngredient(List<Ingredient> children)) {
             //Special handling for neo's compound ingredient to map all children as best as we can
             // as maybe some of them are simple
             boolean result = false;
@@ -47,9 +41,18 @@ public class ItemInputCache<RECIPE extends MekanismRecipe<?>> extends ComponentS
             for (Holder<Item> holder : componentIngredient.itemSet()) {
                 addNbtInputCache(holder, components, recipe);
             }
+        } else if (input.getCustomIngredient() != null) {
+            //Other custom ingredients cannot be expanded via Ingredient#getValues in 26.1,
+            // so we fall back to the complex recipe path and test them on demand.
+            return true;
+        } else if (input.isSimple()) {
+            //Simple ingredients don't actually check anything related to NBT,
+            // so we can add the items to our base/raw input cache directly
+            for (Holder<Item> item : input.getValues()) {
+                addInputCache(item.value(), recipe);
+            }
         } else {
-            //Else it is a custom ingredient, so we don't have a great way of handling it using the normal extraction checks
-            // and instead have to just mark it as complex and test as needed
+            //Non-simple ingredients without a dedicated mapping path are treated as complex and tested on demand.
             return true;
         }
         return false;

--- a/src/main/resources/assets/mekanism/models/item/advanced_bin.json
+++ b/src/main/resources/assets/mekanism/models/item/advanced_bin.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/bin/advanced"
+}

--- a/src/main/resources/assets/mekanism/models/item/advanced_chemical_tank.json
+++ b/src/main/resources/assets/mekanism/models/item/advanced_chemical_tank.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/chemical_tank/advanced"
+}

--- a/src/main/resources/assets/mekanism/models/item/advanced_combining_factory.json
+++ b/src/main/resources/assets/mekanism/models/item/advanced_combining_factory.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/factory/combining/advanced"
+}

--- a/src/main/resources/assets/mekanism/models/item/advanced_compressing_factory.json
+++ b/src/main/resources/assets/mekanism/models/item/advanced_compressing_factory.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/factory/compressing/advanced"
+}

--- a/src/main/resources/assets/mekanism/models/item/advanced_crushing_factory.json
+++ b/src/main/resources/assets/mekanism/models/item/advanced_crushing_factory.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/factory/crushing/advanced"
+}

--- a/src/main/resources/assets/mekanism/models/item/advanced_enriching_factory.json
+++ b/src/main/resources/assets/mekanism/models/item/advanced_enriching_factory.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/factory/enriching/advanced"
+}

--- a/src/main/resources/assets/mekanism/models/item/advanced_induction_cell.json
+++ b/src/main/resources/assets/mekanism/models/item/advanced_induction_cell.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/induction/cell/advanced"
+}

--- a/src/main/resources/assets/mekanism/models/item/advanced_induction_provider.json
+++ b/src/main/resources/assets/mekanism/models/item/advanced_induction_provider.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/induction/provider/advanced"
+}

--- a/src/main/resources/assets/mekanism/models/item/advanced_infusing_factory.json
+++ b/src/main/resources/assets/mekanism/models/item/advanced_infusing_factory.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/factory/infusing/advanced"
+}

--- a/src/main/resources/assets/mekanism/models/item/advanced_injecting_factory.json
+++ b/src/main/resources/assets/mekanism/models/item/advanced_injecting_factory.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/factory/injecting/advanced"
+}

--- a/src/main/resources/assets/mekanism/models/item/advanced_purifying_factory.json
+++ b/src/main/resources/assets/mekanism/models/item/advanced_purifying_factory.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/factory/purifying/advanced"
+}

--- a/src/main/resources/assets/mekanism/models/item/advanced_sawing_factory.json
+++ b/src/main/resources/assets/mekanism/models/item/advanced_sawing_factory.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/factory/sawing/advanced"
+}

--- a/src/main/resources/assets/mekanism/models/item/advanced_smelting_factory.json
+++ b/src/main/resources/assets/mekanism/models/item/advanced_smelting_factory.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/factory/smelting/advanced"
+}

--- a/src/main/resources/assets/mekanism/models/item/basic_bin.json
+++ b/src/main/resources/assets/mekanism/models/item/basic_bin.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/bin/basic"
+}

--- a/src/main/resources/assets/mekanism/models/item/basic_chemical_tank.json
+++ b/src/main/resources/assets/mekanism/models/item/basic_chemical_tank.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/chemical_tank/basic"
+}

--- a/src/main/resources/assets/mekanism/models/item/basic_combining_factory.json
+++ b/src/main/resources/assets/mekanism/models/item/basic_combining_factory.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/factory/combining/basic"
+}

--- a/src/main/resources/assets/mekanism/models/item/basic_compressing_factory.json
+++ b/src/main/resources/assets/mekanism/models/item/basic_compressing_factory.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/factory/compressing/basic"
+}

--- a/src/main/resources/assets/mekanism/models/item/basic_crushing_factory.json
+++ b/src/main/resources/assets/mekanism/models/item/basic_crushing_factory.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/factory/crushing/basic"
+}

--- a/src/main/resources/assets/mekanism/models/item/basic_enriching_factory.json
+++ b/src/main/resources/assets/mekanism/models/item/basic_enriching_factory.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/factory/enriching/basic"
+}

--- a/src/main/resources/assets/mekanism/models/item/basic_induction_cell.json
+++ b/src/main/resources/assets/mekanism/models/item/basic_induction_cell.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/induction/cell/basic"
+}

--- a/src/main/resources/assets/mekanism/models/item/basic_induction_provider.json
+++ b/src/main/resources/assets/mekanism/models/item/basic_induction_provider.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/induction/provider/basic"
+}

--- a/src/main/resources/assets/mekanism/models/item/basic_infusing_factory.json
+++ b/src/main/resources/assets/mekanism/models/item/basic_infusing_factory.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/factory/infusing/basic"
+}

--- a/src/main/resources/assets/mekanism/models/item/basic_injecting_factory.json
+++ b/src/main/resources/assets/mekanism/models/item/basic_injecting_factory.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/factory/injecting/basic"
+}

--- a/src/main/resources/assets/mekanism/models/item/basic_purifying_factory.json
+++ b/src/main/resources/assets/mekanism/models/item/basic_purifying_factory.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/factory/purifying/basic"
+}

--- a/src/main/resources/assets/mekanism/models/item/basic_sawing_factory.json
+++ b/src/main/resources/assets/mekanism/models/item/basic_sawing_factory.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/factory/sawing/basic"
+}

--- a/src/main/resources/assets/mekanism/models/item/basic_smelting_factory.json
+++ b/src/main/resources/assets/mekanism/models/item/basic_smelting_factory.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/factory/smelting/basic"
+}

--- a/src/main/resources/assets/mekanism/models/item/block_bio_fuel.json
+++ b/src/main/resources/assets/mekanism/models/item/block_bio_fuel.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/storage/bio_fuel"
+}

--- a/src/main/resources/assets/mekanism/models/item/block_bronze.json
+++ b/src/main/resources/assets/mekanism/models/item/block_bronze.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/storage/bronze"
+}

--- a/src/main/resources/assets/mekanism/models/item/block_charcoal.json
+++ b/src/main/resources/assets/mekanism/models/item/block_charcoal.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/storage/charcoal"
+}

--- a/src/main/resources/assets/mekanism/models/item/block_fluorite.json
+++ b/src/main/resources/assets/mekanism/models/item/block_fluorite.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/storage/fluorite"
+}

--- a/src/main/resources/assets/mekanism/models/item/block_refined_glowstone.json
+++ b/src/main/resources/assets/mekanism/models/item/block_refined_glowstone.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/storage/refined_glowstone"
+}

--- a/src/main/resources/assets/mekanism/models/item/block_refined_obsidian.json
+++ b/src/main/resources/assets/mekanism/models/item/block_refined_obsidian.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/storage/refined_obsidian"
+}

--- a/src/main/resources/assets/mekanism/models/item/block_salt.json
+++ b/src/main/resources/assets/mekanism/models/item/block_salt.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/storage/salt"
+}

--- a/src/main/resources/assets/mekanism/models/item/block_steel.json
+++ b/src/main/resources/assets/mekanism/models/item/block_steel.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/storage/steel"
+}

--- a/src/main/resources/assets/mekanism/models/item/boiler_valve.json
+++ b/src/main/resources/assets/mekanism/models/item/boiler_valve.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/boiler_valve_input"
+}

--- a/src/main/resources/assets/mekanism/models/item/cardboard_box.json
+++ b/src/main/resources/assets/mekanism/models/item/cardboard_box.json
@@ -1,0 +1,11 @@
+{
+  "parent": "mekanism:block/cardboard_box",
+  "overrides": [
+    {
+      "predicate": {
+        "mekanism:storage": 1
+      },
+      "model": "mekanism:item/cardboard_box_storage"
+    }
+  ]
+}

--- a/src/main/resources/assets/mekanism/models/item/cardboard_box_storage.json
+++ b/src/main/resources/assets/mekanism/models/item/cardboard_box_storage.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/cardboard_box_storage"
+}

--- a/src/main/resources/assets/mekanism/models/item/creative_bin.json
+++ b/src/main/resources/assets/mekanism/models/item/creative_bin.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/bin/creative"
+}

--- a/src/main/resources/assets/mekanism/models/item/creative_chemical_tank.json
+++ b/src/main/resources/assets/mekanism/models/item/creative_chemical_tank.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/chemical_tank/creative"
+}

--- a/src/main/resources/assets/mekanism/models/item/electric_bow.json
+++ b/src/main/resources/assets/mekanism/models/item/electric_bow.json
@@ -2,5 +2,26 @@
     "parent": "item/bow",
     "textures": { 
         "layer0": "mekanism:item/electric_bow"
-    }
+    },
+    "overrides": [
+    {
+        "predicate": {
+            "mekanism:pulling": 1
+        },
+        "model": "mekanism:item/electric_bow_pulling_0"
+    },
+    {
+        "predicate": {
+            "mekanism:pulling": 1,
+            "mekanism:pull": 0.65
+        },
+        "model": "mekanism:item/electric_bow_pulling_1"
+    },
+    {
+        "predicate": {
+            "mekanism:pulling": 1,
+            "mekanism:pull": 0.9
+        },
+        "model": "mekanism:item/electric_bow_pulling_2"
+    }]
 }

--- a/src/main/resources/assets/mekanism/models/item/elite_bin.json
+++ b/src/main/resources/assets/mekanism/models/item/elite_bin.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/bin/elite"
+}

--- a/src/main/resources/assets/mekanism/models/item/elite_chemical_tank.json
+++ b/src/main/resources/assets/mekanism/models/item/elite_chemical_tank.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/chemical_tank/elite"
+}

--- a/src/main/resources/assets/mekanism/models/item/elite_combining_factory.json
+++ b/src/main/resources/assets/mekanism/models/item/elite_combining_factory.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/factory/combining/elite"
+}

--- a/src/main/resources/assets/mekanism/models/item/elite_compressing_factory.json
+++ b/src/main/resources/assets/mekanism/models/item/elite_compressing_factory.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/factory/compressing/elite"
+}

--- a/src/main/resources/assets/mekanism/models/item/elite_crushing_factory.json
+++ b/src/main/resources/assets/mekanism/models/item/elite_crushing_factory.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/factory/crushing/elite"
+}

--- a/src/main/resources/assets/mekanism/models/item/elite_enriching_factory.json
+++ b/src/main/resources/assets/mekanism/models/item/elite_enriching_factory.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/factory/enriching/elite"
+}

--- a/src/main/resources/assets/mekanism/models/item/elite_induction_cell.json
+++ b/src/main/resources/assets/mekanism/models/item/elite_induction_cell.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/induction/cell/elite"
+}

--- a/src/main/resources/assets/mekanism/models/item/elite_induction_provider.json
+++ b/src/main/resources/assets/mekanism/models/item/elite_induction_provider.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/induction/provider/elite"
+}

--- a/src/main/resources/assets/mekanism/models/item/elite_infusing_factory.json
+++ b/src/main/resources/assets/mekanism/models/item/elite_infusing_factory.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/factory/infusing/elite"
+}

--- a/src/main/resources/assets/mekanism/models/item/elite_injecting_factory.json
+++ b/src/main/resources/assets/mekanism/models/item/elite_injecting_factory.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/factory/injecting/elite"
+}

--- a/src/main/resources/assets/mekanism/models/item/elite_purifying_factory.json
+++ b/src/main/resources/assets/mekanism/models/item/elite_purifying_factory.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/factory/purifying/elite"
+}

--- a/src/main/resources/assets/mekanism/models/item/elite_sawing_factory.json
+++ b/src/main/resources/assets/mekanism/models/item/elite_sawing_factory.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/factory/sawing/elite"
+}

--- a/src/main/resources/assets/mekanism/models/item/elite_smelting_factory.json
+++ b/src/main/resources/assets/mekanism/models/item/elite_smelting_factory.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/factory/smelting/elite"
+}

--- a/src/main/resources/assets/mekanism/models/item/hdpe_broken_elytra.json
+++ b/src/main/resources/assets/mekanism/models/item/hdpe_broken_elytra.json
@@ -1,0 +1,6 @@
+{
+    "parent": "minecraft:item/generated",
+    "textures": { 
+        "layer0": "mekanism:item/hdpe_broken_elytra"
+    }
+}

--- a/src/main/resources/assets/mekanism/models/item/induction_casing.json
+++ b/src/main/resources/assets/mekanism/models/item/induction_casing.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/induction/casing"
+}

--- a/src/main/resources/assets/mekanism/models/item/induction_port.json
+++ b/src/main/resources/assets/mekanism/models/item/induction_port.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/induction/port"
+}

--- a/src/main/resources/assets/mekanism/models/item/qio_redstone_adapter.json
+++ b/src/main/resources/assets/mekanism/models/item/qio_redstone_adapter.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/qio_redstone_adapter_unlit"
+}

--- a/src/main/resources/assets/mekanism/models/item/thermal_evaporation_block.json
+++ b/src/main/resources/assets/mekanism/models/item/thermal_evaporation_block.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/thermal_evaporation/block"
+}

--- a/src/main/resources/assets/mekanism/models/item/thermal_evaporation_controller.json
+++ b/src/main/resources/assets/mekanism/models/item/thermal_evaporation_controller.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/thermal_evaporation/controller"
+}

--- a/src/main/resources/assets/mekanism/models/item/thermal_evaporation_valve.json
+++ b/src/main/resources/assets/mekanism/models/item/thermal_evaporation_valve.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/thermal_evaporation/valve"
+}

--- a/src/main/resources/assets/mekanism/models/item/ultimate_bin.json
+++ b/src/main/resources/assets/mekanism/models/item/ultimate_bin.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/bin/ultimate"
+}

--- a/src/main/resources/assets/mekanism/models/item/ultimate_chemical_tank.json
+++ b/src/main/resources/assets/mekanism/models/item/ultimate_chemical_tank.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/chemical_tank/ultimate"
+}

--- a/src/main/resources/assets/mekanism/models/item/ultimate_combining_factory.json
+++ b/src/main/resources/assets/mekanism/models/item/ultimate_combining_factory.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/factory/combining/ultimate"
+}

--- a/src/main/resources/assets/mekanism/models/item/ultimate_compressing_factory.json
+++ b/src/main/resources/assets/mekanism/models/item/ultimate_compressing_factory.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/factory/compressing/ultimate"
+}

--- a/src/main/resources/assets/mekanism/models/item/ultimate_crushing_factory.json
+++ b/src/main/resources/assets/mekanism/models/item/ultimate_crushing_factory.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/factory/crushing/ultimate"
+}

--- a/src/main/resources/assets/mekanism/models/item/ultimate_enriching_factory.json
+++ b/src/main/resources/assets/mekanism/models/item/ultimate_enriching_factory.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/factory/enriching/ultimate"
+}

--- a/src/main/resources/assets/mekanism/models/item/ultimate_induction_cell.json
+++ b/src/main/resources/assets/mekanism/models/item/ultimate_induction_cell.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/induction/cell/ultimate"
+}

--- a/src/main/resources/assets/mekanism/models/item/ultimate_induction_provider.json
+++ b/src/main/resources/assets/mekanism/models/item/ultimate_induction_provider.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/induction/provider/ultimate"
+}

--- a/src/main/resources/assets/mekanism/models/item/ultimate_infusing_factory.json
+++ b/src/main/resources/assets/mekanism/models/item/ultimate_infusing_factory.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/factory/infusing/ultimate"
+}

--- a/src/main/resources/assets/mekanism/models/item/ultimate_injecting_factory.json
+++ b/src/main/resources/assets/mekanism/models/item/ultimate_injecting_factory.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/factory/injecting/ultimate"
+}

--- a/src/main/resources/assets/mekanism/models/item/ultimate_purifying_factory.json
+++ b/src/main/resources/assets/mekanism/models/item/ultimate_purifying_factory.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/factory/purifying/ultimate"
+}

--- a/src/main/resources/assets/mekanism/models/item/ultimate_sawing_factory.json
+++ b/src/main/resources/assets/mekanism/models/item/ultimate_sawing_factory.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/factory/sawing/ultimate"
+}

--- a/src/main/resources/assets/mekanism/models/item/ultimate_smelting_factory.json
+++ b/src/main/resources/assets/mekanism/models/item/ultimate_smelting_factory.json
@@ -1,0 +1,3 @@
+{
+  "parent": "mekanism:block/factory/smelting/ultimate"
+}


### PR DESCRIPTION
- Update JEI to 29.6.2.31 (NeoForge 26.1 compatible)
- Remove obsolete commented-out fluid model code from GeneratorsClientRegistration (superseded by RegisterFluidModelsEvent)
- Restore 22 missing generator item model JSONs
- Restore ~67 missing main mod item model JSONs (bins, factories, chemical tanks, induction cells/providers, boilers, etc.)
- Remove 26 duplicate item models that clashed with datagen
- Fix electric_bow.json overrides for pulling animation
- Fix BoltRenderer: replace null buffer with MekanismRenderType.MEK_LIGHTNING
- Re-enable global bolt rendering in RenderTickHandler (RenderLevelStageEvent.AfterTranslucentParticles)
- Clean resolved TODOs from RenderBin, RenderEnergyCube, RenderSPS, MultiLineTooltip, and RenderPersonalChest
- Restore crumble-related TODOs in RenderIndustrialAlarm and RenderSeismicVibrator as they indicate actual visual bugs
- Update GuiAntiprotonicNucleosynthesizer TODO to document why GUI custom 3D rendering is blocked in 26.1 (Matrix3x2fStack, no bufferSource)
