### PR TITLE
Fix client-side NPE when placing blocks connected to a remote server

### DIFF
--- a/src/main/java/mekanism/common/lib/frequency/TileComponentFrequency.java
+++ b/src/main/java/mekanism/common/lib/frequency/TileComponentFrequency.java
@@ -150,7 +150,10 @@ public class TileComponentFrequency implements ITileComponent {
     }
 
     public <FREQ extends Frequency> void setFrequencyFromData(FrequencyType<FREQ> type, FrequencyIdentity data, UUID player) {
-        if (player != null) {
+        //Frequency controllers only exist server-side (FrequencyControllerManager#serverLoad), so getController() is null on
+        // the client. Block placement (BlockMekanism#setPlacedBy -> setOwnerUUID) and applyImplicitComponents both run on the
+        // client too; skip there to avoid an NPE. The client receives owner/frequency state via sync instead.
+        if (player != null && !tile.isRemote()) {
             FrequencyData frequencyData = getFrequencyData(type);
             if (frequencyData != null) {
                 setFrequencyFromData(type, data, player, frequencyData);


### PR DESCRIPTION
## Changes proposed in this pull request:
- Guard the public `TileComponentFrequency#setFrequencyFromData` with `!tile.isRemote()` so a client no longer tries to access server-only frequency controllers when a block is placed.

### The bug
On a remote client (multiplayer, connecting to a dedicated/hosted server), placing **any** Mekanism machine crashes the client:

```
java.lang.NullPointerException: Cannot invoke "mekanism.common.lib.frequency.FrequencyController.getPublicLookup()" because the return value of "mekanism.common.lib.frequency.FrequencyType.getController()" is null
    at mekanism.common.lib.frequency.FrequencyType.getLookup(FrequencyType.java:116)
    at mekanism.common.lib.frequency.TileComponentFrequency.setFrequencyFromData(TileComponentFrequency.java:175)
    at mekanism.common.lib.frequency.TileComponentFrequency.setFrequencyFromData(TileComponentFrequency.java:156)
    at mekanism.common.lib.frequency.IFrequencyHandler.setFrequency(IFrequencyHandler.java:19)
    at mekanism.common.tile.component.TileComponentSecurity.setOwnerUUID(TileComponentSecurity.java:58)
    at mekanism.common.lib.security.ISecurityTile.setOwnerUUID(ISecurityTile.java:51)
    at mekanism.common.block.BlockMekanism.setPlacedBy(BlockMekanism.java:159)
```

### Root cause
`FrequencyControllerManager` only populates its `controllers` map in `serverLoad(MinecraftServer)`, so `FrequencyType#getController()` is `null` on a client that is not running an integrated server. `BlockMekanism#setPlacedBy` calls `securityTile.setOwnerUUID(placer.getUUID())` on both logical sides (only the follow-up `PacketSyncSecurity` is guarded by `!world.isClientSide()`), so the client walks `setOwnerUUID -> setFrequency -> setFrequencyFromData -> FrequencyType#getLookup`, dereferences the null controller and crashes. This lines up with the existing `//TODO - 26.1 - does this even get called on the client? seems not` note in `FrequencyControllerManager#createLookup`. The same path is also reachable from `TileComponentSecurity#applyImplicitComponents`.

In singleplayer the integrated server populates the controllers in the same process, so the crash only manifests for a remote client.

### Fix
Skip the controller-backed frequency logic on the client in the public `setFrequencyFromData`; the client receives owner/frequency state via sync. This is the single chokepoint shared by both `setPlacedBy` and `applyImplicitComponents`. The only other `getController()` caller, `updateFrequency`, is reached exclusively from `tickServer`, so it is unaffected.

### Testing
Built against the `26.1` branch and verified on a dedicated-server setup (one host + one remote client): before the change the client crashed every time it placed a Mekanism machine; after the change placement works and ownership/security syncs to the client correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
