### PR TITLE
Fix Free Runners lookup in `CommonPlayerTickHandler`

### DIFF
--- a/src/main/java/mekanism/common/CommonPlayerTickHandler.java
+++ b/src/main/java/mekanism/common/CommonPlayerTickHandler.java
@@ -73,18 +73,22 @@ public class CommonPlayerTickHandler {
         if (player.isShiftKeyDown()) {
             return 0;
         }
-        ItemStack stack = player.getItemBySlot(EquipmentSlot.FEET);
+        
+        ItemStack stack = IFreeRunnerItem.getPrimaryFreeRunners(player);
+
         if (stack.isEmpty()) {
             return 0;
         }
+        
         IModule<ModuleHydraulicPropulsionUnit> hydraulic = IModuleHelper.INSTANCE.getIfEnabled(stack, MekanismModules.HYDRAULIC_PROPULSION_UNIT);
         if (hydraulic != null) {
             return hydraulic.getCustomInstance().getStepHeight();
         }
-        ItemStack primaryFreeRunners = IFreeRunnerItem.getPrimaryFreeRunners(player);
-        if (!primaryFreeRunners.isEmpty() && ((IFreeRunnerItem) primaryFreeRunners.getItem()).getFreeRunnerMode(primaryFreeRunners).providesStepBoost()) {
+
+        if (((IFreeRunnerItem) stack.getItem()).getFreeRunnerMode(stack).providesStepBoost()) {
             return 0.5F;
         }
+        
         return 0;
     }
 


### PR DESCRIPTION
## Changes proposed in this pull request:
Currently, `mekanism.common.CommonPlayerTickHandler.getStepBoost` tries to get the item currently equipped in the `FEET` slot and short-circuits if there's none. This causes the new, interface-based logic from `IFreeRunnerItem.getPrimaryFreeRunners` to be skipped, so Free Runners in the Curios slot don't work when there's nothing in the normal feet slot.

This PR replaces the current `getItemBySlot` call with `IFreeRunnerItem.getPrimaryFreeRunners` and reuses the result when checking the free-running mode at the end. 