### PR TITLE
Relocate BlockBounding removal code to TileEntityBoundingBlock

### DIFF
--- a/src/main/java/mekanism/common/block/BlockBounding.java
+++ b/src/main/java/mekanism/common/block/BlockBounding.java
@@ -125,23 +125,6 @@ public class BlockBounding extends Block implements IHasTileEntity<TileEntityBou
         return new BlockHitResult(location, hit.getDirection(), mainPos, hit.isInside());
     }
 
-    //TODO - 26.2: onRemove @Override
-    protected void onRemove(BlockState state, Level world, BlockPos pos, BlockState newState, boolean isMoving) {
-        //Remove the main block if a bounding block gets broken by being directly replaced
-        // Note: We only do this if we don't go from bounding block to bounding block
-        if (!state.is(newState.getBlock())) {
-            BlockPos mainPos = getMainBlockPos(world, pos);
-            if (mainPos != null) {
-                BlockState mainState = world.getBlockState(mainPos);
-                if (!mainState.isAir()) {
-                    //Set the main block to air, which will invalidate the rest of the bounding blocks
-                    world.removeBlock(mainPos, false);
-                }
-            }
-            //TODO - 26.2: super.onRemove(state, world, pos, newState, isMoving);
-        }
-    }
-
     /// {@inheritDoc}
     ///
     /// Delegate to main [Block#getCloneItemStack(LevelReader, BlockPos, BlockState, boolean, Player)].

--- a/src/main/java/mekanism/common/tile/TileEntityBoundingBlock.java
+++ b/src/main/java/mekanism/common/tile/TileEntityBoundingBlock.java
@@ -74,6 +74,19 @@ public class TileEntityBoundingBlock extends TileEntityUpdateable implements IUp
     }
 
     @Override
+    public void preRemoveSideEffects(BlockPos pos, BlockState state) {
+        //Remove the main block if a bounding block gets broken by being directly replaced
+        if (level != null && mainPos != null) {
+            BlockState mainState = level.getBlockState(mainPos);
+            if (!mainState.isAir()) {
+                //Set the main block to air, which will invalidate the rest of the bounding blocks
+                level.removeBlock(mainPos, false);
+            }
+        }
+        super.preRemoveSideEffects(pos, state);
+    }
+
+    @Override
     public boolean triggerEvent(int id, int param) {
         boolean handled = super.triggerEvent(id, param);
         IBoundingBlock main = getMain();


### PR DESCRIPTION
## Changes proposed in this pull request:
- Remove the unused method `BlockBounding::onRemove` which is superseded by `TileEntityBoundingBlock::preRemoveSideEffects`.