### PR TITLE
fix: multiple bugfixes and NeoForge version bump for 26.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,11 +7,11 @@ minecraft_version=26.2
 major_minecraft_version=26.2
 previous_minecraft_version=1.21.1
 previous_minor_minecraft_version=26.1.2
-neo_version=26.2.0.18-beta
+neo_version=26.2.0.23-beta
 mod_version=10.8.0
 #This determines the minimum version of forge required to use Mekanism
 # Only bump it whenever we need access to a feature in forge that is not available in earlier versions
-neo_version_range=[26.2.0.18-beta,)
+neo_version_range=[26.2.0.23-beta,)
 minecraft_version_range=[26.2,26.3)
 #This specifies what type of release it will be uploaded to CurseForge and Modrinth as
 # options are: alpha, beta, release

--- a/src/api/java/mekanism/api/recipes/ingredients/ItemStackIngredient.java
+++ b/src/api/java/mekanism/api/recipes/ingredients/ItemStackIngredient.java
@@ -70,12 +70,8 @@ public final class ItemStackIngredient implements InputIngredient<Item, ItemStac
     public boolean testType(TypedInstance<Item> instance) {
         Objects.requireNonNull(instance);
         Ingredient vanillaIngredient = ingredient.ingredient();
-        if (vanillaIngredient.isCustom()) {
-            //Component data might be necessary, make it into a stack and test it
-            return vanillaIngredient.test(IngredientCreatorAccess.item().createStack(instance));
-        }
-        //Vanilla ingredients don't need to check component data so we can just skip converting the resource to a stack
-        return vanillaIngredient.acceptsItem(instance.typeHolder());
+        //Component data might be necessary, make it into a stack and test it
+        return vanillaIngredient.test(IngredientCreatorAccess.item().createStack(instance));
     }
 
     @Override

--- a/src/main/java/mekanism/client/ClientTickHandler.java
+++ b/src/main/java/mekanism/client/ClientTickHandler.java
@@ -80,20 +80,13 @@ public class ClientTickHandler {
                 return false;
             }
             JetpackMode mode = ((IJetpackItem) jetpackType.getItem()).getJetpackMode(jetpackType);
-            boolean guiOpen = minecraft.gui.screen() != null;
-            boolean ascending = player.input.keyPresses.jump();
-            boolean rising = ascending && !guiOpen;
-            if (mode == JetpackMode.NORMAL || mode == JetpackMode.VECTOR) {
-                return rising;
-            } else if (mode == JetpackMode.HOVER) {
-                boolean descending = player.input.keyPresses.shift();
-                if (!rising || descending) {
-                    return !CommonPlayerTickHandler.isOnGroundOrSleeping(player);
-                }
-                return true;
-            }
+            return IJetpackItem.getPlayerJetpackMode(player, mode, ClientTickHandler::isAscending) != JetpackMode.DISABLED;
         }
         return false;
+    }
+
+    private static boolean isAscending(LocalPlayer player) {
+        return minecraft.gui.screen() == null && player.input.keyPresses.jump();
     }
 
     public static boolean isScubaMaskOn(Player player) {
@@ -188,11 +181,11 @@ public class ClientTickHandler {
             ItemResource primaryJetpack = IJetpackItem.getPrimaryJetpack(minecraft.player);
             if (!primaryJetpack.isEmpty()) {
                 JetpackMode primaryMode = ((IJetpackItem) primaryJetpack.getItem()).getJetpackMode(primaryJetpack);
-                JetpackMode mode = IJetpackItem.getPlayerJetpackMode(minecraft.player, primaryMode, p -> p.input.keyPresses.jump());
-                MekanismClient.updateKey(minecraft.player.input.keyPresses.jump(), KeySync.ASCEND);
+                JetpackMode mode = IJetpackItem.getPlayerJetpackMode(minecraft.player, primaryMode, ClientTickHandler::isAscending);
+                MekanismClient.updateKey(isAscending(minecraft.player), KeySync.ASCEND);
                 try (Transaction simulation = Transaction.openRoot()) {
                     double jetpackThrust = ((IJetpackItem) jetpack.getResource().getItem()).useJetpackFuel(registryAccess, jetpack, primaryJetpack, simulation);
-                    if (jetpackThrust > 0 && jetpackInUse && IJetpackItem.handleJetpackMotion(minecraft.player, mode, jetpackThrust, p -> p.input.keyPresses.jump())) {
+                    if (jetpackThrust > 0 && jetpackInUse && IJetpackItem.handleJetpackMotion(minecraft.player, mode, jetpackThrust, ClientTickHandler::isAscending)) {
                         minecraft.player.resetFallDistance();
                     }
                 }

--- a/src/main/java/mekanism/common/block/BlockMekanism.java
+++ b/src/main/java/mekanism/common/block/BlockMekanism.java
@@ -158,13 +158,11 @@ public abstract class BlockMekanism extends Block {
             //Note: We call onAdded here rather than in onPlace so that we make sure we can run any client side code and that the
             // tile is present
             tile.onAdded(world);
-            if (tile instanceof ISecurityTile securityTile && securityTile.getOwnerUUID() == null && placer != null) {
+            if (!world.isClientSide() && tile instanceof ISecurityTile securityTile && securityTile.getOwnerUUID() == null && placer != null) {
                 //There was no stored owner that got set, use the placer's id
                 securityTile.setOwnerUUID(placer.getUUID(), null);
-                if (!world.isClientSide()) {
-                    //If the machine doesn't already have an owner, make sure we portray this
-                    PacketDistributor.sendToAllPlayers(new PacketSyncSecurity(placer.getUUID()));
-                }
+                //If the machine doesn't already have an owner, make sure we portray this
+                PacketDistributor.sendToAllPlayers(new PacketSyncSecurity(placer.getUUID()));
             }
         }
     }

--- a/src/main/java/mekanism/common/content/network/transmitter/UniversalCable.java
+++ b/src/main/java/mekanism/common/content/network/transmitter/UniversalCable.java
@@ -178,12 +178,11 @@ public class UniversalCable extends BufferedTransmitter<EnergyHandler, EnergyNet
         if (hasTransmitterNetwork()) {
             EnergyNetwork transmitterNetwork = getTransmitterNetworkNN();
             if (!transmitterNetwork.energyContainer.isEmpty() && saveShareJournal.saveShare > 0) {
-                //TODO: I believe I fixed the save share distribution bug that caused this to be necessary. If this comes back up look into it again
-                // or reinstate the clamping
+                long networkEnergy = transmitterNetwork.energyContainer.getAmountAsLong();
                 //Clamp the value so that we can't error if the network's energy is less than the amount we are saving
-                //saveShareJournal.saveShare = Math.min(transmitterNetwork.energyContainer.getAmountAsLong(), saveShareJournal.saveShare);
-                transmitterNetwork.energyContainer.setEnergy(transmitterNetwork.energyContainer.getAmountAsLong() - saveShareJournal.saveShare, transaction);
-                buffer.setEnergy(saveShareJournal.saveShare, transaction);
+                long saveShare = Math.min(networkEnergy, saveShareJournal.saveShare);
+                transmitterNetwork.energyContainer.setEnergy(networkEnergy - saveShare, transaction);
+                buffer.setEnergy(saveShare, transaction);
             }
         }
     }

--- a/src/main/java/mekanism/common/lib/frequency/FrequencyType.java
+++ b/src/main/java/mekanism/common/lib/frequency/FrequencyType.java
@@ -90,10 +90,14 @@ public class FrequencyType<FREQ extends Frequency> {
 
     @Nullable
     public FrequencyLookup<FREQ> getLookup(@Nullable UUID owner, SecurityMode securityMode) {
+        FrequencyController<FREQ> controller = getController();
+        if (controller == null) {
+            return null;
+        }
         return switch (securityMode) {
-            case PUBLIC -> getController().getPublicLookup();
-            case PRIVATE -> getController().getPrivateLookup(owner);
-            case TRUSTED -> getController().getTrustedLookup(owner);
+            case PUBLIC -> controller.getPublicLookup();
+            case PRIVATE -> controller.getPrivateLookup(owner);
+            case TRUSTED -> controller.getTrustedLookup(owner);
         };
     }
 
@@ -104,6 +108,9 @@ public class FrequencyType<FREQ extends Frequency> {
             return null;
         }
         FrequencyController<FREQ> controller = getController();
+        if (controller == null) {
+            return null;
+        }
         if (freq.getType() == FrequencyTypes.SECURITY) {
             //Frequency#getSecurity means something slightly different for security frequencies. They are always public
             return controller.getPublicLookup();
@@ -117,10 +124,14 @@ public class FrequencyType<FREQ extends Frequency> {
 
     @Nullable
     public FrequencyLookup<FREQ> getLookup(FrequencyIdentity identity, @Nullable UUID owner) {
+        FrequencyController<FREQ> controller = getController();
+        if (controller == null) {
+            return null;
+        }
         return switch (identity.securityMode()) {
-            case PUBLIC -> getController().getPublicLookup();
-            case PRIVATE -> getController().getPrivateLookup(owner);
-            case TRUSTED -> getController().getTrustedLookup(owner);
+            case PUBLIC -> controller.getPublicLookup();
+            case PRIVATE -> controller.getPrivateLookup(owner);
+            case TRUSTED -> controller.getTrustedLookup(owner);
         };
     }
 

--- a/src/main/java/mekanism/common/lib/frequency/TileComponentFrequency.java
+++ b/src/main/java/mekanism/common/lib/frequency/TileComponentFrequency.java
@@ -163,7 +163,9 @@ public class TileComponentFrequency implements ITileComponent {
         FREQ freq = null;
         if (!Objects.equals(data.ownerUUID(), player) && SecurityUtils.get().isTrusted(data.securityMode(), data.ownerUUID(), player)) {
             manager = type.getLookup(data, data.ownerUUID());
-            freq = manager.getFrequency(data.key());
+            if (manager != null) {
+                freq = manager.getFrequency(data.key());
+            }
             if (freq == null) {
                 //Frequency doesn't exist, update the data to having the player as the owner
                 data = new FrequencyIdentity(data.key(), data.securityMode(), player);
@@ -172,6 +174,9 @@ public class TileComponentFrequency implements ITileComponent {
         if (freq == null) {
             //If the player is the owner, or is trying to create a new trusted frequency, create it for this player instead
             manager = type.getLookup(data, player);
+            if (manager == null) {
+                return;
+            }
             freq = manager.getOrCreateFrequency(data, player);
         }
         if (!freq.equals(oldFrequency)) {

--- a/src/main/java/mekanism/common/tile/component/TileComponentSecurity.java
+++ b/src/main/java/mekanism/common/tile/component/TileComponentSecurity.java
@@ -58,6 +58,10 @@ public class TileComponentSecurity implements ITileComponent {
         if (ownerUUID == null) {
             tile.getFrequencyComponent().unsetFrequency(FrequencyTypes.SECURITY);
         } else {
+            Level level = tile.getLevel();
+            if (level != null && level.isClientSide()) {
+                return;
+            }
             tile.setFrequency(FrequencyTypes.SECURITY, new FrequencyIdentity(ownerUUID, SecurityMode.PUBLIC, ownerUUID), ownerUUID);
         }
     }


### PR DESCRIPTION
## Summary

Multiple bugfixes and improvements for the 26.2 branch:

- **Fix client-side security owner assignment** — correct security owner handling on client side
- **Refactor getLookup methods** — use controller variable for cleaner frequency lookups
- **Guard missing frequency lookup on placement** — prevent NPE when frequency lookup fails during block placement
- **Avoid Ingredient acceptsItem lookup** — optimize ingredient matching to avoid unnecessary item lookups
- **Fix jetpack hover client state sync** — fix client-side jetpack hover state not syncing properly
- **Clamp universal cable saved energy share** — prevent energy share values from exceeding bounds
- **Bump NeoForge version to 26.2.0.23-beta** — update minimum NeoForge version requirement

All fixes are tested and working on the 26.2 branch.