### PR TITLE
Expose datagen source set to test classpath

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,9 @@ configurations {
 
 //Add all extra source sets that the main sourceSet should have
 setupExtraSourceSets(sourceSets.main)
+//Expose datagen classes to the test source set so unit tests can cover datagen-only utilities
+// (e.g. FormatSplitter, language providers that are not pulled into the main module).
+project.sourceSets.test.compileClasspath += sourceSets.datagenMain.output
 setupExtraSourceSets(sourceSets.gameTest, false)
 
 //Create sourceSets and configurations for each of the additional modules in src/$name and adds a reference to


### PR DESCRIPTION
## What this does
Adds `datagenMain.output` to the `test` source set's `compileClasspath`, mirroring the existing wiring that already exposes `main` and `api`. This lets unit tests reference classes that live in `src/datagen/main/java` (e.g. `FormatSplitter` and the language providers), which are currently invisible to `src/test`.

## Why
`FormatSplitter` is a pure-Java, zero-Minecraft-dependency utility, so it is a great candidate for fast unit tests — but the test source set could not see it. Rather than move it into `main` (changing its module), this just widens test visibility.

## Impact
- No production code changed. No runtime behavior changed.
- Only effect: `src/test/java` can now `import` classes from `src/datagen/main/java`.

[no-changelog]